### PR TITLE
fix(bottom-sheet-native): fixing onOpen and onClose events

### DIFF
--- a/packages/pluggableWidgets/bottom-sheet-native/package.json
+++ b/packages/pluggableWidgets/bottom-sheet-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bottom-sheet-native",
   "widgetName": "BottomSheet",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/pluggableWidgets/bottom-sheet-native/src/BottomSheet.tsx
+++ b/packages/pluggableWidgets/bottom-sheet-native/src/BottomSheet.tsx
@@ -5,6 +5,7 @@ import { ExpandingDrawer } from "./components/ExpandingDrawer";
 import { NativeBottomSheet } from "./components/NativeBottomSheet";
 import { BottomSheetProps } from "../typings/BottomSheetProps";
 import { StyleSheet } from "react-native";
+import { executeAction } from "@widgets-resources/piw-utils";
 
 export function BottomSheet(props: BottomSheetProps<BottomSheetStyle>): ReactElement {
     const styles = StyleSheet.flatten(props.style);
@@ -31,6 +32,8 @@ export function BottomSheet(props: BottomSheetProps<BottomSheetStyle>): ReactEle
                 smallContent={props.smallContent}
                 largeContent={props.largeContent}
                 fullscreenContent={props.showFullscreenContent ? props.fullscreenContent : null}
+                onOpen={() => executeAction(props.onOpen)}
+                onClose={() => executeAction(props.onClose)}
                 styles={styles}
             />
         );

--- a/packages/pluggableWidgets/bottom-sheet-native/src/components/ExpandingDrawer.tsx
+++ b/packages/pluggableWidgets/bottom-sheet-native/src/components/ExpandingDrawer.tsx
@@ -7,6 +7,8 @@ interface ExpandingDrawerProps {
     smallContent?: ReactNode;
     largeContent?: ReactNode;
     fullscreenContent?: ReactNode;
+    onOpen?: () => void;
+    onClose?: () => void;
     styles: BottomSheetStyle;
 }
 
@@ -113,8 +115,12 @@ export const ExpandingDrawer = (props: ExpandingDrawerProps): ReactElement => {
                     initialSnap={snapPoints.length - 1}
                     renderContent={renderContent}
                     enabledInnerScrolling={false}
+                    onOpenStart={props.onOpen}
                     onOpenEnd={() => setIsOpen(true)}
-                    onCloseStart={() => setIsOpen(false)}
+                    onCloseStart={() => {
+                        setIsOpen(false);
+                        props.onClose?.();
+                    }}
                 />
             )}
         </View>

--- a/packages/pluggableWidgets/bottom-sheet-native/src/package.xml
+++ b/packages/pluggableWidgets/bottom-sheet-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="BottomSheet" version="1.0.2" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="BottomSheet" version="1.0.3" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="BottomSheet.xml"/>
         </widgetFiles>


### PR DESCRIPTION
In this PR we are implementing the execution of actions for onOpen and onClose in expanding bottomsheets.

Details:
- The events were attached to:
  - OnClose -> onCloseEnd because this action should only be triggered if the bottom sheet is already closed.
  - OnOpen -> onOpenStart because if attached to onOpenEnd it will be triggered twice for fullscreen bottom sheet (2 stages) and when starting to open there is no way to stop.