### PR TITLE
Add link to documentation

### DIFF
--- a/packages/jsActions/native-mobile-resources/README.md
+++ b/packages/jsActions/native-mobile-resources/README.md
@@ -1,1 +1,1 @@
-# Nanoflow actions
+Please see [Native Mobile Resources](https://docs.mendix.com/appstore/modules/native-mobile-resources) in the documentation for details.


### PR DESCRIPTION
So that the documentation is easily available and only needs to be maintained in one place, the README for this component should feature a link to the proper component doc published in the App Store Guide. This is also the content that should appear on the **Documentation** tab in the App Store for the component upon the next and all future releases.

Please update the App Store Guide as you update the component.

You can contact me with any questions.
