### PR TITLE
fix(app-events): trigger onload in correct state to fix canexecute=false

### DIFF
--- a/detox/specs/colorPicker.spec.ts
+++ b/detox/specs/colorPicker.spec.ts
@@ -139,7 +139,7 @@ describe("Color Picker", () => {
             await element(by.id("checkBoxColorPickerConditional")).tap();
             await waitFor(colorPicker.getHue())
                 .toBeVisible()
-                .withTimeout(3000);
+                .withTimeout(5000);
             await expect(colorPicker.getHue()).toBeVisible();
         });
 

--- a/packages-native/app-events/src/AppEvents.tsx
+++ b/packages-native/app-events/src/AppEvents.tsx
@@ -16,12 +16,10 @@ export class AppEvents extends Component<Props> {
     private isConnected?: boolean;
     private lastOnOnline = 0;
     private lastOnOffline = 0;
-
+    private onLoadTriggered = false;
     private timeoutHandle?: any;
 
     async componentDidMount(): Promise<void> {
-        executeAction(this.props.onLoadAction);
-
         if (this.props.onResumeAction) {
             AppState.addEventListener("change", this.onAppStateChangeHandler);
         }
@@ -34,6 +32,13 @@ export class AppEvents extends Component<Props> {
         if (this.props.onOnlineAction || this.props.onOfflineAction) {
             this.isConnected = await NetInfo.isConnected.fetch();
             NetInfo.isConnected.addEventListener("connectionChange", this.onConnectionChangeHandler);
+        }
+    }
+
+    componentDidUpdate(): void {
+        if (!this.onLoadTriggered && this.props.onLoadAction?.canExecute) {
+            this.onLoadTriggered = true;
+            executeAction(this.props.onLoadAction);
         }
     }
 

--- a/packages-native/app-events/src/__tests__/AppEvents.spec.tsx
+++ b/packages-native/app-events/src/__tests__/AppEvents.spec.tsx
@@ -49,8 +49,8 @@ describe("AppEvents", () => {
     describe("with on load action", () => {
         it("executes the on load action", () => {
             const onLoadAction = actionValue();
-            render(<AppEvents {...defaultProps} onLoadAction={onLoadAction} />);
-
+            const { update } = render(<AppEvents {...defaultProps} onLoadAction={onLoadAction} />);
+            update(<AppEvents {...defaultProps} onLoadAction={onLoadAction} />);
             expect(onLoadAction.execute).toHaveBeenCalledTimes(1);
         });
     });


### PR DESCRIPTION
- We fixed an error where on certain conditions onLoad event wouldn't trigger. Fixes: https://mendixsupport.zendesk.com/agent/tickets/96361 