### PR TITLE
fix(pwt): spaces in project path

### DIFF
--- a/packages/tools/pluggable-widgets-tools/bin/mx-scripts.js
+++ b/packages/tools/pluggable-widgets-tools/bin/mx-scripts.js
@@ -28,8 +28,8 @@ for (const subCommand of realCommand.split(/&&/g)) {
 
 function getRealCommand(cmd, toolsRoot) {
     const eslintCommand = "eslint --config .eslintrc.js --ext .jsx,.js,.ts,.tsx src";
-    const prettierCommand = 'prettier --config prettier.config.js "{src,tests}/**/*.{js,jsx,ts,tsx}"';
-    const gulpCommand = `gulp --gulpfile ${join(toolsRoot, "scripts/gulp.js")} --cwd ${process.cwd()}`;
+    const prettierCommand = 'prettier --config prettier.config.js "{src,test}/**/*.{js,jsx,ts,tsx}"';
+    const gulpCommand = `gulp --gulpfile "${join(toolsRoot, "scripts/gulp.js")}" --cwd "${process.cwd()}"`;
 
     switch (cmd) {
         case "start:server":


### PR DESCRIPTION
Fix for #215, added two sets of double quotes around the paths in the gulp command