### PR TITLE
Fix/calendar start date attribute change

### DIFF
--- a/packages-web/calendar/package.json
+++ b/packages-web/calendar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar",
   "widgetName": "Calendar",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Display and manage calendar events",
   "copyright": "Mendix BV",
   "repository": {

--- a/packages-web/calendar/src/components/Calendar.ts
+++ b/packages-web/calendar/src/components/Calendar.ts
@@ -65,7 +65,17 @@ export interface CalendarEvent {
     title: string;
 }
 
-class Calendar extends Component<CalendarProps> {
+interface State {
+    date?: Date;
+}
+
+class Calendar extends Component<CalendarProps, State> {
+    readonly state: State = {
+        date: undefined
+    };
+
+    private readonly onNavigateHandler = this.onNavigate.bind(this);
+
     render(): ReactNode {
         return createElement(
             SizeContainer,
@@ -125,6 +135,10 @@ class Calendar extends Component<CalendarProps> {
         return createElement(Alert, { className: "widget-calendar-alert" }, this.props.alertMessage);
     }
 
+    private onNavigate(date: Date): void {
+        this.setState({ date });
+    }
+
     private renderCalendar(): ReactNode {
         const wrapToolbar = (injectedProps: HOCToolbarProps): Function => (toolbarProps: Container.ToolbarProps) =>
             createElement(CustomToolbar as any, { ...injectedProps, ...toolbarProps });
@@ -136,8 +150,9 @@ class Calendar extends Component<CalendarProps> {
             components: {
                 toolbar: wrapToolbar({ customViews: this.getToolbarProps(), onClickToolbarButton: this.onRangeChange })
             },
+            onNavigate: this.onNavigateHandler,
             eventPropGetter: this.eventColor,
-            date: this.props.startPosition,
+            date: this.state.date ?? this.props.startPosition,
             defaultView: this.defaultView(),
             formats: this.props.viewOption === "custom" ? this.props.formats : "",
             messages: this.props.viewOption === "custom" ? this.props.messages : "",

--- a/packages-web/calendar/src/components/CalendarContainer.ts
+++ b/packages-web/calendar/src/components/CalendarContainer.ts
@@ -228,7 +228,7 @@ export default class CalendarContainer extends Component<Container.CalendarConta
                 window.mx.data.subscribe({
                     guid: mxObject.getGuid(),
                     attr: this.props.startDateAttribute,
-                    callback: () => this.getStartPosition(mxObject)
+                    callback: () => this.loadEvents(mxObject)
                 })
             );
             this.subscriptionContextHandles.push(

--- a/packages-web/calendar/src/package.xml
+++ b/packages-web/calendar/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Calendar2" version="1.0.5" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Calendar2" version="1.0.6" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Calendar.xml"/>
         </widgetFiles>


### PR DESCRIPTION
- We fixed an issue where the calendar wouldn't update on a start date attribute value change.
- We fixed an issue where calendar widget on week view and +more events wouldn't open the correct date.