### PR TITLE
fix(pwt): spaces in project path

### DIFF
--- a/packages/tools/pluggable-widgets-tools/bin/mx-scripts.js
+++ b/packages/tools/pluggable-widgets-tools/bin/mx-scripts.js
@@ -29,7 +29,7 @@ for (const subCommand of realCommand.split(/&&/g)) {
 function getRealCommand(cmd, toolsRoot) {
     const eslintCommand = "eslint --config .eslintrc.js --ext .jsx,.js,.ts,.tsx src";
     const prettierCommand = 'prettier --config prettier.config.js "{src,tests}/**/*.{js,jsx,ts,tsx}"';
-    const gulpCommand = `gulp --gulpfile ${join(toolsRoot, "scripts/gulp.js")} --cwd ${process.cwd()}`;
+    const gulpCommand = `gulp --gulpfile "${join(toolsRoot, "scripts/gulp.js")}" --cwd "${process.cwd()}"`;
 
     switch (cmd) {
         case "start:server":

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "8.12.3",
+  "version": "8.12.4",
   "description": "Mendix Pluggable Widgets Tools",
   "license": "Apache-2.0",
   "copyright": "2020 Mendix Technology BV",


### PR DESCRIPTION
The gulp command currently fails if you have spaces in your project path. This commit adds quotes around the two paths in the gulp command.