### PR TITLE
Add option to skip typings generator

### DIFF
--- a/packages-common/pluggable-widgets-tools/scripts/gulp.js
+++ b/packages-common/pluggable-widgets-tools/scripts/gulp.js
@@ -96,7 +96,7 @@ function runWebpack(env, cb) {
 }
 
 function generateTypings() {
-    if (!variables.isTypescript) {
+    if (!variables.isTypescript || process.env.MX_SKIP_TYPEGENERATOR) {
         return gulp.src(".", { allowEmpty: true });
     }
     return gulp


### PR DESCRIPTION
I am using the `@mendix/widget` generator to generate both Pluggable as well as Custom React widgets. For the latter, I have been using the `pluggable-widget-tools` as well, which worked fine in 8.6.0.

In the newer versions of the tools, the typings generator that generates typings from the XML, is always enabled (even if I change my `build` command in `package.json` to `pluggable-widgets-tools build:js`).

As we're already loading the `.env` file from a widget project folder (so we can set the proper path to the Mendix project), I suggest adding an extra option there:

`MX_SKIP_TYPEGENERATOR`

If you add this to the `.env` file, it will skip the typings generator and the pluggable widgets tools will work for custom React widgets as well