### PR TITLE
fix: prebuild windows compatible

### DIFF
--- a/packages-common/nanoflow-commons/package.json
+++ b/packages-common/nanoflow-commons/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "npm run build:tsc",
-    "prebuild:tsc": "rm -rf dist/tsc",
+    "prebuild:tsc": "..\"/../node_modules/.bin/rimraf\" dist/tsc",
     "build:tsc": "..\"/../node_modules/.bin/tsc\" --project src/tsconfig.json",
     "postbuild": "..\"/../node_modules/.bin/ts-node\" --project scripts/tsconfig.json ./scripts/copyActionsToTestProject.ts",
     "lint": "..\"/../node_modules/.bin/eslint\" --config ../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/"

--- a/packages-common/piw-utils/package.json
+++ b/packages-common/piw-utils/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "start": "..\"/../node_modules/.bin/tsc\" --watch",
-    "prebuild": "rm -rf ./dist",
+    "prebuild": "..\"/../node_modules/.bin/rimraf\" ./dist",
     "build": "..\"/../node_modules/.bin/tsc\"",
     "lint": "..\"/../node_modules/.bin/eslint\" --config ../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "prepare": "npm run build"

--- a/packages-hybrid/hybrid-mobile-actions/package.json
+++ b/packages-hybrid/hybrid-mobile-actions/package.json
@@ -7,7 +7,7 @@
     "watch-ts": "..\"/../node_modules/.bin/tsc\" --project src/tsconfig.json --watch ",
     "watch-copy": "npm-watch",
     "build": "npm run build:tsc",
-    "prebuild:tsc": "rm -rf dist/tsc",
+    "prebuild:tsc": "..\"/../node_modules/.bin/rimraf\" dist/tsc",
     "build:tsc": "..\"/../node_modules/.bin/tsc\" --project src/tsconfig.json",
     "postbuild": "..\"/../node_modules/.bin/ts-node\" --project ../../scripts/modules/tsconfig.json ../../scripts/modules/copyActionsToTestProject.ts",
     "lint": "..\"/../node_modules/.bin/eslint\" --config ../../.eslintrc.js --parser-options=project:src/tsconfig.json --ext .ts src/",

--- a/packages-native/actions/package.json
+++ b/packages-native/actions/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/mendix/widgets-resources.git"
   },
   "scripts": {
-    "prebuild": "rm -rf ./dist/tsc",
+    "prebuild": "..\"/../node_modules/.bin/rimraf\" ./dist/tsc",
     "build": "npm run build:tsc",
     "build:tsc": "..\"/../node_modules/.bin/tsc\" --project src/tsconfig.json",
     "postbuild": "..\"/../node_modules/.bin/ts-node\" --project ./scripts/tsconfig.json ./scripts/copyActionsToTestProject.ts",

--- a/packages-native/util-widgets/package.json
+++ b/packages-native/util-widgets/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "start": "..\"/../node_modules/.bin/tsc\" --watch",
-    "prebuild": "rm -rf ./dist",
+    "prebuild": "..\"/../node_modules/.bin/rimraf\" ./dist",
     "build": "..\"/../node_modules/.bin/tsc\"",
     "lint": "..\"/../node_modules/.bin/eslint\" --config ../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "prepare": "npm run build"

--- a/packages-web/actions/package.json
+++ b/packages-web/actions/package.json
@@ -7,7 +7,7 @@
     "watch-ts": "..\"/../node_modules/.bin/tsc\" --project src/tsconfig.json --watch ",
     "watch-copy": "npm-watch",
     "build": "npm run build:tsc",
-    "prebuild:tsc": "rm -rf dist/tsc",
+    "prebuild:tsc": "..\"/../node_modules/.bin/rimraf\" dist/tsc",
     "build:tsc": "..\"/../node_modules/.bin/tsc\" --project src/tsconfig.json",
     "postbuild": "..\"/../node_modules/.bin/ts-node\" --project ../../scripts/modules/tsconfig.json ../../scripts/modules/copyActionsToTestProject.ts",
     "lint": "..\"/../node_modules/.bin/eslint\" --config ../../.eslintrc.js --parser-options=project:src/tsconfig.json --ext .ts src/",


### PR DESCRIPTION
Dear team,

The `rm` command is an Unix command that is not compatible with Windows.
Using `rimraf` will make build and install run cross OS 

Travis CI is running windows build. Though the OS includes the GitBash shell. So *NIX commands will run.... but other widget devs might not run it from the same shell.

Cheers, Andries