### PR TITLE
Fix type generation for labeled widgets

### DIFF
--- a/packages/pluggableWidgets/video-player-web/src/components/SizeContainer.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/SizeContainer.tsx
@@ -10,7 +10,7 @@ export interface Dimensions {
     width: number;
     heightUnit: HeightUnitType;
     height: number;
-    tabIndex: number;
+    tabIndex?: number;
 }
 
 export interface SizeProps extends Dimensions {

--- a/packages/tools/pluggable-widgets-tools/jest.config.js
+++ b/packages/tools/pluggable-widgets-tools/jest.config.js
@@ -4,13 +4,13 @@ const nativeBaseConfig = require("./test-config/jest.native.config.js");
 const webConfig = {
     ...webBaseConfig,
     rootDir: ".",
-    testMatch: ["<rootDir>/src/{web,typings-generator}/**/*.spec.{ts,tsx}"]
+    testMatch: ["<rootDir>/src/@(web|typings-generator)/**/*.spec.ts"]
 };
 
 const nativeConfig = {
     ...nativeBaseConfig,
     rootDir: ".",
-    testMatch: ["<rootDir>/src/native/**/*.spec.{ts,tsx}"]
+    testMatch: ["<rootDir>/src/native/**/*.spec.ts"]
 };
 
 module.exports = {

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/WidgetXml.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/WidgetXml.ts
@@ -78,6 +78,7 @@ export interface PropertyGroup {
     };
     propertyGroup?: PropertyGroup[];
     property?: Property[];
+    systemProperty?: SystemProperty[];
 }
 
 export interface SystemProperty {

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
@@ -15,7 +15,7 @@ import { datasourceInput, datasourceInputNative } from "./inputs/datasource";
 import { datasourceNativeOutput, datasourceWebOutput } from "./outputs/datasource";
 import { generateForWidget } from "../generate";
 import { generateClientTypes } from "../generateClientTypes";
-import { extractProperties } from "../helpers";
+import { extractProperties, extractSystemProperties } from "../helpers";
 import { WidgetXml } from "../WidgetXml";
 import { content, contentGroup, contentGroupNative, contentNative } from "./inputs";
 import { nativeResult, webResult, webResultGroup } from "./outputs";
@@ -112,15 +112,15 @@ describe("Generating tests", () => {
     });
 });
 
-function generateFullTypesFor(xml: string) {
+function generateFullTypesFor(xml: string): string {
     return generateForWidget(convertXmltoJson(xml), "MyWidget");
 }
 
-function generateNativeTypesFor(xml: string) {
+function generateNativeTypesFor(xml: string): string {
     const widgetXml = convertXmltoJson(xml);
-    return generateClientTypes("MyWidget", extractProperties(widgetXml!.widget!.properties[0]), true, false).join(
-        "\n\n"
-    );
+    const props = extractProperties(widgetXml!.widget!.properties[0]);
+    const systemProps = extractSystemProperties(widgetXml!.widget!.properties[0]);
+    return generateClientTypes("MyWidget", props, systemProps, true).join("\n\n");
 }
 
 function convertXmltoJson(xml: string): WidgetXml {

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
@@ -18,7 +18,7 @@ import { generateClientTypes } from "../generateClientTypes";
 import { extractProperties } from "../helpers";
 import { WidgetXml } from "../WidgetXml";
 import { content, contentGroup, contentGroupNative, contentNative } from "./inputs";
-import { nativeResult, webResult } from "./outputs";
+import { nativeResult, webResult, webResultGroup } from "./outputs";
 
 describe("Generating tests", () => {
     it("Generates a parsed typing from XML for native", () => {
@@ -38,7 +38,7 @@ describe("Generating tests", () => {
 
     it("Generates a parsed typing from XML for web with groups", () => {
         const newContent = generateFullTypesFor(contentGroup);
-        expect(newContent).toBe(webResult);
+        expect(newContent).toBe(webResultGroup);
     });
 
     it("Generates a parsed typing from XML for native using list of actions", () => {
@@ -118,7 +118,9 @@ function generateFullTypesFor(xml: string) {
 
 function generateNativeTypesFor(xml: string) {
     const widgetXml = convertXmltoJson(xml);
-    return generateClientTypes("MyWidget", extractProperties(widgetXml!.widget!.properties[0]), true).join("\n\n");
+    return generateClientTypes("MyWidget", extractProperties(widgetXml!.widget!.properties[0]), true, false).join(
+        "\n\n"
+    );
 }
 
 function convertXmltoJson(xml: string): WidgetXml {

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/file.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/file.ts
@@ -19,16 +19,18 @@ export const fileInput = `<?xml version="1.0" encoding="utf-8"?>
                 <description />
                 <attributeTypes>
                     <attributeType name="String"/>
-                </attributeTypes>    
+                </attributeTypes>
             </property>
             <property key="action" type="action">
                 <caption>Action</caption>
                 <description />
             </property>
         </propertyGroup>
-        <propertyGroup caption="System Properties">
-            <systemProperty key="Label"></systemProperty>
-            <systemProperty key="TabIndex"></systemProperty>
+        <propertyGroup caption="Tab group">
+            <propertyGroup caption="Sub group ">
+                <systemProperty key="Label"></systemProperty>
+                <systemProperty key="TabIndex"></systemProperty>
+            </propertyGroup>
         </propertyGroup>
     </properties>
 </widget>`;
@@ -54,7 +56,7 @@ export const fileInputNative = `<?xml version="1.0" encoding="utf-8"?>
                 <description />
                 <attributeTypes>
                     <attributeType name="String"/>
-                </attributeTypes>    
+                </attributeTypes>
             </property>
             <property key="action" type="action">
                 <caption>Action</caption>

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
@@ -10,7 +10,7 @@ export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
     content: ReactNode;
     description: EditableValue<string>;
     action?: ActionValue;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
@@ -3,13 +3,13 @@ export const containmentWebOutput = `/**
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
-import { ComponentType, CSSProperties, ReactNode } from "react";
+import { ComponentType, ReactNode } from "react";
 import { ActionValue, EditableValue } from "mendix";
 
 export interface MyWidgetContainerProps {
     name: string;
     class: string;
-    style?: CSSProperties;
+    id: string;
     tabIndex?: number;
     content: ReactNode;
     description: EditableValue<string>;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
@@ -3,14 +3,15 @@ export const containmentWebOutput = `/**
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
-import { ComponentType, ReactNode } from "react";
+import { ComponentType, CSSProperties, ReactNode } from "react";
 import { ActionValue, EditableValue } from "mendix";
 
 export interface MyWidgetContainerProps {
     name: string;
     class: string;
-    id: string;
+    style?: CSSProperties;
     tabIndex?: number;
+    id: string;
     content: ReactNode;
     description: EditableValue<string>;
     action?: ActionValue;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
@@ -3,7 +3,7 @@ export const datasourceWebOutput = `/**
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
-import { ComponentType, CSSProperties } from "react";
+import { ComponentType } from "react";
 import { ActionValue, EditableValue, ListValue, ListActionValue, ListAttributeValue, ListWidgetValue } from "mendix";
 
 export interface DatasourcePropertiesType {
@@ -21,7 +21,7 @@ export interface DatasourcePropertiesPreviewType {
 export interface MyWidgetContainerProps {
     name: string;
     class: string;
-    style?: CSSProperties;
+    id: string;
     tabIndex?: number;
     contentSource: ListValue;
     content: ListWidgetValue;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
@@ -22,7 +22,7 @@ export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
     contentSource: ListValue;
     content: ListWidgetValue;
     markerDataAttribute: ListAttributeValue<string | boolean | BigJs.Big>;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
@@ -3,7 +3,7 @@ export const datasourceWebOutput = `/**
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
-import { ComponentType } from "react";
+import { ComponentType, CSSProperties } from "react";
 import { ActionValue, EditableValue, ListValue, ListActionValue, ListAttributeValue, ListWidgetValue } from "mendix";
 
 export interface DatasourcePropertiesType {
@@ -21,8 +21,9 @@ export interface DatasourcePropertiesPreviewType {
 export interface MyWidgetContainerProps {
     name: string;
     class: string;
-    id: string;
+    style?: CSSProperties;
     tabIndex?: number;
+    id: string;
     contentSource: ListValue;
     content: ListWidgetValue;
     markerDataAttribute: ListAttributeValue<string | boolean | BigJs.Big>;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/file.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/file.ts
@@ -3,13 +3,12 @@ export const fileWebOutput = `/**
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
-import { CSSProperties } from "react";
 import { ActionValue, DynamicValue, EditableValue, FileValue } from "mendix";
 
 export interface MyWidgetContainerProps {
     name: string;
     class: string;
-    style?: CSSProperties;
+    id: string;
     tabIndex?: number;
     file: DynamicValue<FileValue>;
     file2?: DynamicValue<FileValue>;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/file.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/file.ts
@@ -3,13 +3,15 @@ export const fileWebOutput = `/**
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
+import { CSSProperties } from "react";
 import { ActionValue, DynamicValue, EditableValue, FileValue } from "mendix";
 
 export interface MyWidgetContainerProps {
     name: string;
     class: string;
-    id: string;
+    style?: CSSProperties;
     tabIndex?: number;
+    id: string;
     file: DynamicValue<FileValue>;
     file2?: DynamicValue<FileValue>;
     description: EditableValue<string>;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/file.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/file.ts
@@ -10,7 +10,7 @@ export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
     file: DynamicValue<FileValue>;
     file2?: DynamicValue<FileValue>;
     description: EditableValue<string>;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/icon.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/icon.ts
@@ -20,7 +20,7 @@ export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
     icons: IconsType[];
 }
 

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/icon.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/icon.ts
@@ -3,6 +3,7 @@ export const iconWebOutput = `/**
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
+import { CSSProperties } from "react";
 import { DynamicValue, WebIcon } from "mendix";
 
 export interface IconsType {
@@ -18,8 +19,9 @@ export interface IconsPreviewType {
 export interface MyWidgetContainerProps {
     name: string;
     class: string;
-    id: string;
+    style?: CSSProperties;
     tabIndex?: number;
+    id: string;
     icons: IconsType[];
 }
 

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/icon.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/icon.ts
@@ -3,7 +3,6 @@ export const iconWebOutput = `/**
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
-import { CSSProperties } from "react";
 import { DynamicValue, WebIcon } from "mendix";
 
 export interface IconsType {
@@ -19,7 +18,7 @@ export interface IconsPreviewType {
 export interface MyWidgetContainerProps {
     name: string;
     class: string;
-    style?: CSSProperties;
+    id: string;
     tabIndex?: number;
     icons: IconsType[];
 }

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
@@ -90,7 +90,7 @@ export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
     valueAttribute?: EditableValue<string | BigJs.Big>;
     mywidgetValue: string;
     valueExpression?: DynamicValue<string>;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
@@ -130,6 +130,7 @@ export const webResultGroup = `/**
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
+import { CSSProperties } from "react";
 import { ActionValue, DynamicValue, EditableValue, FileValue, WebImage } from "mendix";
 
 export type BootstrapStyleEnum = "default" | "primary" | "success" | "info" | "inverse" | "warning" | "danger";
@@ -153,8 +154,9 @@ export interface ActionsPreviewType {
 export interface MyWidgetContainerProps {
     name: string;
     class: string;
-    id: string;
+    style?: CSSProperties;
     tabIndex?: number;
+    id: string;
     valueAttribute?: EditableValue<string | BigJs.Big>;
     mywidgetValue: string;
     valueExpression?: DynamicValue<string>;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
@@ -124,3 +124,67 @@ export interface MyWidgetPreviewProps {
     actions: ActionsPreviewType[];
 }
 `;
+
+export const webResultGroup = `/**
+ * This file was generated from MyWidget.xml
+ * WARNING: All changes made to this file will be overwritten
+ * @author Mendix UI Content Team
+ */
+import { ActionValue, DynamicValue, EditableValue, FileValue, WebImage } from "mendix";
+
+export type BootstrapStyleEnum = "default" | "primary" | "success" | "info" | "inverse" | "warning" | "danger";
+
+export type MywidgetTypeEnum = "badge" | "label";
+
+export interface ActionsType {
+    name: string;
+    enabled: boolean;
+    action?: ActionValue;
+    image: DynamicValue<WebImage>;
+}
+
+export interface ActionsPreviewType {
+    name: string;
+    enabled: boolean;
+    action: {} | null;
+    image: string;
+}
+
+export interface MyWidgetContainerProps {
+    name: string;
+    class: string;
+    id: string;
+    tabIndex?: number;
+    valueAttribute?: EditableValue<string | BigJs.Big>;
+    mywidgetValue: string;
+    valueExpression?: DynamicValue<string>;
+    valueExpressionDecimal?: DynamicValue<BigJs.Big>;
+    file: DynamicValue<FileValue>;
+    bootstrapStyle: BootstrapStyleEnum;
+    mywidgetType: MywidgetTypeEnum;
+    tries?: number;
+    amount?: BigJs.Big;
+    image?: DynamicValue<WebImage>;
+    onClickAction?: ActionValue;
+    onChange?: ActionValue;
+    actions: ActionsType[];
+}
+
+export interface MyWidgetPreviewProps {
+    class: string;
+    style: string;
+    valueAttribute: string;
+    mywidgetValue: string;
+    valueExpression: string;
+    valueExpressionDecimal: string;
+    file: string;
+    bootstrapStyle: BootstrapStyleEnum;
+    mywidgetType: MywidgetTypeEnum;
+    tries: number | null;
+    amount: number | null;
+    image: string;
+    onClickAction: {} | null;
+    onChange: {} | null;
+    actions: ActionsPreviewType[];
+}
+`;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-action.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-action.ts
@@ -3,6 +3,7 @@ export const listActionWebOutput = `/**
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
+import { CSSProperties } from "react";
 import { ActionValue, EditableValue } from "mendix";
 
 export interface ActionsType {
@@ -18,8 +19,9 @@ export interface ActionsPreviewType {
 export interface MyWidgetContainerProps {
     name: string;
     class: string;
-    id: string;
+    style?: CSSProperties;
     tabIndex?: number;
+    id: string;
     actions: ActionsType[];
 }
 

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-action.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-action.ts
@@ -20,7 +20,7 @@ export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
     actions: ActionsType[];
 }
 

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-action.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-action.ts
@@ -3,7 +3,6 @@ export const listActionWebOutput = `/**
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
-import { CSSProperties } from "react";
 import { ActionValue, EditableValue } from "mendix";
 
 export interface ActionsType {
@@ -19,7 +18,7 @@ export interface ActionsPreviewType {
 export interface MyWidgetContainerProps {
     name: string;
     class: string;
-    style?: CSSProperties;
+    id: string;
     tabIndex?: number;
     actions: ActionsType[];
 }

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-files.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-files.ts
@@ -18,7 +18,7 @@ export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
     actions: ActionsType[];
 }
 

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-files.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-files.ts
@@ -3,6 +3,7 @@ export const listFileWebOutput = `/**
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
+import { CSSProperties } from "react";
 import { DynamicValue, FileValue } from "mendix";
 
 export interface ActionsType {
@@ -16,8 +17,9 @@ export interface ActionsPreviewType {
 export interface MyWidgetContainerProps {
     name: string;
     class: string;
-    id: string;
+    style?: CSSProperties;
     tabIndex?: number;
+    id: string;
     actions: ActionsType[];
 }
 

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-files.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-files.ts
@@ -3,7 +3,6 @@ export const listFileWebOutput = `/**
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
-import { CSSProperties } from "react";
 import { DynamicValue, FileValue } from "mendix";
 
 export interface ActionsType {
@@ -17,7 +16,7 @@ export interface ActionsPreviewType {
 export interface MyWidgetContainerProps {
     name: string;
     class: string;
-    style?: CSSProperties;
+    id: string;
     tabIndex?: number;
     actions: ActionsType[];
 }

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
@@ -18,7 +18,7 @@ export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
     actions: ActionsType[];
 }
 

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
@@ -3,6 +3,7 @@ export const listImageWebOutput = `/**
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
+import { CSSProperties } from "react";
 import { DynamicValue, WebImage } from "mendix";
 
 export interface ActionsType {
@@ -16,8 +17,9 @@ export interface ActionsPreviewType {
 export interface MyWidgetContainerProps {
     name: string;
     class: string;
-    id: string;
+    style?: CSSProperties;
     tabIndex?: number;
+    id: string;
     actions: ActionsType[];
 }
 

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
@@ -3,7 +3,6 @@ export const listImageWebOutput = `/**
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
-import { CSSProperties } from "react";
 import { DynamicValue, WebImage } from "mendix";
 
 export interface ActionsType {
@@ -17,7 +16,7 @@ export interface ActionsPreviewType {
 export interface MyWidgetContainerProps {
     name: string;
     class: string;
-    style?: CSSProperties;
+    id: string;
     tabIndex?: number;
     actions: ActionsType[];
 }

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generate.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generate.ts
@@ -32,14 +32,13 @@ export function generateForWidget(widgetXml: WidgetXml, widgetName: string) {
         ? extractSystemProperties(widgetXml.widget.properties[0])
         : []
     ).filter(prop => prop && prop.$ && prop.$.key);
-    const isLabeled = systemProperties.some(p => p.$.key === "Label");
 
     const properties = (widgetXml.widget.properties.length > 0
         ? extractProperties(widgetXml.widget.properties[0])
         : []
     ).filter(prop => prop && prop.$ && prop.$.key);
 
-    const clientTypes = generateClientTypes(widgetName, properties, isNative, isLabeled);
+    const clientTypes = generateClientTypes(widgetName, properties, systemProperties, isNative);
     const modelerTypes = generatePreviewTypes(widgetName, properties);
 
     const generatedTypesCode = clientTypes

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generate.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generate.ts
@@ -1,6 +1,6 @@
 import { generateClientTypes } from "./generateClientTypes";
 import { generatePreviewTypes } from "./generatePreviewTypes";
-import { extractProperties } from "./helpers";
+import { extractProperties, extractSystemProperties } from "./helpers";
 import { WidgetXml } from "./WidgetXml";
 
 const mxExports = [
@@ -28,12 +28,18 @@ export function generateForWidget(widgetXml: WidgetXml, widgetName: string) {
 
     const isNative = widgetXml.widget.$.supportedPlatform === "Native";
 
+    const systemProperties = (widgetXml.widget.properties.length > 0
+        ? extractSystemProperties(widgetXml.widget.properties[0])
+        : []
+    ).filter(prop => prop && prop.$ && prop.$.key);
+    const isLabeled = systemProperties.some(p => p.$.key === "Label");
+
     const properties = (widgetXml.widget.properties.length > 0
         ? extractProperties(widgetXml.widget.properties[0])
         : []
     ).filter(prop => prop && prop.$ && prop.$.key);
 
-    const clientTypes = generateClientTypes(widgetName, properties, isNative);
+    const clientTypes = generateClientTypes(widgetName, properties, isNative, isLabeled);
     const modelerTypes = generatePreviewTypes(widgetName, properties);
 
     const generatedTypesCode = clientTypes

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
@@ -19,8 +19,13 @@ ${generateClientTypeBody(properties, true, results)}
             : `export interface ${widgetName}ContainerProps {
     name: string;
     class: string;
-    ${isLabeled ? `id: string;` : `style?: CSSProperties;`}
-    tabIndex?: number;
+    style?: CSSProperties;
+    tabIndex?: number;${
+        isLabeled
+            ? `
+    id: string;`
+            : ``
+    }
 ${generateClientTypeBody(properties, false, results)}
 }`
     );

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
@@ -14,7 +14,7 @@ ${generateClientTypeBody(properties, true, results)}
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
 ${generateClientTypeBody(properties, false, results)}
 }`
     );

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
@@ -1,13 +1,14 @@
-import { Property } from "./WidgetXml";
+import { Property, SystemProperty } from "./WidgetXml";
 import { capitalizeFirstLetter, extractProperties } from "./helpers";
 
 export function generateClientTypes(
     widgetName: string,
     properties: Property[],
-    isNative: boolean,
-    isLabeled: boolean
+    systemProperties: SystemProperty[],
+    isNative: boolean
 ): string[] {
     const results = Array.of<string>();
+    const isLabeled = systemProperties.some(p => p.$.key === "Label");
     results.push(
         isNative
             ? `export interface ${widgetName}Props<Style> {
@@ -26,7 +27,7 @@ ${generateClientTypeBody(properties, false, results)}
     return results;
 }
 
-function generateClientTypeBody(properties: Property[], isNative: boolean, generatedTypes: string[]) {
+function generateClientTypeBody(properties: Property[], isNative: boolean, generatedTypes: string[]): string {
     return properties
         .map(prop => {
             const isOptional =
@@ -37,7 +38,7 @@ function generateClientTypeBody(properties: Property[], isNative: boolean, gener
         .join("\n");
 }
 
-function toClientPropType(prop: Property, isNative: boolean, generatedTypes: string[]) {
+function toClientPropType(prop: Property, isNative: boolean, generatedTypes: string[]): string {
     switch (prop.$.type) {
         case "boolean":
             return "boolean";
@@ -98,7 +99,7 @@ ${generateClientTypeBody(extractProperties(prop.properties[0]), isNative, genera
     }
 }
 
-function generateEnum(typeName: string, prop: Property) {
+function generateEnum(typeName: string, prop: Property): string {
     if (!prop.enumerationValues?.length || !prop.enumerationValues[0].enumerationValue?.length) {
         throw new Error("[XML] Enumeration property requires enumerations element");
     }

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
@@ -1,7 +1,12 @@
 import { Property } from "./WidgetXml";
 import { capitalizeFirstLetter, extractProperties } from "./helpers";
 
-export function generateClientTypes(widgetName: string, properties: Property[], isNative: boolean): string[] {
+export function generateClientTypes(
+    widgetName: string,
+    properties: Property[],
+    isNative: boolean,
+    isLabeled: boolean
+): string[] {
     const results = Array.of<string>();
     results.push(
         isNative
@@ -13,7 +18,7 @@ ${generateClientTypeBody(properties, true, results)}
             : `export interface ${widgetName}ContainerProps {
     name: string;
     class: string;
-    style?: CSSProperties;
+    ${isLabeled ? `id: string;` : `style?: CSSProperties;`}
     tabIndex?: number;
 ${generateClientTypeBody(properties, false, results)}
 }`

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/helpers.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/helpers.ts
@@ -1,4 +1,4 @@
-import { Properties, Property } from "./WidgetXml";
+import { SystemProperty, Properties, Property } from "./WidgetXml";
 
 export function extractProperties(propElements: Properties): Property[] {
     if (!propElements.propertyGroup) {
@@ -6,6 +6,14 @@ export function extractProperties(propElements: Properties): Property[] {
     }
 
     return (propElements.propertyGroup ?? []).map(pg => extractProperties(pg)).reduce((a, e) => a.concat(e), []);
+}
+
+export function extractSystemProperties(propElements: Properties): SystemProperty[] {
+    if (!propElements.propertyGroup) {
+        return propElements.systemProperty ?? [];
+    }
+
+    return (propElements.propertyGroup ?? []).map(pg => extractSystemProperties(pg)).reduce((a, e) => a.concat(e), []);
 }
 
 export function capitalizeFirstLetter(text: string): string {


### PR DESCRIPTION
- Labeled widgets do have an `id` prop, so it can be used for accessibility. (Fixes https://github.com/mendix/pluggable-widgets-typing-generator/issues/36)
- Labeled widgets do not have a `style` prop, as it is already applied to surrounding FormGroup
- The `tabIndex` is optional. If the value in the modeler is 0 it will be the prop is omitted.
- Fixed the jest match for the tests, it did not match web and generator tests