### PR TITLE
Fix linting in PIW tooling

### DIFF
--- a/packages/tools/generator-widget/generators/app/index.js
+++ b/packages/tools/generator-widget/generators/app/index.js
@@ -72,7 +72,7 @@ class MxGenerator extends Generator {
             this.log(text.END_NPM_NEED_INSTALL_MSG);
         } else {
             this.log(text.END_RUN_BUILD_MSG);
-            this.spawnCommandSync("npm", ["run", "lint"]); // eslint-disable-line no-sync
+            this.spawnCommandSync("npm", ["run", "lint:fix"]); // eslint-disable-line no-sync
             this.spawnCommandSync("npm", ["run", "build"]); // eslint-disable-line no-sync
         }
 
@@ -166,9 +166,10 @@ class MxGenerator extends Generator {
     }
 
     _writeUtilityFiles() {
-        this._copyFile("commons/_gitignore", ".gitignore");
+        this._copyTemplate("commons/.gitignore", ".gitignore");
         this._copyFile(`commons/eslintrc.${this.widget.isLanguageTS ? "ts" : "js"}.js`, ".eslintrc.js");
         this._copyFile("commons/prettier.config.js", "prettier.config.js");
+        this._copyTemplate("commons/.prettierignore", ".prettierignore");
         this._copyFile("commons/.gitattributes", ".gitattributes");
 
         if (this.widget.license) {

--- a/packages/tools/generator-widget/generators/app/templates/commons/.gitignore
+++ b/packages/tools/generator-widget/generators/app/templates/commons/.gitignore
@@ -1,4 +1,5 @@
 dist/
 node_modules/
+<%- projectPath %>/
 *.log
 .env

--- a/packages/tools/generator-widget/generators/app/templates/commons/.prettierignore
+++ b/packages/tools/generator-widget/generators/app/templates/commons/.prettierignore
@@ -1,0 +1,1 @@
+<%- projectPath %>/

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTs/src/components/__tests__/HelloWorldSample.spec.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTs/src/components/__tests__/HelloWorldSample.spec.tsx.ejs
@@ -1,10 +1,10 @@
 import { createElement } from "react";
-import { shallow } from "enzyme";
+import { shallow, ShallowWrapper } from "enzyme";
 
 import { HelloWorldSample, HelloWorldSampleProps } from "../HelloWorldSample";
 
 describe("HelloWorldSample", () => {
-    const createHelloWorld = (props: HelloWorldSampleProps) => shallow(<HelloWorldSample {...props} />);
+    const createHelloWorld = (props: HelloWorldSampleProps): ShallowWrapper => shallow(<HelloWorldSample {...props} />);
 
     it("should render the structure correctly", () => {
         const helloWorldProps: HelloWorldSampleProps = {

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTs/src/components/__tests__/BadgeSample.spec.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTs/src/components/__tests__/BadgeSample.spec.tsx.ejs
@@ -1,10 +1,10 @@
 import { createElement } from "react";
-import { shallow } from "enzyme";
+import { shallow, ShallowWrapper } from "enzyme";
 
 import { BadgeSample, BadgeSampleProps } from "../BadgeSample";
 
 describe("Badge", () => {
-    const createBadge = (props: BadgeSampleProps) => shallow(<BadgeSample {...props} />);
+    const createBadge = (props: BadgeSampleProps): ShallowWrapper => shallow(<BadgeSample {...props} />);
 
     it("should render the structure", () => {
         const badgeProps: BadgeSampleProps = {

--- a/packages/tools/pluggable-widgets-tools/bin/mx-scripts.js
+++ b/packages/tools/pluggable-widgets-tools/bin/mx-scripts.js
@@ -28,7 +28,7 @@ for (const subCommand of realCommand.split(/&&/g)) {
 
 function getRealCommand(cmd, toolsRoot) {
     const eslintCommand = "eslint --config .eslintrc.js --ext .jsx,.js,.ts,.tsx src";
-    const prrettierCommand = 'prettier --config prettier.config.js "{src,test}/**/*.{js,jsx,ts,tsx}"';
+    const prettierCommand = 'prettier --config prettier.config.js "{src,tests}/**/*.{js,jsx,ts,tsx}"';
     const gulpCommand = `gulp --gulpfile ${join(toolsRoot, "scripts/gulp.js")} --cwd ${process.cwd()}`;
 
     switch (cmd) {
@@ -63,11 +63,11 @@ function getRealCommand(cmd, toolsRoot) {
         case "release:ts:native":
             return `${gulpCommand} release --native --silent`;
         case "lint":
-            return `${prrettierCommand} --check && ${eslintCommand}`;
+            return `${prettierCommand} --check && ${eslintCommand}`;
         case "lint:fix":
-            return `${prrettierCommand} --write && ${eslintCommand} --fix`;
+            return `${prettierCommand} --write && ${eslintCommand} --fix`;
         case "format":
-            return `${prrettierCommand} --write`;
+            return `${prettierCommand} --write`;
         case "test:unit":
         case "test:unit:web":
             return `jest --projects ${join(toolsRoot, "test-config/jest.config.js")}`;


### PR DESCRIPTION
- Fix prettier command to also prettify `tests` folder.
- Add `.prettierignore` to prevent prettifying MX (test) project. Eslint only touches source, so there's no need to ignore anything there.
- Add `.gitignore` to prevent PIW-devs from committing a MX (test) project.
- Run `npm run lint:fix` after scaffolding the project.
- Fix lint warnings in unit test spec files of web templates.