### PR TITLE
Feat/a11y helper

### DIFF
--- a/packages-common/pluggable-widgets-tools/configs/variables.js
+++ b/packages-common/pluggable-widgets-tools/configs/variables.js
@@ -13,7 +13,9 @@ const widgetEntry = widgetSrcFiles.filter(file =>
     file.match(new RegExp(`[/\\\\]${escape(package.widgetName)}\\.[jt]sx?$`, "i"))
 )[0];
 if (!widgetEntry) {
-    throw new Error("Cannot find a widget entry file");
+    throw new Error(
+        "Cannot find a widget entry file. Make sure your widgetName in package.json matches with your main [jt]sx ? file"
+    );
 }
 
 const editorConfigEntry = widgetSrcFiles.filter(file =>

--- a/packages-common/pluggable-widgets-tools/configs/variables.js
+++ b/packages-common/pluggable-widgets-tools/configs/variables.js
@@ -13,9 +13,7 @@ const widgetEntry = widgetSrcFiles.filter(file =>
     file.match(new RegExp(`[/\\\\]${escape(package.widgetName)}\\.[jt]sx?$`, "i"))
 )[0];
 if (!widgetEntry) {
-    throw new Error(
-        "Cannot find a widget entry file. Make sure your widgetName in package.json matches with your main [jt]sx ? file"
-    );
+    throw new Error("Cannot find a widget entry file");
 }
 
 const editorConfigEntry = widgetSrcFiles.filter(file =>

--- a/packages-web/accessibility-helper/package.json
+++ b/packages-web/accessibility-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "accessibility-helper",
   "widgetName": "AccessibilityHelper",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "Set an attribute to a DOM element",
   "copyright": "Mendix 2020",
   "author": "Widget Team",

--- a/packages-web/accessibility-helper/package.json
+++ b/packages-web/accessibility-helper/package.json
@@ -24,8 +24,10 @@
     "svncheckout": "..\"/../node_modules/.bin/ts-node\" --project ../../scripts/tsconfig.json ../../scripts/svn/CheckoutProject.ts"
   },
   "license": "Apache-2.0",
+  "dependencies": {
+    "@widgets-resources/piw-utils": "^1.0.0"
+  },
   "devDependencies": {
-    "@widgets-resources/piw-utils": "^1.0.0",
     "@mendix/pluggable-widgets-tools": ">=8.9.2"
   }
 }

--- a/packages-web/accessibility-helper/package.json
+++ b/packages-web/accessibility-helper/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "accessibility-helper",
+  "widgetName": "AccessibilityHelper",
+  "version": "0.0.2",
+  "description": "Set an attribute to a DOM element",
+  "copyright": "Mendix 2020",
+  "author": "Widget Team",
+  "config": {
+    "widgetPath": "./tests/TestProjects/Mendix8/widgets",
+    "projectPath": "./tests/TestProjects/Mendix8",
+    "mendixHost": "http://localhost:8080",
+    "developmentPort": 3000
+  },
+  "packagePath": "com.mendix.widget.web",
+  "scripts": {
+    "start": "pluggable-widgets-tools start:server --open",
+    "dev": "pluggable-widgets-tools start:ts",
+    "build": "pluggable-widgets-tools build:ts",
+    "format": "pluggable-widgets-tools format",
+    "lint": "..\"/../node_modules/.bin/eslint\" --config ../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
+    "test": "..\"/../node_modules/.bin/jest\" --config ../../scripts/test/jest.web.config.js",
+    "test:e2e:dev": "..\"/../node_modules/.bin/cross-env\" DEBUG=true ../../node_modules/.bin/wdio ../../configs/e2e/wdio.conf.js",
+    "release": "pluggable-widgets-tools release:web",
+    "svncheckout": "..\"/../node_modules/.bin/ts-node\" --project ../../scripts/tsconfig.json ../../scripts/svn/CheckoutProject.ts"
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@widgets-resources/piw-utils": "^1.0.0",
+    "@mendix/pluggable-widgets-tools": ">=8.9.2"
+  }
+}

--- a/packages-web/accessibility-helper/package.json
+++ b/packages-web/accessibility-helper/package.json
@@ -13,12 +13,12 @@
     "testProjectId": "c8bda497-ac0a-42a6-9301-f0848d6b2ca8",
     "testProjects": [
       {
-        "revision": 3,
+        "revision": 8,
         "branch": "MX_8",
         "path": "./tests/TestProjects/Mendix8/"
       },
       {
-        "revision": 4,
+        "revision": 9,
         "branch": "nightly",
         "path": "./tests/TestProjects/Nightly/"
       }

--- a/packages-web/accessibility-helper/package.json
+++ b/packages-web/accessibility-helper/package.json
@@ -18,7 +18,6 @@
     "build": "pluggable-widgets-tools build:ts",
     "format": "pluggable-widgets-tools format",
     "lint": "..\"/../node_modules/.bin/eslint\" --config ../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
-    "test": "..\"/../node_modules/.bin/jest\" --config ../../scripts/test/jest.web.config.js",
     "test:e2e:dev": "..\"/../node_modules/.bin/cross-env\" DEBUG=true ../../node_modules/.bin/wdio ../../configs/e2e/wdio.conf.js",
     "release": "pluggable-widgets-tools release:web",
     "svncheckout": "..\"/../node_modules/.bin/ts-node\" --project ../../scripts/tsconfig.json ../../scripts/svn/CheckoutProject.ts"

--- a/packages-web/accessibility-helper/package.json
+++ b/packages-web/accessibility-helper/package.json
@@ -9,7 +9,20 @@
     "widgetPath": "./tests/TestProjects/Mendix8/widgets",
     "projectPath": "./tests/TestProjects/Mendix8",
     "mendixHost": "http://localhost:8080",
-    "developmentPort": 3000
+    "developmentPort": 3000,
+    "testProjectId": "c8bda497-ac0a-42a6-9301-f0848d6b2ca8",
+    "testProjects": [
+      {
+        "revision": 3,
+        "branch": "MX_8",
+        "path": "./tests/TestProjects/Mendix8/"
+      },
+      {
+        "revision": 4,
+        "branch": "nightly",
+        "path": "./tests/TestProjects/Nightly/"
+      }
+    ]
   },
   "packagePath": "com.mendix.widget.web",
   "scripts": {

--- a/packages-web/accessibility-helper/src/AccessibilityHelper.editorConfig.ts
+++ b/packages-web/accessibility-helper/src/AccessibilityHelper.editorConfig.ts
@@ -1,0 +1,14 @@
+import { hidePropertyIn, Properties } from "@widgets-resources/piw-utils";
+import { AttributesListPreviewType, AccessibilityHelperPreviewProps } from "../typings/AccessibilityHelperProps";
+
+export function getProperties(values: AccessibilityHelperPreviewProps, defaultProperties: Properties): Properties {
+    values.attributesList.forEach((item: AttributesListPreviewType, index: number) => {
+        if (item.valueSourceType === "text") {
+            hidePropertyIn(defaultProperties, values, "attributesList", index, "valueExpression");
+        }
+        if (item.valueSourceType === "expression") {
+            hidePropertyIn(defaultProperties, values, "attributesList", index, "valueText");
+        }
+    });
+    return defaultProperties;
+}

--- a/packages-web/accessibility-helper/src/AccessibilityHelper.editorConfig.ts
+++ b/packages-web/accessibility-helper/src/AccessibilityHelper.editorConfig.ts
@@ -1,5 +1,7 @@
-import { hidePropertyIn, Properties } from "@widgets-resources/piw-utils";
+import { hidePropertyIn, Properties, Problem } from "@widgets-resources/piw-utils";
 import { AttributesListPreviewType, AccessibilityHelperPreviewProps } from "../typings/AccessibilityHelperProps";
+
+const PROHIBITED_ATTRIBUTES = ["class", "style", "widgetid", "data-mendix-id"];
 
 export function getProperties(values: AccessibilityHelperPreviewProps, defaultProperties: Properties): Properties {
     values.attributesList.forEach((item: AttributesListPreviewType, index: number) => {
@@ -11,4 +13,19 @@ export function getProperties(values: AccessibilityHelperPreviewProps, defaultPr
         }
     });
     return defaultProperties;
+}
+
+export function check(values: AccessibilityHelperPreviewProps): Problem[] {
+    const errors: Problem[] = [];
+    values.attributesList.forEach((item: AttributesListPreviewType) => {
+        if (PROHIBITED_ATTRIBUTES.some(value => value === item.attribute)) {
+            errors.push({
+                property: "attributesList.attribute",
+                message: `Widget tries to change ${item.attribute} attribute, this is prohibited`,
+                url: "https://docs.mendix.com/appstore/widgets/accessibility-helper"
+            });
+        }
+    });
+
+    return errors;
 }

--- a/packages-web/accessibility-helper/src/AccessibilityHelper.tsx
+++ b/packages-web/accessibility-helper/src/AccessibilityHelper.tsx
@@ -42,7 +42,7 @@ const AccessibilityHelper = (props: AccessibilityHelperContainerProps): ReactEle
             return;
         }
         update();
-    }, [props.attributesList]);
+    }, [props.targetSelector, props.attributesList]);
 
     useEffect(() => {
         const contentWrapper = contentRef.current;
@@ -71,7 +71,7 @@ const AccessibilityHelper = (props: AccessibilityHelperContainerProps): ReactEle
             });
             observer.observe(contentWrapper, mutationConfig);
         }
-    }, [props.content, props.targetSelector, props.attributesList]);
+    }, [contentRef.current, props.targetSelector, props.attributesList]);
 
     return <div ref={contentRef}>{props.content}</div>;
 };

--- a/packages-web/accessibility-helper/src/AccessibilityHelper.tsx
+++ b/packages-web/accessibility-helper/src/AccessibilityHelper.tsx
@@ -1,0 +1,139 @@
+import { ReactNode, MutableRefObject, createElement, useRef, useEffect, useCallback } from "react";
+
+import { DynamicValue, ValueStatus } from "mendix";
+
+import { AccessibilityHelperContainerProps } from "../typings/AccessibilityHelperProps";
+
+const PROHIBITED_ATTRIBUTES = ["class", "style", "widgetid", "data-mendix-id"];
+
+const isValid = function isValid(selector: string): boolean {
+    if (PROHIBITED_ATTRIBUTES.indexOf(selector) !== -1) {
+        console.error(`Widget tries to change ${selector} attribute, this is prohibited`);
+        return false;
+    }
+    return true;
+};
+
+const AccessibilityHelper = (props: AccessibilityHelperContainerProps): ReactNode => {
+    // console.log("render accessibility-helper", props.valueExpression.status, props.valueExpression.value);
+    const contentRef: MutableRefObject<HTMLDivElement | null> = useRef(null);
+
+    const attributeValue: MutableRefObject<string | null> = useRef(null);
+    const attributeCondition: MutableRefObject<boolean | null> = useRef(null);
+
+    const value: MutableRefObject<DynamicValue<string> | undefined> = useRef(undefined);
+    const condition: MutableRefObject<DynamicValue<boolean> | undefined> = useRef(undefined);
+    condition.current = props.attributeCondition;
+    value.current = props.valueSource === "expression" ? props.valueExpression : props.valueText;
+
+    // console.log("render accessibility-helper", value.current.status, value.current.value);
+
+    const update = useCallback(() => {
+        // console.log("check updateContent", value.current.status, value.current.value);
+        const containerElement = contentRef.current;
+        if (containerElement) {
+            // console.log("has current ref");
+            let target = null;
+            try {
+                target = containerElement.querySelector(props.targetSelector);
+            } catch (error) {
+                console.error(`Set Attribute Target sector ${props.targetSelector} is not valid`, error);
+            }
+            if (!target) {
+                console.debug(`Set Attribute Target ${props.targetSelector} does not exist or is not visible`);
+                return;
+            }
+            // if (
+            //     value.current.status === ValueStatus.Available &&
+            //     target.getAttribute(props.attribute) === value.current.value
+            // ) {
+            //     console.log("not changed");
+            // }
+            if (condition.current?.status === ValueStatus.Available && condition.current?.value) {
+                if (
+                    value.current?.status === ValueStatus.Available &&
+                    target.getAttribute(props.attribute) !== value.current?.value
+                ) {
+                    // console.log(`set attribute value: ${props.attribute}="${value.current?.value}"`);
+                    attributeValue.current = value.current?.value;
+                    attributeCondition.current = true;
+                    target.setAttribute(props.attribute, value.current?.value);
+                }
+            } else if (condition.current?.status === ValueStatus.Available && !condition.current?.value) {
+                // console.log("remove attribute", props.attribute);
+                attributeValue.current = null;
+                attributeCondition.current = false;
+                target.removeAttribute(props.attribute);
+            }
+            // else {
+            //     console.log("condition loading");
+            // }
+        }
+    }, [props.targetSelector, props.attribute]);
+
+    useEffect(() => {
+        // console.log("useEffect, initial, no dep");
+        if (!isValid(props.targetSelector)) {
+            return;
+        }
+        if (
+            (attributeValue.current !== value.current?.value &&
+                value.current?.status === ValueStatus.Available &&
+                condition.current?.value) ||
+            (attributeCondition.current !== condition.current?.value &&
+                condition.current?.status === ValueStatus.Available)
+        ) {
+            // console.log("value Changed");
+            update();
+        }
+        // else {
+        //     console.log("no change");
+        // }
+    }, [value.current, condition.current]);
+
+    useEffect(() => {
+        // console.log("useEffect, with dep");
+
+        const contentWrapperNode = contentRef.current;
+        if (contentWrapperNode && isValid(props.targetSelector)) {
+            const config: MutationObserverInit = {
+                attributes: true,
+                childList: true,
+                subtree: true,
+                attributeFilter: [props.attribute]
+            };
+            const observer = new MutationObserver(mutationList => {
+                const doUpdate = mutationList.some(
+                    mutation =>
+                        !(
+                            mutation.type === "attributes" &&
+                            mutation.attributeName === props.attribute &&
+                            (mutation.target as Element).getAttribute(mutation.attributeName) === attributeValue.current
+                        )
+                );
+                if (doUpdate) {
+                    update();
+                }
+                // else {
+                //     console.log("self update");
+                // }
+            });
+            observer.observe(contentWrapperNode, config);
+            console.log("observe changes");
+
+            return () => {
+                // console.log("disconnect");
+                attributeValue.current = null;
+                attributeCondition.current = null;
+                observer.disconnect();
+            };
+        }
+        // else {
+        //     console.log("no ref found");
+        // }
+    }, [props.content, props.targetSelector, props.attribute]);
+
+    return <div ref={contentRef}>{props.content}</div>;
+};
+
+export default AccessibilityHelper;

--- a/packages-web/accessibility-helper/src/AccessibilityHelper.tsx
+++ b/packages-web/accessibility-helper/src/AccessibilityHelper.tsx
@@ -12,9 +12,8 @@ const AccessibilityHelper = (props: AccessibilityHelperContainerProps): ReactEle
 
     const update = useCallback(() => {
         if (contentRef.current) {
-            let target: Element | null = null;
             try {
-                target = contentRef.current.querySelector(props.targetSelector);
+                const target = contentRef.current.querySelector(props.targetSelector);
                 if (target) {
                     props.attributesList.forEach(attrEntry => {
                         const valueToBeSet = getValueBySourceType(attrEntry);
@@ -23,12 +22,12 @@ const AccessibilityHelper = (props: AccessibilityHelperContainerProps): ReactEle
                         if (condition.status === ValueStatus.Available && condition.value) {
                             if (
                                 valueToBeSet?.status === ValueStatus.Available &&
-                                valueToBeSet?.value !== target!.getAttribute(attrEntry.attribute)
+                                valueToBeSet?.value !== target.getAttribute(attrEntry.attribute)
                             ) {
-                                target!.setAttribute(attrEntry.attribute, valueToBeSet?.value);
+                                target.setAttribute(attrEntry.attribute, valueToBeSet?.value);
                             }
                         } else if (condition.status === ValueStatus.Available && !condition.value) {
-                            target!.removeAttribute(attrEntry.attribute);
+                            target.removeAttribute(attrEntry.attribute);
                         }
                     });
                 }

--- a/packages-web/accessibility-helper/src/AccessibilityHelper.tsx
+++ b/packages-web/accessibility-helper/src/AccessibilityHelper.tsx
@@ -21,21 +21,23 @@ const AccessibilityHelper = (props: AccessibilityHelperContainerProps): ReactEle
 
     const update = useCallback(() => {
         try {
-            const target = contentRef.current?.querySelector(props.targetSelector);
-            if (target) {
-                conditions.forEach(attrEntry => {
-                    const valueToBeSet = getValueBySourceType(attrEntry.attribute);
+            const targets = contentRef.current?.querySelectorAll(props.targetSelector);
+            if (targets && targets.length > 0) {
+                targets.forEach(target => {
+                    conditions.forEach(attrEntry => {
+                        const valueToBeSet = getValueBySourceType(attrEntry.attribute);
 
-                    if (attrEntry.condition.status === ValueStatus.Available && attrEntry.condition.value) {
-                        if (
-                            valueToBeSet?.status === ValueStatus.Available &&
-                            valueToBeSet?.value !== target.getAttribute(attrEntry.attribute)
-                        ) {
-                            target.setAttribute(attrEntry.attribute, valueToBeSet?.value);
+                        if (attrEntry.condition.status === ValueStatus.Available && attrEntry.condition.value) {
+                            if (
+                                valueToBeSet?.status === ValueStatus.Available &&
+                                valueToBeSet?.value !== target.getAttribute(attrEntry.attribute)
+                            ) {
+                                target.setAttribute(attrEntry.attribute, valueToBeSet?.value);
+                            }
+                        } else if (attrEntry.condition.status === ValueStatus.Available && !attrEntry.condition.value) {
+                            target.removeAttribute(attrEntry.attribute);
                         }
-                    } else if (attrEntry.condition.status === ValueStatus.Available && !attrEntry.condition.value) {
-                        target.removeAttribute(attrEntry.attribute);
-                    }
+                    });
                 });
             }
         } catch (error) {

--- a/packages-web/accessibility-helper/src/AccessibilityHelper.xml
+++ b/packages-web/accessibility-helper/src/AccessibilityHelper.xml
@@ -3,27 +3,28 @@
         supportedPlatform="Web"
         xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
-    <name>Accessibility Helper</name>
+    <name>Accessibility helper</name>
     <description/>
+    <helpUrl>https://docs.mendix.com/appstore/widgets/accessibility-helper</helpUrl>
     <icon>iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAQKADAAQAAAABAAAAQAAAAABGUUKwAAAHfElEQVR4Ae1bXWhURxS+m9SaxIREBaGo0AeLWrAFbfFFQaGWxoLRh6gPKyyKeRZrfWgLGmh9sCg+pyQsuFB/HjR50NIIDeiLtAqtYBV8KGgQCjFZEndjZbP9vs3M9dy5c/fn7q7umr1wd86cmTnzne/O35076ziNq8FAg4GFzECk2s739vY2NzU1bZybm9saiUTWZ7PZtQhXI+xA3bx5TUM3Dd1jhA8QPkCZmyhz9/Lly5n5LNX5rQoBfX19i5LJ5E44cgD3Z4DeGRJ+EuVGQUais7Pz2sDAwMuQdgKLVZQAPO1WPMEjcPor1Lg8sNZwCROwfQa2z6FVpMOZ8JeqCAFs5jAdw92PeyXual7jMH4Cd7wS3aNsAvbu3cum/iMAfZjHaz4xNuXf0K8fQH7U2to6mU6np1kGcgfkpRDXIM865NkOeQeTcAdd95H32MWLF68HZShGH5oAOB3Zt2/f9wi/sVWE5jqJtGGEw11dXb+i/6Zs+YJ0GEfapqamPoeNHtjoQUiCfBfSToGE7xBmfYlFKEIRgCbfDtsJ3D2WOlIAc7a9vf300NBQ7glb8pSkOnjwYMfMzMxxkHAUBdsshYehi6JLzFjS8qpKJmD//v3vZzKZEVjdYFjmdDW4ePHik4lE4qmRVpFoNBp978WLFydh7BBujjvyutfc3LzrwoUL/0hlIbkkApTzt2F0hWF4HJXvRuV/GPqqRIHjEzyEqzBuDrj/AsfmUkhoKhYhm7168qbzt/HUP31dzhMv62KdEPkw5LWCGFUXlfpAuSgC0PfYUtjnPc0efT2xZMmSbdVq8oGoCQbdjHUTg5GPGBMKs5HkjxbVBTDV/QCDntGeFV+6dOmA3+Tr1wDfeeCLypqB7xTwfSt1Nvkdm1Lq1DzvcR7pt9va2g7LfKXI3deyq7IvZ087WWdbrlzEGYssajl+fWfkSSl2dF5ief78+QeIb9Y6PjBM07cKrRPytgC1wvsLRuUiZ5z9L2yzzzn/3+yfsLlMg1Xhs8i7LR+HJUHNEL/DlhwY7yP+Ub4VY6ExIAYD0vkMR/uwzsOWk3vyfueZtEylUS75IiZiQ0H59kjssXzGAgnA0+cytN8oPFj2aK+bvWE4F82XZstv6BS2QUPdr3wx1PPRQAIwiBxBFtmcUlzkWK3UkFJhlMvulcoXK0orAXyfxyDCV1r3gpGz5TT9V4acMVc2BQyGpqrUODESqyxHX+iT1GnZSgBeQr5EBvd9HgYnubbXhcoJOdqj/DOLjWcqzZJUmopYiVmUWs4NGhF3RSsBSPXMqWBwuFIvNhzlOdo7Eedn1MN3hqeUy5kBXG+UQKzELPV4xfb4pNN806Ca+iaQwd3GApt7sKjg2rtuLqxfdoOEKwJwEvJyc0q0tYBNyOg6DznN93lhqC5EhVlunXViA2WjCd62EtxiZBotZjOje2S225nLDmBXYpVRvqJRNNknTlOk7/qulrw7QcSM1jyKyndpAOgGWyFzseRevhaA5r7eTYXAbSwZD5Rfg/OsO0cw6grEIRJM7KZvzOojAP1mrbDhqD08qaob2cRu+kZHfASApdWGh4+MuD2KZplrnvbUiml1FyjSoAe7xTfHNwaApQ5pnLu3Mh4kqz5pkudm/+JquqRNy192t/pmKNdYkYLaeXZzm74xwdcCoPMQoLeuXSt1JFiwe3yjKzYC6sjF8qHaCPBsZfOjRfnVvBkLFuwe34jKRwAGCk8m9cXmzXhQZq0mdtM3KwEYKB4b9a4x4vUU9WC3+GZtAQ+lh1hMrJPxepJN7GgBHt/oi68LgKW/pZNYTGyX8XqSTeymb/TFRwB0twwnd/BDpaErO8p5Xt5lGzQMKMz8wuxeaBE33YgSbATcQRpfHfXVyq+0OlIvocLMfU19JdEi7uqIDn0E8H0ZfeWGzsAQTadHxutE5g6xvEbNvQAm+gigEgScZ6gvxHv4iVrHaz1UWN3XYOJF80/YcFsJ4IEkZJ7QBdAClvL7vI7XeqjOEiwVOCeUT0I1L1oJwGbCSzz1MzI3SDjKry9SV4syMRKrxEZf6JPUadlKABNh5ByCcZ0RYZs6nCBUtScqjHLWGle+WMEGEoABg/tpJ4xSh3g4wdDVTFRhO2QAOqF8MdTz0UACVO44wvtKZtDMkxlhuoLcLJGyti11UtbphUJiUqdGmkVeYo+LuE/MS4CaEr82Sq1EM7sSi8VaDH3+qNoxyjkH2Ze5ULqvwCsFsRATNPJTHkf+Y7ap71VJzHgyEiS/zQckiiIAg0gEJJBhz4IIo2uChxPi8fhsEHnV1PPJp1Kpn4AvatQzjA85e4Cv4DZc3i6gjSpDrOSe1jFkxTiZMRZmTJB2wsisk3VbnCfGaDHOs96iWoAG+DYekyuJABKhSBiBuEETo8IMwrf7oKR2GJ+cFu5RWU0CB8YFe1hak8BQHaNbeMflJQnqTEEMun7cnsWIzFchme8nXKLXxh8mpFMgYmH+ZUaSQJkHkir1pynM5zdwn6+LP02ZRDCuuscmiFvgSDF/m3uIAZY709ycvVNoLY88javBQIOBBgOhGfgfyCdfnMgXXcMAAAAASUVORK5CYII=</icon>
     <properties>
         <propertyGroup caption="General">
             <property key="targetSelector" type="string">
                 <caption>Target selector</caption>
-                <description>Selector to find the HTML element you want to target</description>
+                <description>Selector to find the HTML element you want to target which must be a valid CSS selector like '.mx-name-texbox1 input'</description>
             </property>
             <property key="content" type="widgets">
                 <caption>Content</caption>
                 <description/>
             </property>
             <property key="attributesList" type="object" isList="true" required="false">
-                <caption>Attributes</caption>
+                <caption>HTML Attributes</caption>
                 <description />
                 <properties>
                     <property key="attribute" type="string">
-                        <caption>Attribute</caption>
+                        <caption>HTML attribute</caption>
                         <category>General</category>
-                        <description>Desired attribute to be set based on condition</description>
+                        <description>The HTML attribute to be set based on the condition. The following attributes are not allowed: 'class', 'style', 'widgetid', 'data-mendix-id'.</description>
                     </property>
                     <property key="valueSourceType" type="enumeration" defaultValue="text">
                         <caption>Source type</caption>
@@ -48,7 +49,7 @@
                     <property key="attributeCondition" type="expression" defaultValue="true">
                         <caption>Condition</caption>
                         <category>General</category>
-                        <description>Condition to determine if the attribute must be set or not</description>
+                        <description>Condition to determine if the HTML attribute must be set or not</description>
                         <returnType type="Boolean" />
                     </property>
                 </properties>

--- a/packages-web/accessibility-helper/src/AccessibilityHelper.xml
+++ b/packages-web/accessibility-helper/src/AccessibilityHelper.xml
@@ -16,35 +16,6 @@
                 <caption>Content</caption>
                 <description/>
             </property>
-
-            <property key="attribute" type="string">
-                <caption>Attribute</caption>
-                <description/>
-            </property>
-            <property key="valueSource" type="enumeration" defaultValue="text">
-                <caption>Source1</caption>
-                <description/>
-                <enumerationValues>
-                    <enumerationValue key="text">Text</enumerationValue>
-                    <enumerationValue key="expression">Expression</enumerationValue>
-                </enumerationValues>
-            </property>
-            <property key="valueExpression" type="expression" required="false">
-                <caption>Value expression</caption>
-                <description/>
-                <returnType type="String" />
-            </property>
-            <property key="valueText" type="textTemplate" required="false">
-                <caption>Value text</caption>
-                <description/>
-            </property>
-            <property key="attributeCondition" type="expression" defaultValue="true">
-                <caption>Condition</caption>
-                <description/>
-                <returnType type="Boolean" />
-            </property>
-
-
             <property key="attributesList" type="object" isList="true" required="false">
                 <caption>Attributes</caption>
                 <description />
@@ -80,7 +51,6 @@
                         <category>General</category>
                         <description/>
                     </property>
-
                 </properties>
             </property>
         </propertyGroup>

--- a/packages-web/accessibility-helper/src/AccessibilityHelper.xml
+++ b/packages-web/accessibility-helper/src/AccessibilityHelper.xml
@@ -5,12 +5,12 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name>Accessibility Helper</name>
     <description/>
-    <icon/>
+    <icon>iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAQKADAAQAAAABAAAAQAAAAABGUUKwAAAHfElEQVR4Ae1bXWhURxS+m9SaxIREBaGo0AeLWrAFbfFFQaGWxoLRh6gPKyyKeRZrfWgLGmh9sCg+pyQsuFB/HjR50NIIDeiLtAqtYBV8KGgQCjFZEndjZbP9vs3M9dy5c/fn7q7umr1wd86cmTnzne/O35076ziNq8FAg4GFzECk2s739vY2NzU1bZybm9saiUTWZ7PZtQhXI+xA3bx5TUM3Dd1jhA8QPkCZmyhz9/Lly5n5LNX5rQoBfX19i5LJ5E44cgD3Z4DeGRJ+EuVGQUais7Pz2sDAwMuQdgKLVZQAPO1WPMEjcPor1Lg8sNZwCROwfQa2z6FVpMOZ8JeqCAFs5jAdw92PeyXual7jMH4Cd7wS3aNsAvbu3cum/iMAfZjHaz4xNuXf0K8fQH7U2to6mU6np1kGcgfkpRDXIM865NkOeQeTcAdd95H32MWLF68HZShGH5oAOB3Zt2/f9wi/sVWE5jqJtGGEw11dXb+i/6Zs+YJ0GEfapqamPoeNHtjoQUiCfBfSToGE7xBmfYlFKEIRgCbfDtsJ3D2WOlIAc7a9vf300NBQ7glb8pSkOnjwYMfMzMxxkHAUBdsshYehi6JLzFjS8qpKJmD//v3vZzKZEVjdYFjmdDW4ePHik4lE4qmRVpFoNBp978WLFydh7BBujjvyutfc3LzrwoUL/0hlIbkkApTzt2F0hWF4HJXvRuV/GPqqRIHjEzyEqzBuDrj/AsfmUkhoKhYhm7168qbzt/HUP31dzhMv62KdEPkw5LWCGFUXlfpAuSgC0PfYUtjnPc0efT2xZMmSbdVq8oGoCQbdjHUTg5GPGBMKs5HkjxbVBTDV/QCDntGeFV+6dOmA3+Tr1wDfeeCLypqB7xTwfSt1Nvkdm1Lq1DzvcR7pt9va2g7LfKXI3deyq7IvZ087WWdbrlzEGYssajl+fWfkSSl2dF5ief78+QeIb9Y6PjBM07cKrRPytgC1wvsLRuUiZ5z9L2yzzzn/3+yfsLlMg1Xhs8i7LR+HJUHNEL/DlhwY7yP+Ub4VY6ExIAYD0vkMR/uwzsOWk3vyfueZtEylUS75IiZiQ0H59kjssXzGAgnA0+cytN8oPFj2aK+bvWE4F82XZstv6BS2QUPdr3wx1PPRQAIwiBxBFtmcUlzkWK3UkFJhlMvulcoXK0orAXyfxyDCV1r3gpGz5TT9V4acMVc2BQyGpqrUODESqyxHX+iT1GnZSgBeQr5EBvd9HgYnubbXhcoJOdqj/DOLjWcqzZJUmopYiVmUWs4NGhF3RSsBSPXMqWBwuFIvNhzlOdo7Eedn1MN3hqeUy5kBXG+UQKzELPV4xfb4pNN806Ca+iaQwd3GApt7sKjg2rtuLqxfdoOEKwJwEvJyc0q0tYBNyOg6DznN93lhqC5EhVlunXViA2WjCd62EtxiZBotZjOje2S225nLDmBXYpVRvqJRNNknTlOk7/qulrw7QcSM1jyKyndpAOgGWyFzseRevhaA5r7eTYXAbSwZD5Rfg/OsO0cw6grEIRJM7KZvzOojAP1mrbDhqD08qaob2cRu+kZHfASApdWGh4+MuD2KZplrnvbUiml1FyjSoAe7xTfHNwaApQ5pnLu3Mh4kqz5pkudm/+JquqRNy192t/pmKNdYkYLaeXZzm74xwdcCoPMQoLeuXSt1JFiwe3yjKzYC6sjF8qHaCPBsZfOjRfnVvBkLFuwe34jKRwAGCk8m9cXmzXhQZq0mdtM3KwEYKB4b9a4x4vUU9WC3+GZtAQ+lh1hMrJPxepJN7GgBHt/oi68LgKW/pZNYTGyX8XqSTeymb/TFRwB0twwnd/BDpaErO8p5Xt5lGzQMKMz8wuxeaBE33YgSbATcQRpfHfXVyq+0OlIvocLMfU19JdEi7uqIDn0E8H0ZfeWGzsAQTadHxutE5g6xvEbNvQAm+gigEgScZ6gvxHv4iVrHaz1UWN3XYOJF80/YcFsJ4IEkZJ7QBdAClvL7vI7XeqjOEiwVOCeUT0I1L1oJwGbCSzz1MzI3SDjKry9SV4syMRKrxEZf6JPUadlKABNh5ByCcZ0RYZs6nCBUtScqjHLWGle+WMEGEoABg/tpJ4xSh3g4wdDVTFRhO2QAOqF8MdTz0UACVO44wvtKZtDMkxlhuoLcLJGyti11UtbphUJiUqdGmkVeYo+LuE/MS4CaEr82Sq1EM7sSi8VaDH3+qNoxyjkH2Ze5ULqvwCsFsRATNPJTHkf+Y7ap71VJzHgyEiS/zQckiiIAg0gEJJBhz4IIo2uChxPi8fhsEHnV1PPJp1Kpn4AvatQzjA85e4Cv4DZc3i6gjSpDrOSe1jFkxTiZMRZmTJB2wsisk3VbnCfGaDHOs96iWoAG+DYekyuJABKhSBiBuEETo8IMwrf7oKR2GJ+cFu5RWU0CB8YFe1hak8BQHaNbeMflJQnqTEEMun7cnsWIzFchme8nXKLXxh8mpFMgYmH+ZUaSQJkHkir1pynM5zdwn6+LP02ZRDCuuscmiFvgSDF/m3uIAZY709ycvVNoLY88javBQIOBBgOhGfgfyCdfnMgXXcMAAAAASUVORK5CYII=</icon>
     <properties>
         <propertyGroup caption="General">
             <property key="targetSelector" type="string">
                 <caption>Target selector</caption>
-                <description/>
+                <description>Selector to find the HTML element you want to target</description>
             </property>
             <property key="content" type="widgets">
                 <caption>Content</caption>
@@ -23,10 +23,10 @@
                     <property key="attribute" type="string">
                         <caption>Attribute</caption>
                         <category>General</category>
-                        <description/>
+                        <description>Desired attribute to be set based on condition</description>
                     </property>
                     <property key="valueSourceType" type="enumeration" defaultValue="text">
-                        <caption>Source</caption>
+                        <caption>Source type</caption>
                         <category>General</category>
                         <description/>
                         <enumerationValues>
@@ -34,22 +34,22 @@
                             <enumerationValue key="expression">Expression</enumerationValue>
                         </enumerationValues>
                     </property>
-                    <property key="attributeCondition" type="expression" defaultValue="true">
-                        <caption>Condition</caption>
-                        <category>General</category>
-                        <description/>
-                        <returnType type="Boolean" />
-                    </property>
                     <property key="valueExpression" type="expression" required="false">
-                        <caption>Value expression</caption>
+                        <caption>Expression value</caption>
                         <category>General</category>
                         <description/>
                         <returnType type="String" />
                     </property>
                     <property key="valueText" type="textTemplate" required="false">
-                        <caption>Value text</caption>
+                        <caption>Text value</caption>
                         <category>General</category>
                         <description/>
+                    </property>
+                    <property key="attributeCondition" type="expression" defaultValue="true">
+                        <caption>Condition</caption>
+                        <category>General</category>
+                        <description>Condition to determine if the attribute must be set or not</description>
+                        <returnType type="Boolean" />
                     </property>
                 </properties>
             </property>

--- a/packages-web/accessibility-helper/src/AccessibilityHelper.xml
+++ b/packages-web/accessibility-helper/src/AccessibilityHelper.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<widget id="com.mendix.widget.web.accessibilityhelper.AccessibilityHelper" pluginWidget="true" needsEntityContext="true" offlineCapable="true"
+        supportedPlatform="Web"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
+    <name>Accessibility Helper</name>
+    <description/>
+    <icon/>
+    <properties>
+        <propertyGroup caption="General">
+            <property key="targetSelector" type="string">
+                <caption>Target selector</caption>
+                <description/>
+            </property>
+            <property key="content" type="widgets">
+                <caption>Content</caption>
+                <description/>
+            </property>
+
+            <property key="attribute" type="string">
+                <caption>Attribute</caption>
+                <description/>
+            </property>
+            <property key="valueSource" type="enumeration" defaultValue="text">
+                <caption>Source1</caption>
+                <description/>
+                <enumerationValues>
+                    <enumerationValue key="text">Text</enumerationValue>
+                    <enumerationValue key="expression">Expression</enumerationValue>
+                </enumerationValues>
+            </property>
+            <property key="valueExpression" type="expression" required="false">
+                <caption>Value expression</caption>
+                <description/>
+                <returnType type="String" />
+            </property>
+            <property key="valueText" type="textTemplate" required="false">
+                <caption>Value text</caption>
+                <description/>
+            </property>
+            <property key="attributeCondition" type="expression" defaultValue="true">
+                <caption>Condition</caption>
+                <description/>
+                <returnType type="Boolean" />
+            </property>
+
+
+            <property key="attributesList" type="object" isList="true" required="false">
+                <caption>Attributes</caption>
+                <description />
+                <properties>
+                    <property key="attribute" type="string">
+                        <caption>Attribute</caption>
+                        <category>General</category>
+                        <description/>
+                    </property>
+                    <property key="valueSourceType" type="enumeration" defaultValue="text">
+                        <caption>Source</caption>
+                        <category>General</category>
+                        <description/>
+                        <enumerationValues>
+                            <enumerationValue key="text">Text</enumerationValue>
+                            <enumerationValue key="expression">Expression</enumerationValue>
+                        </enumerationValues>
+                    </property>
+                    <property key="attributeCondition" type="expression" defaultValue="true">
+                        <caption>Condition</caption>
+                        <category>General</category>
+                        <description/>
+                        <returnType type="Boolean" />
+                    </property>
+                    <property key="valueExpression" type="expression" required="false">
+                        <caption>Value expression</caption>
+                        <category>General</category>
+                        <description/>
+                        <returnType type="String" />
+                    </property>
+                    <property key="valueText" type="textTemplate" required="false">
+                        <caption>Value text</caption>
+                        <category>General</category>
+                        <description/>
+                    </property>
+
+                </properties>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>

--- a/packages-web/accessibility-helper/src/AccessibilityHelper.xml
+++ b/packages-web/accessibility-helper/src/AccessibilityHelper.xml
@@ -11,7 +11,7 @@
         <propertyGroup caption="General">
             <property key="targetSelector" type="string">
                 <caption>Target selector</caption>
-                <description>Selector to find the HTML element you want to target which must be a valid CSS selector like '.mx-name-texbox1 input'</description>
+                <description>Selector to find the first HTML element you want to target which must be a valid CSS selector like '.mx-name-texbox1 input'</description>
             </property>
             <property key="content" type="widgets">
                 <caption>Content</caption>

--- a/packages-web/accessibility-helper/src/package.xml
+++ b/packages-web/accessibility-helper/src/package.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<package xmlns="http://www.mendix.com/package/1.0/">
+    <clientModule name="AccessibilityHelper" version="0.0.2" xmlns="http://www.mendix.com/clientModule/1.0/">
+        <widgetFiles>
+            <widgetFile path="AccessibilityHelper.xml"/>
+        </widgetFiles>
+        <files>
+            <file path="com/mendix/widget/web/accessibilityhelper"/>
+        </files>
+    </clientModule>
+</package>

--- a/packages-web/accessibility-helper/src/package.xml
+++ b/packages-web/accessibility-helper/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="AccessibilityHelper" version="0.0.2" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="AccessibilityHelper" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="AccessibilityHelper.xml"/>
         </widgetFiles>

--- a/packages-web/accessibility-helper/tests/e2e/specs/AccessibilityHelper.spec.ts
+++ b/packages-web/accessibility-helper/tests/e2e/specs/AccessibilityHelper.spec.ts
@@ -1,0 +1,14 @@
+import page from "../../../../../configs/e2e/src/pages/page";
+
+describe("accessibility-helper", () => {
+    beforeAll(() => {
+        page.open("");
+    });
+
+    it("sets attributes when condition is true", () => {
+        const elementToBeChanged = page.getWidget("elementToBeChanged");
+        expect(elementToBeChanged.getAttribute("yolo1")).toEqual(null);
+        $(".mx-name-radiButtons1 input").click();
+        expect(elementToBeChanged.getAttribute("yolo1")).toEqual("yolo1");
+    });
+});

--- a/packages-web/accessibility-helper/tests/e2e/specs/AccessibilityHelper.spec.ts
+++ b/packages-web/accessibility-helper/tests/e2e/specs/AccessibilityHelper.spec.ts
@@ -11,4 +11,24 @@ describe("accessibility-helper", () => {
         $(".mx-name-radiButtons1 input").click();
         expect(elementToBeChanged.getAttribute("yolo1")).toEqual("yolo1");
     });
+
+    it("hides attributes when condition is false", () => {
+        expect(true).toBe(true);
+    });
+
+    it("updates target attributes when attributes are dynamic", () => {
+        expect(true).toBe(true);
+    });
+
+    it("doesnt change forbidden attributes", () => {
+        expect(true).toBe(true);
+    });
+
+    it("sets target attributes even though target's props changed eg: textinput", () => {
+        expect(true).toBe(true);
+    });
+
+    it("sets target attributes even though target is conditionally shown after being hidden", () => {
+        expect(true).toBe(true);
+    });
 });

--- a/packages-web/accessibility-helper/tests/e2e/specs/AccessibilityHelper.spec.ts
+++ b/packages-web/accessibility-helper/tests/e2e/specs/AccessibilityHelper.spec.ts
@@ -16,7 +16,7 @@ describe("accessibility-helper", () => {
         expect(true).toBe(true);
     });
 
-    it("updates target attributes when attributes are dynamic", () => {
+    it("updates target attributes when attributes are expression", () => {
         expect(true).toBe(true);
     });
 
@@ -25,6 +25,9 @@ describe("accessibility-helper", () => {
     });
 
     it("sets target attributes even though target's props changed eg: textinput", () => {
+        // set attribute
+        // someone changes the target outside
+        // check if attribute is still there
         expect(true).toBe(true);
     });
 

--- a/packages-web/accessibility-helper/tests/e2e/specs/AccessibilityHelper.spec.ts
+++ b/packages-web/accessibility-helper/tests/e2e/specs/AccessibilityHelper.spec.ts
@@ -46,8 +46,9 @@ describe("accessibility-helper", () => {
             expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
             const textBox = page.getWidget("textBox1");
             textBox.$("input").setValue("test");
+            $(".mx-name-radioButtons2 input").click();
 
-            expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
+            expect(elementToBeChanged.getAttribute("expressionvalue")).toContain("test");
         });
 
         it("sets target attributes even though target is conditionally shown after being hidden", () => {
@@ -69,6 +70,7 @@ describe("accessibility-helper", () => {
 
     describe("with multiple targets", () => {
         it("sets attributes when condition is true", () => {
+            $(".mx-name-actionButton2").click();
             $(".mx-name-radioButtons2 input").click();
             const elementToBeChanged = page.getWidget("text3");
             const elementToBeChanged2 = page.getWidget("text4");
@@ -78,6 +80,7 @@ describe("accessibility-helper", () => {
         });
 
         it("hides attributes when condition is false", () => {
+            $(".mx-name-actionButton2").click();
             $(".mx-name-radioButtons2 input").click();
             const elementToBeChanged = page.getWidget("text3");
             const elementToBeChanged2 = page.getWidget("text4");
@@ -87,6 +90,7 @@ describe("accessibility-helper", () => {
         });
 
         it("updates target attributes when attributes are expression", () => {
+            $(".mx-name-actionButton2").click();
             $(".mx-name-radioButtons2 input").click();
             const elementToBeChanged = page.getWidget("text3");
             const elementToBeChanged2 = page.getWidget("text4");
@@ -98,6 +102,7 @@ describe("accessibility-helper", () => {
             expect(elementToBeChanged2.getAttribute("expressionValue")).toEqual("test");
         });
         it("updates target attributes using a NF", () => {
+            $(".mx-name-actionButton2").click();
             $(".mx-name-radioButtons2 input").click();
             $(".mx-name-radioButtons1 input").click();
             const elementToBeChanged = page.getWidget("text3");
@@ -110,23 +115,23 @@ describe("accessibility-helper", () => {
         });
 
         it("sets target attributes even though target's props changed eg: textinput", () => {
+            $(".mx-name-actionButton2").click();
             $(".mx-name-radioButtons2 input").click();
             $(".mx-name-radioButtons1 input").click();
             const elementToBeChanged = page.getWidget("text3");
             const elementToBeChanged2 = page.getWidget("text4");
+            const textBox = page.getWidget("textBox1");
+            textBox.$("input").setValue("test");
+            $(".mx-name-radioButtons2 input").click();
 
             expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
             expect(elementToBeChanged2.getAttribute("a11yhelper")).toContain("a11yhelper");
-
-            const textBox = page.getWidget("textBox1");
-            textBox.$("input").setValue("test");
-
-            // TODO: we should check the changed attribute, not the static one
-            expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
-            expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
+            expect(elementToBeChanged.getAttribute("expressionvalue")).toContain("test");
+            expect(elementToBeChanged2.getAttribute("expressionvalue")).toContain("test");
         });
 
         it("sets target attributes even though target is conditionally shown after being hidden", () => {
+            $(".mx-name-actionButton2").click();
             const radioVisibility = $(".mx-name-radioButtons2 input");
             const radioAtt = $(".mx-name-radioButtons1 input");
             radioVisibility.click();

--- a/packages-web/accessibility-helper/tests/e2e/specs/AccessibilityHelper.spec.ts
+++ b/packages-web/accessibility-helper/tests/e2e/specs/AccessibilityHelper.spec.ts
@@ -1,37 +1,59 @@
 import page from "../../../../../configs/e2e/src/pages/page";
 
 describe("accessibility-helper", () => {
-    beforeAll(() => {
+    beforeEach(() => {
         page.open("");
     });
 
     it("sets attributes when condition is true", () => {
-        const elementToBeChanged = page.getWidget("elementToBeChanged");
-        expect(elementToBeChanged.getAttribute("yolo1")).toEqual(null);
-        $(".mx-name-radiButtons1 input").click();
-        expect(elementToBeChanged.getAttribute("yolo1")).toEqual("yolo1");
+        $(".mx-name-radioButtons2 input").click();
+        const elementToBeChanged = page.getWidget("text3");
+        expect(elementToBeChanged.getAttribute("trueCondition")).toEqual("true");
     });
 
     it("hides attributes when condition is false", () => {
-        expect(true).toBe(true);
+        $(".mx-name-radioButtons2 input").click();
+        const elementToBeChanged = page.getWidget("text3");
+        expect(elementToBeChanged.getAttribute("a11yhelper")).not.toBe("a11yhelper");
     });
 
     it("updates target attributes when attributes are expression", () => {
-        expect(true).toBe(true);
+        $(".mx-name-radioButtons2 input").click();
+        const elementToBeChanged = page.getWidget("text3");
+        const textBox = page.getWidget("textBox1");
+        textBox.$("input").setValue("test");
+        $(".mx-name-radioButtons1 input").click();
+        expect(elementToBeChanged.getAttribute("expressionValue")).toEqual("test");
     });
-
-    it("doesnt change forbidden attributes", () => {
-        expect(true).toBe(true);
+    it("updates target attributes using a NF", () => {
+        $(".mx-name-radioButtons2 input").click();
+        $(".mx-name-radioButtons1 input").click();
+        const elementToBeChanged = page.getWidget("text3");
+        $(".mx-name-actionButton1").click();
+        browser.pause(1000);
+        expect(elementToBeChanged.getAttribute("expressionValue")).toEqual("NF changes");
     });
 
     it("sets target attributes even though target's props changed eg: textinput", () => {
-        // set attribute
-        // someone changes the target outside
-        // check if attribute is still there
-        expect(true).toBe(true);
+        $(".mx-name-radioButtons2 input").click();
+        $(".mx-name-radioButtons1 input").click();
+        const elementToBeChanged = page.getWidget("text3");
+        expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
+        const textBox = page.getWidget("textBox1");
+        textBox.$("input").setValue("test");
+        expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
     });
 
     it("sets target attributes even though target is conditionally shown after being hidden", () => {
-        expect(true).toBe(true);
+        const radioVisibility = $(".mx-name-radioButtons2 input");
+        const radioAtt = $(".mx-name-radioButtons1 input");
+        radioVisibility.click();
+        radioAtt.click();
+        const elementToBeChanged = page.getWidget("text3");
+        expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
+        const radioNo = $(".mx-name-radioButtons1").$("label*=No");
+        radioNo.click();
+        radioAtt.click();
+        expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
     });
 });

--- a/packages-web/accessibility-helper/tests/e2e/specs/AccessibilityHelper.spec.ts
+++ b/packages-web/accessibility-helper/tests/e2e/specs/AccessibilityHelper.spec.ts
@@ -5,55 +5,144 @@ describe("accessibility-helper", () => {
         page.open("");
     });
 
-    it("sets attributes when condition is true", () => {
-        $(".mx-name-radioButtons2 input").click();
-        const elementToBeChanged = page.getWidget("text3");
-        expect(elementToBeChanged.getAttribute("trueCondition")).toEqual("true");
+    describe("with single target", () => {
+        it("sets attributes when condition is true", () => {
+            $(".mx-name-radioButtons2 input").click();
+            const elementToBeChanged = page.getWidget("text3");
+
+            expect(elementToBeChanged.getAttribute("trueCondition")).toEqual("true");
+        });
+
+        it("hides attributes when condition is false", () => {
+            $(".mx-name-radioButtons2 input").click();
+            const elementToBeChanged = page.getWidget("text3");
+
+            expect(elementToBeChanged.getAttribute("a11yhelper")).not.toBe("a11yhelper");
+        });
+
+        it("updates target attributes when attributes are expression", () => {
+            $(".mx-name-radioButtons2 input").click();
+            const elementToBeChanged = page.getWidget("text3");
+            const textBox = page.getWidget("textBox1");
+            textBox.$("input").setValue("test");
+            $(".mx-name-radioButtons1 input").click();
+
+            expect(elementToBeChanged.getAttribute("expressionValue")).toEqual("test");
+        });
+        it("updates target attributes using a NF", () => {
+            $(".mx-name-radioButtons2 input").click();
+            $(".mx-name-radioButtons1 input").click();
+            const elementToBeChanged = page.getWidget("text3");
+            $(".mx-name-actionButton1").click();
+            browser.pause(1000);
+
+            expect(elementToBeChanged.getAttribute("expressionValue")).toEqual("NF changes");
+        });
+
+        it("sets target attributes even though target's props changed eg: textinput", () => {
+            $(".mx-name-radioButtons2 input").click();
+            $(".mx-name-radioButtons1 input").click();
+            const elementToBeChanged = page.getWidget("text3");
+            expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
+            const textBox = page.getWidget("textBox1");
+            textBox.$("input").setValue("test");
+
+            expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
+        });
+
+        it("sets target attributes even though target is conditionally shown after being hidden", () => {
+            const radioVisibility = $(".mx-name-radioButtons2 input");
+            const radioAtt = $(".mx-name-radioButtons1 input");
+            radioVisibility.click();
+            radioAtt.click();
+            const elementToBeChanged = page.getWidget("text3");
+
+            expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
+
+            const radioNo = $(".mx-name-radioButtons1").$("label*=No");
+            radioNo.click();
+            radioAtt.click();
+
+            expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
+        });
     });
 
-    it("hides attributes when condition is false", () => {
-        $(".mx-name-radioButtons2 input").click();
-        const elementToBeChanged = page.getWidget("text3");
-        expect(elementToBeChanged.getAttribute("a11yhelper")).not.toBe("a11yhelper");
-    });
+    describe("with multiple targets", () => {
+        it("sets attributes when condition is true", () => {
+            $(".mx-name-radioButtons2 input").click();
+            const elementToBeChanged = page.getWidget("text3");
+            const elementToBeChanged2 = page.getWidget("text4");
 
-    it("updates target attributes when attributes are expression", () => {
-        $(".mx-name-radioButtons2 input").click();
-        const elementToBeChanged = page.getWidget("text3");
-        const textBox = page.getWidget("textBox1");
-        textBox.$("input").setValue("test");
-        $(".mx-name-radioButtons1 input").click();
-        expect(elementToBeChanged.getAttribute("expressionValue")).toEqual("test");
-    });
-    it("updates target attributes using a NF", () => {
-        $(".mx-name-radioButtons2 input").click();
-        $(".mx-name-radioButtons1 input").click();
-        const elementToBeChanged = page.getWidget("text3");
-        $(".mx-name-actionButton1").click();
-        browser.pause(1000);
-        expect(elementToBeChanged.getAttribute("expressionValue")).toEqual("NF changes");
-    });
+            expect(elementToBeChanged.getAttribute("trueCondition")).toEqual("true");
+            expect(elementToBeChanged2.getAttribute("trueCondition")).toEqual("true");
+        });
 
-    it("sets target attributes even though target's props changed eg: textinput", () => {
-        $(".mx-name-radioButtons2 input").click();
-        $(".mx-name-radioButtons1 input").click();
-        const elementToBeChanged = page.getWidget("text3");
-        expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
-        const textBox = page.getWidget("textBox1");
-        textBox.$("input").setValue("test");
-        expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
-    });
+        it("hides attributes when condition is false", () => {
+            $(".mx-name-radioButtons2 input").click();
+            const elementToBeChanged = page.getWidget("text3");
+            const elementToBeChanged2 = page.getWidget("text4");
 
-    it("sets target attributes even though target is conditionally shown after being hidden", () => {
-        const radioVisibility = $(".mx-name-radioButtons2 input");
-        const radioAtt = $(".mx-name-radioButtons1 input");
-        radioVisibility.click();
-        radioAtt.click();
-        const elementToBeChanged = page.getWidget("text3");
-        expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
-        const radioNo = $(".mx-name-radioButtons1").$("label*=No");
-        radioNo.click();
-        radioAtt.click();
-        expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
+            expect(elementToBeChanged.getAttribute("a11yhelper")).not.toBe("a11yhelper");
+            expect(elementToBeChanged2.getAttribute("a11yhelper")).not.toBe("a11yhelper");
+        });
+
+        it("updates target attributes when attributes are expression", () => {
+            $(".mx-name-radioButtons2 input").click();
+            const elementToBeChanged = page.getWidget("text3");
+            const elementToBeChanged2 = page.getWidget("text4");
+            const textBox = page.getWidget("textBox1");
+            textBox.$("input").setValue("test");
+            $(".mx-name-radioButtons1 input").click();
+
+            expect(elementToBeChanged.getAttribute("expressionValue")).toEqual("test");
+            expect(elementToBeChanged2.getAttribute("expressionValue")).toEqual("test");
+        });
+        it("updates target attributes using a NF", () => {
+            $(".mx-name-radioButtons2 input").click();
+            $(".mx-name-radioButtons1 input").click();
+            const elementToBeChanged = page.getWidget("text3");
+            const elementToBeChanged2 = page.getWidget("text4");
+            $(".mx-name-actionButton1").click();
+            browser.pause(1000);
+
+            expect(elementToBeChanged.getAttribute("expressionValue")).toEqual("NF changes");
+            expect(elementToBeChanged2.getAttribute("expressionValue")).toEqual("NF changes");
+        });
+
+        it("sets target attributes even though target's props changed eg: textinput", () => {
+            $(".mx-name-radioButtons2 input").click();
+            $(".mx-name-radioButtons1 input").click();
+            const elementToBeChanged = page.getWidget("text3");
+            const elementToBeChanged2 = page.getWidget("text4");
+
+            expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
+            expect(elementToBeChanged2.getAttribute("a11yhelper")).toContain("a11yhelper");
+
+            const textBox = page.getWidget("textBox1");
+            textBox.$("input").setValue("test");
+
+            // TODO: we should check the changed attribute, not the static one
+            expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
+            expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
+        });
+
+        it("sets target attributes even though target is conditionally shown after being hidden", () => {
+            const radioVisibility = $(".mx-name-radioButtons2 input");
+            const radioAtt = $(".mx-name-radioButtons1 input");
+            radioVisibility.click();
+            radioAtt.click();
+            const elementToBeChanged = page.getWidget("text3");
+            const elementToBeChanged2 = page.getWidget("text4");
+
+            expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
+            expect(elementToBeChanged2.getAttribute("a11yhelper")).toContain("a11yhelper");
+
+            const radioNo = $(".mx-name-radioButtons1").$("label*=No");
+            radioNo.click();
+            radioAtt.click();
+
+            expect(elementToBeChanged.getAttribute("a11yhelper")).toContain("a11yhelper");
+            expect(elementToBeChanged2.getAttribute("a11yhelper")).toContain("a11yhelper");
+        });
     });
 });

--- a/packages-web/accessibility-helper/tests/e2e/tsconfig.json
+++ b/packages-web/accessibility-helper/tests/e2e/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../../../configs/e2e/tsconfig.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "rootDir": "./"
+    },
+    "include": ["./"],
+    "exclude": ["../../node_modules", "../../../../node_modules"]
+}

--- a/packages-web/accessibility-helper/tsconfig.json
+++ b/packages-web/accessibility-helper/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "@mendix/pluggable-widgets-tools/configs/tsconfig.base",
+    "baseUrl": "./",
+    "include": ["./src", "./typings"],
+    "exclude": ["./dist/", "./node_modules/", "./src/**/__tests__"]
+}

--- a/packages-web/accessibility-helper/typings/AccessibilityHelperProps.d.ts
+++ b/packages-web/accessibility-helper/typings/AccessibilityHelperProps.d.ts
@@ -6,8 +6,6 @@
 import { ComponentType, CSSProperties, ReactNode } from "react";
 import { DynamicValue } from "mendix";
 
-export type ValueSourceEnum = "text" | "expression";
-
 export type ValueSourceTypeEnum = "text" | "expression";
 
 export interface AttributesListType {
@@ -33,11 +31,6 @@ export interface AccessibilityHelperContainerProps {
     tabIndex: number;
     targetSelector: string;
     content: ReactNode;
-    attribute: string;
-    valueSource: ValueSourceEnum;
-    valueExpression?: DynamicValue<string>;
-    valueText?: DynamicValue<string>;
-    attributeCondition: DynamicValue<boolean>;
     attributesList: AttributesListType[];
 }
 
@@ -46,10 +39,5 @@ export interface AccessibilityHelperPreviewProps {
     style: string;
     targetSelector: string;
     content: { widgetCount: number; renderer: ComponentType };
-    attribute: string;
-    valueSource: ValueSourceEnum;
-    valueExpression: string;
-    valueText: string;
-    attributeCondition: string;
     attributesList: AttributesListPreviewType[];
 }

--- a/packages-web/accessibility-helper/typings/AccessibilityHelperProps.d.ts
+++ b/packages-web/accessibility-helper/typings/AccessibilityHelperProps.d.ts
@@ -11,17 +11,17 @@ export type ValueSourceTypeEnum = "text" | "expression";
 export interface AttributesListType {
     attribute: string;
     valueSourceType: ValueSourceTypeEnum;
-    attributeCondition: DynamicValue<boolean>;
     valueExpression?: DynamicValue<string>;
     valueText?: DynamicValue<string>;
+    attributeCondition: DynamicValue<boolean>;
 }
 
 export interface AttributesListPreviewType {
     attribute: string;
     valueSourceType: ValueSourceTypeEnum;
-    attributeCondition: string;
     valueExpression: string;
     valueText: string;
+    attributeCondition: string;
 }
 
 export interface AccessibilityHelperContainerProps {

--- a/packages-web/accessibility-helper/typings/AccessibilityHelperProps.d.ts
+++ b/packages-web/accessibility-helper/typings/AccessibilityHelperProps.d.ts
@@ -1,0 +1,55 @@
+/**
+ * This file was generated from AccessibilityHelper.xml
+ * WARNING: All changes made to this file will be overwritten
+ * @author Mendix UI Content Team
+ */
+import { ComponentType, CSSProperties, ReactNode } from "react";
+import { DynamicValue } from "mendix";
+
+export type ValueSourceEnum = "text" | "expression";
+
+export type ValueSourceTypeEnum = "text" | "expression";
+
+export interface AttributesListType {
+    attribute: string;
+    valueSourceType: ValueSourceTypeEnum;
+    attributeCondition: DynamicValue<boolean>;
+    valueExpression?: DynamicValue<string>;
+    valueText?: DynamicValue<string>;
+}
+
+export interface AttributesListPreviewType {
+    attribute: string;
+    valueSourceType: ValueSourceTypeEnum;
+    attributeCondition: string;
+    valueExpression: string;
+    valueText: string;
+}
+
+export interface AccessibilityHelperContainerProps {
+    name: string;
+    class: string;
+    style?: CSSProperties;
+    tabIndex: number;
+    targetSelector: string;
+    content: ReactNode;
+    attribute: string;
+    valueSource: ValueSourceEnum;
+    valueExpression?: DynamicValue<string>;
+    valueText?: DynamicValue<string>;
+    attributeCondition: DynamicValue<boolean>;
+    attributesList: AttributesListType[];
+}
+
+export interface AccessibilityHelperPreviewProps {
+    class: string;
+    style: string;
+    targetSelector: string;
+    content: { widgetCount: number; renderer: ComponentType };
+    attribute: string;
+    valueSource: ValueSourceEnum;
+    valueExpression: string;
+    valueText: string;
+    attributeCondition: string;
+    attributesList: AttributesListPreviewType[];
+}


### PR DESCRIPTION
New Accessibility Helper widget allows adding new list of properties to elements in the HTML page. 

USAGE:

1. **Adding Accessibility Helper widget to the page**
    Since Accessibility Helper is a containment widget it will try to change the widgets inside. Thus user must drag and drop the necessary widgets wants to change. 

2. **Selecting subject widgets**
    After dragging the widget, by using CSS selectors (https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) the subject widget(s) must be obtained. If there are multiple matches, accessibility widget will try to change all the matches.

3. **Adding new accessibility properties**
   Every HTML attribute consists of a "name" and a "value". User can add any attribute via filling the HTML attributes list. However following attribute names are not allowed since it will interfere with mendix's core mechanism: ["class", "style", "widgetid", "data-mendix-id"]. After selecting a "name" for the attribute, user can determine what kind of value the attribute will get via "Source Type" ("Text" or "Expression"). Text can be used for static value, Expression can be used for dynamic values. User may be able to select on which circumstances this HTML attribute must be set or not via "Condition".


- [x] E2e tests Or unit
- [x] Documentation
- [x] Icon + Appstore Banner => Ask Sepideh
- [x] Property description rehaul
