### PR TITLE
[WT-2714] fix of sorting based on attribute type and pagination while filter is applied

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
@@ -46,7 +46,8 @@ export function preview(props: DatagridPreviewProps): ReactElement {
                 },
                 [props.columns]
             )}
-            valueForFilterSort={useCallback(() => undefined, [])}
+            valueForFilter={useCallback(() => undefined, [])}
+            valueForSort={useCallback(() => undefined, [])}
             filterRenderer={useCallback(
                 (renderWrapper, columnIndex) => {
                     const column = props.columns[columnIndex];

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -67,10 +67,17 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
                 },
                 [props.columns]
             )}
-            valueForFilterSort={useCallback(
+            valueForFilter={useCallback(
                 (value, columnIndex) => {
                     const column = props.columns[columnIndex];
                     return column.attribute(value).displayValue;
+                },
+                [props.columns]
+            )}
+            valueForSort={useCallback(
+                (value, columnIndex) => {
+                    const column = props.columns[columnIndex];
+                    return column.attribute(value).value;
                 },
                 [props.columns]
             )}

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Table.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Table.spec.tsx
@@ -92,7 +92,8 @@ function mockTableProps(): TableProps<ObjectItem> {
         columnsFilterable: false,
         columnsSortable: false,
         columns,
-        valueForFilterSort: () => "dummy",
+        valueForFilter: () => "dummy",
+        valueForSort: () => "dummy",
         filterRenderer: () => <input type="text" value="dummy" />,
         cellRenderer: (renderWrapper, _, columnIndex) => renderWrapper(columns[columnIndex].header),
         data: [{ id: "123456" as any }]


### PR DESCRIPTION
In this PR we fixed 2 issues identified by Danny:

- Sorting is just working as string, so number and dates act strange
- While applying filters the pagination always keep the original number of rows as total.