### PR TITLE
Fix/web/star rating/renders 1 star less

### DIFF
--- a/packages-web/star-rating/package.json
+++ b/packages-web/star-rating/package.json
@@ -11,9 +11,9 @@
     "scripts": {
         "start": "utils-react-widgets start",
         "dev": "utils-react-widgets dev",
-        "test:dev": "utils-react-widgets test:dev",
+        "test": "npm run test:unit",
         "test:unit": "jest --config ../../scripts/test/jest.web.config.js",
-        "test:e2e": "export URL=https://booleansliderwidge.mxapps.io/ && utils-react-widgets test:e2e",
+        "test:e2e": "export URL=https://rating100.mxapps.io/ && utils-react-widgets test:e2e",
         "test:e2e:dev": "export DEBUG=true && utils-react-widgets test:e2e",
         "lint": "eslint --config ../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
         "lint:fix": "npm run lint -- --fix",

--- a/packages-web/star-rating/src/components/StarRating.ts
+++ b/packages-web/star-rating/src/components/StarRating.ts
@@ -15,7 +15,7 @@ export interface StarRatingProps {
 }
 
 export class StarRating extends Component<StarRatingProps, {}> {
-    private start = 1;
+    private start = 0;
     private step = 1;
     private stop: number;
     private fractions = 1;

--- a/packages-web/star-rating/src/components/__tests__/StarRating.spec.ts
+++ b/packages-web/star-rating/src/components/__tests__/StarRating.spec.ts
@@ -80,7 +80,7 @@ describe("StarRating", () => {
         starProps.initialRate = -1;
         const starRating = renderStarRating(starProps).find(Rating);
 
-        expect(starRating.props().initialRate).toEqual(1);
+        expect(starRating.props().initialRate).toEqual(0);
     });
 
     it("should render max stars for large positive rating", () => {

--- a/packages-web/star-rating/tests/e2e/StarRating.spec.ts
+++ b/packages-web/star-rating/tests/e2e/StarRating.spec.ts
@@ -1,34 +1,33 @@
 import page from "./pages/home.page";
-import { Element } from "webdriverio";
 
 describe("Star rating", () => {
     beforeAll(() => {
         page.open();
-        page.usernameInput.waitForVisible();
+        page.usernameInput.waitForDisplayed();
         page.usernameInput.setValue("x");
-        page.passwordInput.waitForVisible();
+        page.passwordInput.waitForDisplayed();
         page.passwordInput.setValue("1");
-        page.loginButton.waitForVisible();
+        page.loginButton.waitForDisplayed();
         page.loginButton.click();
     });
 
     // Note: cssProperty %age comparisons are not possible eg: width = 100% is always converted to pixels.
     // since emptyStar is always maxWidth, so fullStar when rated will always have equal width with emptyStar.
     it("should rate on a given star position: 4", () => {
-        page.rateMeButton.waitForVisible();
+        page.rateMeButton.waitForDisplayed();
         page.rateMeButton.click();
-        page.rateMePage.waitForVisible();
-        page.rateOnPosition(4).waitForVisible();
+        page.rateMePage.waitForDisplayed();
+        page.rateOnPosition(4).waitForDisplayed();
         page.rateOnPosition(4).click();
 
         const ratedFullStar = page.fullStarOnPosition(4);
         const ratedEmptyStar = page.emptyStarOnPosition(4);
-        expect(ratedFullStar.getCssProperty("width").value).toEqual(ratedEmptyStar.getCssProperty("width").value);
+        expect(ratedFullStar.getCSSProperty("width").value).toEqual(ratedEmptyStar.getCSSProperty("width").value);
         // Previous fullstar on position 3, should also be fully render over emptyStar
-        expect(page.fullStarOnPosition(3).getCssProperty("width").value)
-            .toEqual(ratedEmptyStar.getCssProperty("width").value);
+        expect(page.fullStarOnPosition(3).getCSSProperty("width").value).toEqual(
+            ratedEmptyStar.getCSSProperty("width").value
+        );
         // Next fullStar on position 5, should not be visible hence width 0px
-        expect(page.fullStarOnPosition(5).getCssProperty("width").value).toEqual("0px");
+        expect(page.fullStarOnPosition(5).getCSSProperty("width").value).toEqual("0px");
     });
-
 });

--- a/packages-web/star-rating/tests/e2e/pages/home.page.ts
+++ b/packages-web/star-rating/tests/e2e/pages/home.page.ts
@@ -1,46 +1,47 @@
-import { Client, Element, RawResult } from "webdriverio";
-
 // browser typings are declared globally
 class HomePage {
-    private modalWindow: Client<RawResult<Element>> & RawResult<Element>;
-    public get usernameInput() {
-        return browser.element("#usernameInput");
+    private modalWindow: WebdriverIO.Element;
+    get usernameInput() {
+        return $("#usernameInput");
     }
 
-    public get passwordInput() {
-        return browser.element("#passwordInput");
+    get passwordInput() {
+        return $("#passwordInput");
     }
 
-    public get loginButton() {
-        return browser.element("#loginButton");
+    get loginButton() {
+        return $("#loginButton");
     }
 
-    public get rateMeButton() {
-        return browser.element(".mx-name-actionButton1");
+    get rateMeButton() {
+        return $(".mx-name-actionButton1");
     }
 
-    public get rateMePage() {
-        this.modalWindow = browser.element("div.modal-content.mx-window-content");
+    get rateMePage() {
+        this.modalWindow = $("div.modal-content.mx-window-content");
         return this.modalWindow;
     }
 
-    public rateOnPosition(position: number) {
-        return browser.element(`div.modal-content.mx-window-content .widget-star-rating > span >` +
-            `span:nth-child(${ position })`);
+    rateOnPosition(position: number) {
+        return $("div.modal-content.mx-window-content .widget-star-rating > span >" + `span:nth-child(${position})`);
     }
 
-    public emptyStarOnPosition(position: number) {
-        return browser.element(`div.modal-content.mx-window-content .widget-star-rating > span >` +
-        `span:nth-child(${ position }) > span:nth-child(1)`);
+    emptyStarOnPosition(position: number) {
+        return $(
+            "div.modal-content.mx-window-content .widget-star-rating > span >" +
+                `span:nth-child(${position}) > span:nth-child(1)`
+        );
     }
 
     // when the fullStar width is 0%, then empty star is still visible and that star is not rated.
-    public fullStarOnPosition(position: number) {
-        return browser.element(`div.modal-content.mx-window-content .widget-star-rating > span >` +
-            `span:nth-child(${ position }) > span:nth-child(2)`);
+    fullStarOnPosition(position: number) {
+        return $(
+            "div.modal-content.mx-window-content .widget-star-rating > span >" +
+                `span:nth-child(${position}) > span:nth-child(2)`
+        );
     }
 
-    public open(): void {
+    open(): void {
         browser.url("/");
     }
 }


### PR DESCRIPTION
This MR fixes a problem where star rating stars from 1 instead of 0, resulting the widget to always render 1 less stars.

Bonus:
Fix package.json tests not migrated properly
Fix e2e url