### PR TITLE
Fix PIW tools script bugs & improve PIW generator default MX project path

### DIFF
--- a/packages/tools/generator-widget/generators/app/lib/prompttexts.js
+++ b/packages/tools/generator-widget/generators/app/lib/prompttexts.js
@@ -64,7 +64,7 @@ function promptWidgetProperties(mxProjectDir, widgetName) {
             type: "input",
             name: "projectPath",
             message: "Mendix project path",
-            default: mxProjectDir ? mxProjectDir : "./dist/MxTestProject"
+            default: mxProjectDir ? mxProjectDir : "./test/TestProject"
         },
         {
             type: "list",

--- a/packages/tools/generator-widget/generators/app/lib/prompttexts.js
+++ b/packages/tools/generator-widget/generators/app/lib/prompttexts.js
@@ -64,7 +64,7 @@ function promptWidgetProperties(mxProjectDir, widgetName) {
             type: "input",
             name: "projectPath",
             message: "Mendix project path",
-            default: mxProjectDir ? mxProjectDir : "./test/TestProject"
+            default: mxProjectDir ? mxProjectDir : "./tests/TestProject"
         },
         {
             type: "list",

--- a/packages/tools/generator-widget/generators/app/lib/prompttexts.js
+++ b/packages/tools/generator-widget/generators/app/lib/prompttexts.js
@@ -64,7 +64,7 @@ function promptWidgetProperties(mxProjectDir, widgetName) {
             type: "input",
             name: "projectPath",
             message: "Mendix project path",
-            default: mxProjectDir ? mxProjectDir : "./tests/TestProject"
+            default: mxProjectDir ? mxProjectDir : "./tests/testProject"
         },
         {
             type: "list",

--- a/packages/tools/generator-widget/package.json
+++ b/packages/tools/generator-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/generator-widget",
-  "version": "8.12.0",
+  "version": "8.12.1",
   "description": "Mendix Pluggable Widgets Generator",
   "license": "Apache-2.0",
   "copyright": "2020 Mendix Technology B.V.",

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "8.12.1",
+  "version": "8.12.2",
   "description": "Mendix Pluggable Widgets Tools",
   "license": "Apache-2.0",
   "copyright": "2020 Mendix Technology BV",

--- a/packages/tools/pluggable-widgets-tools/scripts/gulp.js
+++ b/packages/tools/pluggable-widgets-tools/scripts/gulp.js
@@ -49,7 +49,7 @@ function copyToDeployment() {
                 join(variables.projectPath, "dist/tmp/widgets/**/*"),
                 "!" + join(variables.projectPath, "dist/tmp/widgets/**/package.xml")
             ])
-            .pipe(gulp.dest(join(projectPath, "deployment/web/widgets")))
+            .pipe(gulp.dest(join(projectPath, `deployment/${isNative ? "native" : "web"}/widgets`)))
             .on("error", handleError);
     } else {
         console.log(

--- a/packages/tools/pluggable-widgets-tools/scripts/gulp.js
+++ b/packages/tools/pluggable-widgets-tools/scripts/gulp.js
@@ -43,14 +43,14 @@ function createMpkFile() {
 
 function copyToDeployment() {
     if (existsSync(projectPath) && readdirSync(projectPath).length > 0) {
-        console.log(colors.green(`Files generated in dist and ${projectPath} folder`));
         return gulp
             .src([
                 join(variables.projectPath, "dist/tmp/widgets/**/*"),
                 "!" + join(variables.projectPath, "dist/tmp/widgets/**/package.xml")
             ])
             .pipe(gulp.dest(join(projectPath, `deployment/${isNative ? "native" : "web"}/widgets`)))
-            .on("error", handleError);
+            .on("error", handleError)
+            .on("end", () => console.log(colors.green(`Files generated in dist and ${projectPath} folder`)));
     } else {
         console.log(
             colors.yellow(
@@ -121,6 +121,6 @@ function handleError(err) {
 exports.build = gulp.series(clean, generateTypings, runWebpack.bind(null, "dev"), createMpkFile, copyToDeployment);
 exports.release = gulp.series(clean, generateTypings, runWebpack.bind(null, "prod"), createMpkFile);
 exports.watch = function() {
-    console.log(colors.green(`Watching files in: ${variables.projectPath}`));
+    console.log(colors.green(`Watching files in: ${variables.projectPath}/src`));
     return gulp.watch("src/**/*", { ignoreInitial: false, cwd: variables.projectPath }, exports.build);
 };

--- a/packages/tools/pluggable-widgets-tools/scripts/gulp.js
+++ b/packages/tools/pluggable-widgets-tools/scripts/gulp.js
@@ -6,6 +6,9 @@ const del = require("del");
 const gulp = require("gulp");
 const zip = require("gulp-zip");
 const webpack = require("webpack");
+
+let webpackCompiler;
+
 const variables = require("../configs/variables");
 
 require("dotenv").config({ path: join(variables.projectPath, ".env") });
@@ -85,7 +88,11 @@ function runWebpack(env, cb) {
         }
     }
 
-    webpack(config, (err, stats) => {
+    if (!webpackCompiler) {
+        webpackCompiler = webpack(config);
+    }
+
+    webpackCompiler.run((err, stats) => {
         if (err) {
             handleError(err);
             cb(new Error(`Webpack: ${err}`));

--- a/packages/tools/pluggable-widgets-tools/scripts/gulp.js
+++ b/packages/tools/pluggable-widgets-tools/scripts/gulp.js
@@ -50,7 +50,7 @@ function copyToDeployment() {
             ])
             .pipe(gulp.dest(join(projectPath, `deployment/${isNative ? "native" : "web"}/widgets`)))
             .on("error", handleError)
-            .on("end", () => console.log(colors.green(`Files generated in dist and ${projectPath} folder`)));
+            .on("finish", () => console.log(colors.green(`Files generated in dist and ${projectPath} folder`)));
     } else {
         console.log(
             colors.yellow(


### PR DESCRIPTION
- Changes default MX test project folder to `./tests/TestProject` in PIW generator.
- Fixes webpack not bundling multiple times in Gulp watch mode.
- Fixes bug where native widgets would be copied in the web widgets deployment folder.
- Improves Gulp messaging.

Fixes #218 