### PR TITLE
feat(notifications-native): new optional attribute properties

### DIFF
--- a/packages/pluggableWidgets/notifications-native/package.json
+++ b/packages/pluggableWidgets/notifications-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notifications-native",
   "widgetName": "Notifications",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/pluggableWidgets/notifications-native/src/Notifications.tsx
+++ b/packages/pluggableWidgets/notifications-native/src/Notifications.tsx
@@ -54,6 +54,9 @@ export class Notifications extends Component<NotificationsProps<undefined>> {
         getHandler: (action: ActionsType) => ActionValue | undefined
     ): void {
         const data: NotificationData = notification.data;
+        const body: string = notification.body;
+        const title: string = notification.title;
+        const subtitle: string = notification.subtitle ? notification.subtitle : "";
         const actions = this.props.actions.filter(item => item.name === data.actionName);
 
         if (actions.length === 0) {
@@ -62,6 +65,18 @@ export class Notifications extends Component<NotificationsProps<undefined>> {
 
         if (this.props.guid) {
             this.props.guid.setValue(data.guid);
+        }
+        if (this.props.title) {
+            this.props.title.setValue(title);
+        }
+        if (this.props.subtitle) {
+            this.props.subtitle.setValue(subtitle);
+        }
+        if (this.props.body) {
+            this.props.body.setValue(body);
+        }
+        if (this.props.action) {
+            this.props.action.setValue(actions.join(" "));
         }
 
         actions.forEach(action => {

--- a/packages/pluggableWidgets/notifications-native/src/Notifications.xml
+++ b/packages/pluggableWidgets/notifications-native/src/Notifications.xml
@@ -33,6 +33,34 @@
                     <attributeType name="String"/>
                 </attributeTypes>
             </property>
+            <property key="title" type="attribute" required="false">
+                <caption>Title</caption>
+                <description>If the notification has a title, this attribute will get that value.</description>
+                <attributeTypes>
+                    <attributeType name="String"/>
+                </attributeTypes>
+            </property>
+            <property key="subtitle" type="attribute" required="false">
+                <caption>Subtitle</caption>
+                <description>If the notification has a subtitle, this attribute will get that value.</description>
+                <attributeTypes>
+                    <attributeType name="String"/>
+                </attributeTypes>
+            </property>
+            <property key="body" type="attribute" required="false">
+                <caption>Body</caption>
+                <description>If the notification has a body, this attribute will get that value.</description>
+                <attributeTypes>
+                    <attributeType name="String"/>
+                </attributeTypes>
+            </property>
+            <property key="action" type="attribute" required="false">
+                <caption>Subtitle</caption>
+                <description>If the notification has actions, this attribute will get the name of all actions joined by spaces.</description>
+                <attributeTypes>
+                    <attributeType name="String"/>
+                </attributeTypes>
+            </property>
         </propertyGroup>
     </properties>
 </widget>

--- a/packages/pluggableWidgets/notifications-native/typings/NotificationsProps.d.ts
+++ b/packages/pluggableWidgets/notifications-native/typings/NotificationsProps.d.ts
@@ -22,6 +22,10 @@ export interface NotificationsProps<Style> {
     style: Style[];
     actions: ActionsType[];
     guid?: EditableValue<string>;
+    title?: EditableValue<string>;
+    subtitle?: EditableValue<string>;
+    body?: EditableValue<string>;
+    action?: EditableValue<string>;
 }
 
 export interface NotificationsPreviewProps {
@@ -29,4 +33,8 @@ export interface NotificationsPreviewProps {
     style: string;
     actions: ActionsPreviewType[];
     guid: string;
+    title: string;
+    subtitle: string;
+    body: string;
+    action: string;
 }


### PR DESCRIPTION
Added attribute properties for the following attributes of a notification:
- title
- subtitle
- body
- action


The use case is the following:

- app receives notification while it is active
- on iOS, the standard behavior is that notifications are silently sent to the handler
- we want to display some notification details to the user
- in the handler nanoflow, we had none of the notification details (only had access to a GUID)

This PR adds access to the core data of a notification so we can show an appropriate message or a local notification