### PR TITLE
fix(calendar): start postion updating

### DIFF
--- a/packages-web/calendar/package.json
+++ b/packages-web/calendar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar",
   "widgetName": "Calendar",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Display and manage calendar events",
   "copyright": "Mendix BV",
   "repository": {

--- a/packages-web/calendar/src/components/Calendar.ts
+++ b/packages-web/calendar/src/components/Calendar.ts
@@ -137,7 +137,7 @@ class Calendar extends Component<CalendarProps> {
                 toolbar: wrapToolbar({ customViews: this.getToolbarProps(), onClickToolbarButton: this.onRangeChange })
             },
             eventPropGetter: this.eventColor,
-            defaultDate: this.props.startPosition,
+            date: this.props.startPosition,
             defaultView: this.defaultView(),
             formats: this.props.viewOption === "custom" ? this.props.formats : "",
             messages: this.props.viewOption === "custom" ? this.props.messages : "",

--- a/packages-web/calendar/src/components/CalendarContainer.ts
+++ b/packages-web/calendar/src/components/CalendarContainer.ts
@@ -106,12 +106,12 @@ export default class CalendarContainer extends Component<Container.CalendarConta
     }
 
     private getStartPosition = (mxObject: mendix.lib.MxObject): Date => {
-        if (mxObject && mxObject.get(this.props.startDateAttribute) !== "") {
-            const startPosition = this.props.startDateAttribute
-                ? new Date(mxObject.get(this.props.startDateAttribute) as number)
-                : new Date();
+        if (mxObject) {
+            const startDateAttributeValue = mxObject.get(this.props.startDateAttribute);
 
-            return startPosition;
+            if (startDateAttributeValue) {
+                return new Date(startDateAttributeValue as number);
+            }
         }
 
         return new Date();

--- a/packages-web/calendar/src/package.xml
+++ b/packages-web/calendar/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Calendar2" version="1.0.4" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Calendar2" version="1.0.5" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Calendar.xml"/>
         </widgetFiles>


### PR DESCRIPTION
- When start date attribute value changes, the current date of BigCalendar is updated. Default date only initializes current date.
- Improve getStartPosition implementation