### PR TITLE
test(slider-web): fix mf/nf test spec

### DIFF
--- a/packages/customWidgets/slider-web/tests/e2e/specs/Slider.spec.ts
+++ b/packages/customWidgets/slider-web/tests/e2e/specs/Slider.spec.ts
@@ -60,9 +60,14 @@ describe("Slider widget", () => {
             const sliderWidget = new SliderWidget("sliderMicroflow");
 
             sliderWidget.dragHandleToMinimum();
-
             const modalDialogText = $(".modal-dialog .mx-dialog-body > p");
-            modalDialogText.waitForDisplayed();
+            browser.waitUntil(
+                () => {
+                    return modalDialogText.getText() === "Slider Value is 0";
+                },
+                1000,
+                "expected text to be different after 1s"
+            );
             expect(modalDialogText.getText()).toContain("0");
         });
 
@@ -74,7 +79,13 @@ describe("Slider widget", () => {
             sliderWidget.dragHandleToMinimum();
 
             const modalDialogText = $(".modal-dialog .mx-name-text1");
-            modalDialogText.waitForDisplayed();
+            browser.waitUntil(
+                () => {
+                    return modalDialogText.getText() === "Slider Value is 0";
+                },
+                1000,
+                "expected text to be different after 1s"
+            );
             expect(modalDialogText.getText()).toContain("0");
         });
 


### PR DESCRIPTION
After run locally multiple times the slider mf/nf test starts failing here:
`[firefox 79.0 mac #0-0] 1) Slider triggers a microflow after slide
[firefox 79.0 mac #0-0] Expected '' to contain '0'.
[firefox 79.0 mac #0-0] Error: Expected '' to contain '0'.
[firefox 79.0 mac #0-0]     at <Jasmine>
[firefox 79.0 mac #0-0]     at <Jasmine>
[firefox 79.0 mac #0-0]     at UserContext.<anonymous> (/Users/leonardo.de.souza/Documents/Projects/widgets-resources/packages/customWidgets/slider-web/tests/e2e/specs/Slider.spec.ts:66:47)`
