### PR TITLE
Feat: native safe area view widget - prevent touch event interception

### DIFF
--- a/packages-native/safe-area-view/package.json
+++ b/packages-native/safe-area-view/package.json
@@ -1,7 +1,7 @@
 {
     "name": "safe-area-view",
     "widgetName": "SafeAreaView",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",

--- a/packages-native/safe-area-view/src/SafeAreaView.tsx
+++ b/packages-native/safe-area-view/src/SafeAreaView.tsx
@@ -9,8 +9,10 @@ export const SafeAreaView = (props: SafeAreaViewProps<SafeAreaViewStyle>): JSX.E
     const styles = flattenStyles(defaultSafeAreaViewStyle, props.style);
 
     return (
-        <ReactSaveAreaView style={{ flex: 1 }} testID={props.name}>
-            <View style={styles.container}>{props.content}</View>
+        <ReactSaveAreaView style={{ flex: 1 }} pointerEvents={"box-none"} testID={props.name}>
+            <View style={styles.container} pointerEvents={"box-none"}>
+                {props.content}
+            </View>
         </ReactSaveAreaView>
     );
 };

--- a/packages-native/safe-area-view/src/__tests__/__snapshots__/SafeAreaView.spec.tsx.snap
+++ b/packages-native/safe-area-view/src/__tests__/__snapshots__/SafeAreaView.spec.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Safe area view renders with content 1`] = `
 <RCTSafeAreaView
   emulateUnlessSupported={true}
+  pointerEvents="box-none"
   style={
     Object {
       "flex": 1,
@@ -11,6 +12,7 @@ exports[`Safe area view renders with content 1`] = `
   testID="safe-area-view-test"
 >
   <View
+    pointerEvents="box-none"
     style={
       Object {
         "flex": 1,
@@ -27,6 +29,7 @@ exports[`Safe area view renders with content 1`] = `
 exports[`Safe area view renders with custom styling 1`] = `
 <RCTSafeAreaView
   emulateUnlessSupported={true}
+  pointerEvents="box-none"
   style={
     Object {
       "flex": 1,
@@ -35,6 +38,7 @@ exports[`Safe area view renders with custom styling 1`] = `
   testID="safe-area-view-test"
 >
   <View
+    pointerEvents="box-none"
     style={
       Object {
         "backgroundColor": "green",
@@ -52,6 +56,7 @@ exports[`Safe area view renders with custom styling 1`] = `
 exports[`Safe area view renders without content 1`] = `
 <RCTSafeAreaView
   emulateUnlessSupported={true}
+  pointerEvents="box-none"
   style={
     Object {
       "flex": 1,
@@ -60,6 +65,7 @@ exports[`Safe area view renders without content 1`] = `
   testID="safe-area-view-test"
 >
   <View
+    pointerEvents="box-none"
     style={
       Object {
         "flex": 1,

--- a/packages-native/safe-area-view/src/package.xml
+++ b/packages-native/safe-area-view/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="SafeAreaView" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="SafeAreaView" version="1.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="SafeAreaView.xml"/>
         </widgetFiles>


### PR DESCRIPTION
The safe area view widget won't intercept touch events, so that it allows for interaction with widgets behind the safe area view widget.