### PR TITLE
feat(datagrid-web): implementing state for sorting, filtering, hiding, paging and reordering

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -12,6 +12,7 @@ export function getProperties(values: DatagridPreviewProps, defaultProperties: P
         if (!values.columnsFilterable) {
             hidePropertyIn(defaultProperties, values, "columns", index, "filterable");
             hidePropertyIn(defaultProperties, values, "columns", index, "customFilter");
+            hidePropertyIn(defaultProperties, values, "filterMethod");
         } else if (column.filterable !== "custom") {
             hidePropertyIn(defaultProperties, values, "columns", index, "customFilter");
         }

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
@@ -48,6 +48,7 @@ export function preview(props: DatagridPreviewProps): ReactElement {
             )}
             valueForFilter={useCallback(() => undefined, [])}
             valueForSort={useCallback(() => undefined, [])}
+            filterMethod={props.filterMethod}
             filterRenderer={useCallback(
                 (renderWrapper, columnIndex) => {
                     const column = props.columns[columnIndex];

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -44,6 +44,7 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
             columnsResizable={props.columnsResizable}
             columnsSortable={props.columnsSortable}
             data={props.datasource.items ?? []}
+            filterMethod={props.filterMethod}
             footerWidgets={<div className="header">{props.footerWidgets}</div>}
             hasMoreItems={props.datasource.hasMoreItems ?? false}
             headerWidgets={<div className="footer">{props.headerWidgets}</div>}

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -46,11 +46,11 @@
                         </propertyGroup>
                         <propertyGroup caption="Interactions">
                             <property key="sortable" type="boolean" defaultValue="true">
-                                <caption>Can sort</caption>
+                                <caption>Sorting</caption>
                                 <description/>
                             </property>
                             <property key="filterable" type="enumeration" defaultValue="yes">
-                                <caption>Can filter</caption>
+                                <caption>Filtering</caption>
                                 <description/>
                                 <enumerationValues>
                                     <enumerationValue key="yes">Yes</enumerationValue>
@@ -63,15 +63,15 @@
                                 <description/>
                             </property>
                             <property key="resizable" type="boolean" defaultValue="true">
-                                <caption>Can resize</caption>
+                                <caption>Resizing</caption>
                                 <description/>
                             </property>
                             <property key="draggable" type="boolean" defaultValue="true">
-                                <caption>Can reorder</caption>
+                                <caption>Reordering</caption>
                                 <description/>
                             </property>
                             <property key="hidable" type="enumeration" defaultValue="yes">
-                                <caption>Can hide</caption>
+                                <caption>Hiding</caption>
                                 <description/>
                                 <enumerationValues>
                                     <enumerationValue key="yes">Yes</enumerationValue>
@@ -131,6 +131,15 @@
                 <property key="columnsFilterable" type="boolean" defaultValue="false">
                     <caption>Filtering</caption>
                     <description/>
+                </property>
+                <property key="filterMethod" type="enumeration" defaultValue="startsWith">
+                    <caption>Filter method</caption>
+                    <description/>
+                    <enumerationValues>
+                        <enumerationValue key="startsWith">Starts with</enumerationValue>
+                        <enumerationValue key="contains">Contains</enumerationValue>
+                        <enumerationValue key="endsWith">Ends with</enumerationValue>
+                    </enumerationValues>
                 </property>
                 <property key="columnsResizable" type="boolean" defaultValue="false">
                     <caption>Resizing</caption>

--- a/packages/pluggableWidgets/datagrid-web/src/components/ColumnSelector.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/ColumnSelector.tsx
@@ -1,17 +1,19 @@
 import { createElement, Dispatch, ReactElement, RefObject, SetStateAction, useEffect, useRef, useState } from "react";
-import { ColumnInstance } from "react-table";
+import { ColumnInstance, IdType } from "react-table";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEye } from "@fortawesome/free-regular-svg-icons";
 
 export interface ColumnSelectorProps<D extends object> {
     allColumns: Array<ColumnInstance<D>>;
     width: number;
+    setHiddenColumns: Dispatch<SetStateAction<Array<IdType<object>>>>;
     setWidth: Dispatch<SetStateAction<number>>;
 }
 
 export function ColumnSelector<D extends object>({
     allColumns,
     width,
+    setHiddenColumns,
     setWidth
 }: ColumnSelectorProps<D>): ReactElement {
     const [show, setShow] = useState(false);
@@ -45,7 +47,20 @@ export function ColumnSelector<D extends object>({
                                     id={`checkbox_toggle_${index}`}
                                     type="checkbox"
                                     checked={column.isVisible}
-                                    onClick={() => column.toggleHidden()}
+                                    onClick={() => {
+                                        setHiddenColumns(prev => {
+                                            if (!column.isVisible) {
+                                                prev.splice(
+                                                    prev.findIndex(v => v === column.id),
+                                                    1
+                                                );
+                                                return [...prev];
+                                            } else {
+                                                return [...prev, column.id];
+                                            }
+                                        });
+                                        column.toggleHidden();
+                                    }}
                                     disabled={column.isVisible && visibleColumns === 1}
                                     {...column.getToggleHiddenProps()}
                                 />

--- a/packages/pluggableWidgets/datagrid-web/src/components/ColumnSelector.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/ColumnSelector.tsx
@@ -19,9 +19,6 @@ export function ColumnSelector<D extends object>({
     const [show, setShow] = useState(false);
     const listRef = useRef<HTMLUListElement>(null);
     useOnClickOutside(listRef, () => setShow(false));
-    useEffect(() => {
-        allColumns.filter(column => column.hidden).forEach(column => column.toggleHidden(true));
-    }, [allColumns]);
     const visibleColumns = allColumns.filter(column => column.isVisible).length;
     return (
         <div className="th column-selector">

--- a/packages/pluggableWidgets/datagrid-web/src/components/Header.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Header.tsx
@@ -77,7 +77,7 @@ export function Header<D extends object>(props: HeaderProps<D>): ReactElement {
                                    */
                                   if (!props.column.isSorted) {
                                       props.setSortBy([{ id: props.column.id, desc: false }]);
-                                  } else if (props.column.isSorted && props.column.isSortedDesc === false) {
+                                  } else if (props.column.isSorted && !props.column.isSortedDesc) {
                                       props.setSortBy([{ id: props.column.id, desc: true }]);
                                   } else {
                                       props.setSortBy([]);

--- a/packages/pluggableWidgets/datagrid-web/src/components/Header.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Header.tsx
@@ -70,12 +70,12 @@ export function Header<D extends object>(props: HeaderProps<D>): ReactElement {
                             ? e => {
                                   /**
                                    * Always analyse previous values to predict the next
-                                   * 1 - isSortedDesc === undefined && !props.column.isSorted turns to asc
+                                   * 1 - !props.column.isSorted turns to asc
                                    * 2 - isSortedDesc === false && props.column.isSorted turns to desc
                                    * 3 - isSortedDesc === true && props.column.isSorted turns to unsorted
                                    * If multisort is allowed in the future this should be changed to append instead of just return a new array
                                    */
-                                  if (!props.column.isSorted && props.column.isSortedDesc === undefined) {
+                                  if (!props.column.isSorted) {
                                       props.setSortBy([{ id: props.column.id, desc: false }]);
                                   } else if (props.column.isSorted && props.column.isSortedDesc === false) {
                                       props.setSortBy([{ id: props.column.id, desc: true }]);

--- a/packages/pluggableWidgets/datagrid-web/src/components/Header.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Header.tsx
@@ -1,5 +1,14 @@
-import { createElement, Dispatch, ReactElement, SetStateAction, DragEvent, DragEventHandler, useCallback } from "react";
-import { ColumnInstance, HeaderGroup, IdType, TableHeaderProps } from "react-table";
+import {
+    createElement,
+    Dispatch,
+    ReactElement,
+    SetStateAction,
+    DragEvent,
+    DragEventHandler,
+    useCallback,
+    MouseEvent
+} from "react";
+import { ColumnInstance, HeaderGroup, IdType, SortingRule, TableHeaderProps } from "react-table";
 import classNames from "classnames";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faLongArrowAltDown, faLongArrowAltUp, faArrowsAltV } from "@fortawesome/free-solid-svg-icons";
@@ -12,32 +21,23 @@ export interface HeaderProps<D extends object> {
     draggable: boolean;
     dragOver: string;
     visibleColumns: Array<ColumnInstance<D>>;
-    setColumnOrder: (updater: ((columnOrder: Array<IdType<D>>) => Array<IdType<D>>) | Array<IdType<D>>) => void;
+    setColumnOrder: (updater: Array<IdType<D>>) => void;
     setDragOver: Dispatch<SetStateAction<string>>;
+    setSortBy: Dispatch<SetStateAction<Array<SortingRule<object>>>>;
 }
 
-export function Header<D extends object>({
-    column,
-    sortable,
-    resizable,
-    filterable,
-    draggable,
-    dragOver,
-    visibleColumns,
-    setColumnOrder,
-    setDragOver
-}: HeaderProps<D>): ReactElement {
-    const canSort = sortable && column.canSort;
-    const canDrag = draggable && (column.canDrag ?? false);
-    const draggableProps = useDraggable(canDrag, visibleColumns, setColumnOrder, setDragOver);
+export function Header<D extends object>(props: HeaderProps<D>): ReactElement {
+    const canSort = props.sortable && props.column.canSort;
+    const canDrag = props.draggable && (props.column.canDrag ?? false);
+    const draggableProps = useDraggable(canDrag, props.visibleColumns, props.setColumnOrder, props.setDragOver);
 
-    const { onClick, style, ...rest } = column.getHeaderProps(
-        canSort ? column.getSortByToggleProps() : undefined
-    ) as TableHeaderProps & { onClick: () => void };
+    const { onClick, style, ...rest } = props.column.getHeaderProps(
+        canSort ? props.column.getSortByToggleProps() : undefined
+    ) as TableHeaderProps & { onClick: (e: MouseEvent<HTMLDivElement>) => void };
 
     const sortIcon = canSort
-        ? column.isSorted
-            ? column.isSortedDesc
+        ? props.column.isSorted
+            ? props.column.isSortedDesc
                 ? faLongArrowAltDown
                 : faLongArrowAltUp
             : faArrowsAltV
@@ -49,31 +49,55 @@ export function Header<D extends object>({
             {...rest}
             style={{
                 ...style,
-                ...(!resizable ? { flex: "1 1 0px" } : {}),
-                ...(!sortable || !column.canSort ? { cursor: "unset" } : {})
+                ...(!props.resizable ? { flex: "1 1 0px" } : {}),
+                ...(!props.sortable || !props.column.canSort ? { cursor: "unset" } : {})
             }}
+            title={props.column.render("Header") as string}
         >
             <div
-                id={column.id}
-                className={classNames("column-container", canDrag && column.id === dragOver ? "dragging" : "")}
+                id={props.column.id}
+                className={classNames(
+                    "column-container",
+                    canDrag && props.column.id === props.dragOver ? "dragging" : ""
+                )}
                 {...draggableProps}
             >
                 <div
-                    id={column.id}
+                    id={props.column.id}
                     className={classNames("column-header", canSort ? "clickable" : "")}
-                    onClick={canSort ? onClick : undefined}
+                    onClick={
+                        canSort
+                            ? e => {
+                                  /**
+                                   * Always analyse previous values to predict the next
+                                   * 1 - isSortedDesc === undefined && !props.column.isSorted turns to asc
+                                   * 2 - isSortedDesc === false && props.column.isSorted turns to desc
+                                   * 3 - isSortedDesc === true && props.column.isSorted turns to unsorted
+                                   * If multisort is allowed in the future this should be changed to append instead of just return a new array
+                                   */
+                                  if (!props.column.isSorted && props.column.isSortedDesc === undefined) {
+                                      props.setSortBy([{ id: props.column.id, desc: false }]);
+                                  } else if (props.column.isSorted && props.column.isSortedDesc === false) {
+                                      props.setSortBy([{ id: props.column.id, desc: true }]);
+                                  } else {
+                                      props.setSortBy([]);
+                                  }
+                                  onClick(e);
+                              }
+                            : undefined
+                    }
                 >
-                    {column.render("Header")}
+                    {props.column.render("Header")}
                     {sortIcon && <FontAwesomeIcon icon={sortIcon} />}
                 </div>
-                {filterable &&
-                    column.canFilter &&
-                    (column.customFilter ? column.customFilter : column.render("Filter"))}
+                {props.filterable &&
+                    props.column.canFilter &&
+                    (props.column.customFilter ? props.column.customFilter : props.column.render("Filter"))}
             </div>
-            {resizable && column.canResize && (
+            {props.resizable && props.column.canResize && (
                 <div
-                    {...column.getResizerProps()}
-                    className={`column-resizer ${column.isResizing ? "isResizing" : ""}`}
+                    {...props.column.getResizerProps()}
+                    className={`column-resizer ${props.column.isResizing ? "isResizing" : ""}`}
                 />
             )}
         </div>

--- a/packages/pluggableWidgets/datagrid-web/src/components/Pagination.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Pagination.tsx
@@ -12,25 +12,17 @@ export interface PaginationProps {
     setPaginationIndex?: Dispatch<SetStateAction<number>>;
 }
 
-export function Pagination({
-    gotoPage,
-    previousPage,
-    page,
-    nextPage,
-    canNextPage,
-    canPreviousPage,
-    pageSize,
-    numberOfItems,
-    setPaginationIndex
-}: PaginationProps): ReactElement {
-    const numberOfPages = numberOfItems !== undefined ? Math.ceil(numberOfItems / pageSize) : undefined;
+export function Pagination(props: PaginationProps): ReactElement {
+    const numberOfPages =
+        props.numberOfItems !== undefined ? Math.ceil(props.numberOfItems / props.pageSize) : undefined;
     const lastPage = numberOfPages !== undefined ? numberOfPages - 1 : 0;
     const hasLastPage = numberOfPages !== undefined;
-    const initialItem = page * pageSize + 1;
-    const lastItem = canNextPage || !numberOfItems ? (page + 1) * pageSize : numberOfItems;
+    const initialItem = props.page * props.pageSize + 1;
+    const lastItem =
+        props.canNextPage || !props.numberOfItems ? (props.page + 1) * props.pageSize : props.numberOfItems;
     const setPageIndex = (page: number): void => {
-        if (setPaginationIndex) {
-            setPaginationIndex(page);
+        if (props.setPaginationIndex) {
+            props.setPaginationIndex(page);
         }
     };
     return (
@@ -38,34 +30,34 @@ export function Pagination({
             <button
                 className="btn"
                 onClick={() => {
-                    gotoPage(0);
+                    props.gotoPage(0);
                     setPageIndex(0);
                 }}
-                disabled={page === 0}
+                disabled={props.page === 0}
             >
                 <span className="glyphicon glyphicon-step-backward" />
             </button>
             <button
                 className="btn"
                 onClick={() => {
-                    previousPage();
-                    setPageIndex(page - 1);
+                    props.previousPage();
+                    setPageIndex(props.page - 1);
                 }}
-                disabled={!canPreviousPage}
+                disabled={!props.canPreviousPage}
             >
                 <span className="glyphicon glyphicon-backward" />
             </button>
             <div className="paging-status">
                 {initialItem} to {lastItem}{" "}
-                {hasLastPage ? `of ${numberOfItems ?? (numberOfPages ?? 1) * pageSize}` : ""}
+                {hasLastPage ? `of ${props.numberOfItems ?? (numberOfPages ?? 1) * props.pageSize}` : ""}
             </div>
             <button
                 className="btn"
                 onClick={() => {
-                    nextPage();
-                    setPageIndex(page + 1);
+                    props.nextPage();
+                    setPageIndex(props.page + 1);
                 }}
-                disabled={!canNextPage}
+                disabled={!props.canNextPage}
             >
                 <span className="glyphicon glyphicon-forward" />
             </button>
@@ -73,10 +65,10 @@ export function Pagination({
                 <button
                     className="btn"
                     onClick={() => {
-                        gotoPage(lastPage);
+                        props.gotoPage(lastPage);
                         setPageIndex(lastPage);
                     }}
-                    disabled={page === lastPage}
+                    disabled={props.page === lastPage}
                 >
                     <span className="glyphicon glyphicon-step-forward" />
                 </button>

--- a/packages/pluggableWidgets/datagrid-web/src/components/Pagination.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Pagination.tsx
@@ -1,4 +1,4 @@
-import { createElement, ReactElement } from "react";
+import { createElement, Dispatch, ReactElement, SetStateAction } from "react";
 
 export interface PaginationProps {
     canNextPage: boolean;
@@ -9,6 +9,7 @@ export interface PaginationProps {
     page: number;
     pageSize: number;
     previousPage: () => void;
+    setPaginationIndex?: Dispatch<SetStateAction<number>>;
 }
 
 export function Pagination({
@@ -19,30 +20,64 @@ export function Pagination({
     canNextPage,
     canPreviousPage,
     pageSize,
-    numberOfItems
+    numberOfItems,
+    setPaginationIndex
 }: PaginationProps): ReactElement {
     const numberOfPages = numberOfItems !== undefined ? Math.ceil(numberOfItems / pageSize) : undefined;
     const lastPage = numberOfPages !== undefined ? numberOfPages - 1 : 0;
     const hasLastPage = numberOfPages !== undefined;
     const initialItem = page * pageSize + 1;
     const lastItem = canNextPage || !numberOfItems ? (page + 1) * pageSize : numberOfItems;
+    const setPageIndex = (page: number): void => {
+        if (setPaginationIndex) {
+            setPaginationIndex(page);
+        }
+    };
     return (
         <div className="pagination">
-            <button className="btn" onClick={() => gotoPage(0)} disabled={page === 0}>
+            <button
+                className="btn"
+                onClick={() => {
+                    gotoPage(0);
+                    setPageIndex(0);
+                }}
+                disabled={page === 0}
+            >
                 <span className="glyphicon glyphicon-step-backward" />
             </button>
-            <button className="btn" onClick={() => previousPage()} disabled={!canPreviousPage}>
+            <button
+                className="btn"
+                onClick={() => {
+                    previousPage();
+                    setPageIndex(page - 1);
+                }}
+                disabled={!canPreviousPage}
+            >
                 <span className="glyphicon glyphicon-backward" />
             </button>
             <div className="paging-status">
                 {initialItem} to {lastItem}{" "}
                 {hasLastPage ? `of ${numberOfItems ?? (numberOfPages ?? 1) * pageSize}` : ""}
             </div>
-            <button className="btn" onClick={() => nextPage()} disabled={!canNextPage}>
+            <button
+                className="btn"
+                onClick={() => {
+                    nextPage();
+                    setPageIndex(page + 1);
+                }}
+                disabled={!canNextPage}
+            >
                 <span className="glyphicon glyphicon-forward" />
             </button>
             {hasLastPage && (
-                <button className="btn" onClick={() => gotoPage(lastPage)} disabled={page === lastPage}>
+                <button
+                    className="btn"
+                    onClick={() => {
+                        gotoPage(lastPage);
+                        setPageIndex(lastPage);
+                    }}
+                    disabled={page === lastPage}
+                >
                     <span className="glyphicon glyphicon-step-forward" />
                 </button>
             )}

--- a/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
@@ -54,15 +54,15 @@ export function Table<T>(props: TableProps<T>): ReactElement {
     const isInfinite = !props.paging && !isSortingOrFiltering;
     const [dragOver, setDragOver] = useState("");
     const [columnSelectorWidth, setColumnSelectorWidth] = useState(0);
-    const [columnOrder, setColumnOrder] = useState<Array<IdType<object>>>([]); // TODO: Load config from user
+    const [columnOrder, setColumnOrder] = useState<Array<IdType<object>>>([]);
     const [hiddenColumns, setHiddenColumns] = useState<Array<IdType<object>>>(
         (props.columns
             .map((c, i) => (c.hidable === "hidden" ? i.toString() : undefined))
             .filter(Boolean) as string[]) ?? []
-    ); // TODO: Load config from user
-    const [paginationIndex, setPaginationIndex] = useState<number>(0); // TODO: Load config from user
-    const [sortBy, setSortBy] = useState<Array<SortingRule<object>>>([]); // TODO: Load config from user
-    const [filters, setFilters] = useState<Filters<object>>([]); // TODO: Load config from user
+    );
+    const [paginationIndex, setPaginationIndex] = useState<number>(0);
+    const [sortBy, setSortBy] = useState<Array<SortingRule<object>>>([]);
+    const [filters, setFilters] = useState<Filters<object>>([]);
 
     const filterTypes = useMemo(
         () => ({

--- a/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
@@ -79,7 +79,7 @@ export function Table<T>(props: TableProps<T>): ReactElement {
 
                     switch (props.filterMethod) {
                         case "contains":
-                            return value.toLowerCase().indexOf(String(filterValue).toLowerCase()) !== -1;
+                            return value.toLowerCase().includes(String(filterValue).toLowerCase());
                         case "endsWith":
                             return value.toLowerCase().endsWith(String(filterValue).toLowerCase());
                         case "startsWith":

--- a/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
@@ -6,9 +6,11 @@ import { InfiniteBody } from "./InfiniteBody";
 import {
     ColumnInterface,
     ColumnWithStrictAccessor,
+    Filters,
     FilterValue,
     IdType,
     Row,
+    SortingRule,
     useColumnOrder,
     useFilters,
     useFlexLayout,
@@ -17,7 +19,7 @@ import {
     useSortBy,
     useTable
 } from "react-table";
-import { ColumnsPreviewType, ColumnsType } from "../../typings/DatagridProps";
+import { ColumnsPreviewType, ColumnsType, FilterMethodEnum } from "../../typings/DatagridProps";
 
 export type TableColumn = Omit<ColumnsType | ColumnsPreviewType, "content" | "attribute">;
 
@@ -44,6 +46,7 @@ export interface TableProps<T> {
     valueForFilter: (value: T, columnIndex: number) => string | undefined;
     valueForSort: (value: T, columnIndex: number) => string | BigJs.Big | boolean | Date | undefined;
     filterRenderer: (renderWrapper: (children: ReactNode) => ReactElement, columnIndex: number) => ReactElement;
+    filterMethod: FilterMethodEnum;
 }
 
 export function Table<T>(props: TableProps<T>): ReactElement {
@@ -51,19 +54,35 @@ export function Table<T>(props: TableProps<T>): ReactElement {
     const isInfinite = !props.paging && !isSortingOrFiltering;
     const [dragOver, setDragOver] = useState("");
     const [columnSelectorWidth, setColumnSelectorWidth] = useState(0);
+    const [columnOrder, setColumnOrder] = useState<Array<IdType<object>>>([]); // TODO: Load config from user
+    const [hiddenColumns, setHiddenColumns] = useState<Array<IdType<object>>>([]); // TODO: Load config from user
+    const [paginationIndex, setPaginationIndex] = useState<number>(0); // TODO: Load config from user
+    const [sortBy, setSortBy] = useState<Array<SortingRule<object>>>([]); // TODO: Load config from user
+    const [filters, setFilters] = useState<Filters<object>>([]); // TODO: Load config from user
 
     const filterTypes = useMemo(
         () => ({
             text: (rows: Array<Row<object>>, id: IdType<object>, filterValue: FilterValue) => {
                 return rows.filter(row => {
                     const value = props.valueForFilter(row.values[id], Number(id));
-                    return value !== undefined
-                        ? value.toLowerCase().startsWith(String(filterValue).toLowerCase())
-                        : true;
+                    if (!value) {
+                        return true;
+                    }
+
+                    switch (props.filterMethod) {
+                        case "contains":
+                            return value.toLowerCase().indexOf(String(filterValue).toLowerCase()) !== -1;
+                        case "endsWith":
+                            return value.toLowerCase().endsWith(String(filterValue).toLowerCase());
+                        case "startsWith":
+                            return value.toLowerCase().startsWith(String(filterValue).toLowerCase());
+                        default:
+                            return false;
+                    }
                 });
             }
         }),
-        [props.columns]
+        [props.columns, props.filterMethod, props.valueForFilter]
     );
     const tableColumns: Array<ColumnWithStrictAccessor<{ item: T }>> = useMemo(
         () =>
@@ -116,13 +135,30 @@ export function Table<T>(props: TableProps<T>): ReactElement {
 
     const defaultColumn: ColumnInterface<{ item: T }> = useMemo(
         () => ({
-            Filter: ({ column: { filterValue, setFilter } }): ReactElement => (
+            Filter: ({ column: { filterValue, setFilter, id } }): ReactElement => (
                 <div className="filter">
                     <input
                         className="form-control"
                         value={filterValue || ""}
                         onChange={e => {
-                            setFilter(e.target.value || undefined); // Set undefined to remove the filter entirely
+                            const value = e.target.value || undefined; // Set undefined to remove the filter entirely
+                            setFilter(value);
+                            setFilters(prev => {
+                                if (value) {
+                                    const previousFilter = prev.find(c => c.id === id);
+                                    if (previousFilter) {
+                                        previousFilter.value = value;
+                                    } else {
+                                        prev.push({ id, value });
+                                    }
+                                } else {
+                                    prev.splice(
+                                        prev.findIndex(c => c.id === id),
+                                        1
+                                    );
+                                }
+                                return [...prev];
+                            });
                         }}
                     />
                 </div>
@@ -146,7 +182,7 @@ export function Table<T>(props: TableProps<T>): ReactElement {
         prepareRow,
         getTableBodyProps,
         allColumns,
-        setColumnOrder,
+        setColumnOrder: setOrder,
         visibleColumns,
         state: { pageIndex },
         gotoPage,
@@ -163,8 +199,16 @@ export function Table<T>(props: TableProps<T>): ReactElement {
             disableResizing: !props.columnsResizable,
             disableSortBy: !props.columnsSortable,
             disableFilters: !props.columnsFilterable,
-            initialState: { pageSize: props.pageSize },
-            disableMultiSort: true
+            initialState: {
+                pageSize: props.pageSize,
+                columnOrder,
+                hiddenColumns,
+                pageIndex: paginationIndex,
+                sortBy,
+                filters
+            },
+            disableMultiSort: true,
+            autoResetSortBy: false
         },
         useFilters,
         useSortBy,
@@ -196,6 +240,7 @@ export function Table<T>(props: TableProps<T>): ReactElement {
                 page={pageIndex}
                 pageSize={props.pageSize}
                 previousPage={previousPage}
+                setPaginationIndex={setPaginationIndex}
             />
         )
     ) : null;
@@ -216,8 +261,12 @@ export function Table<T>(props: TableProps<T>): ReactElement {
                                     dragOver={dragOver}
                                     filterable={props.columnsFilterable}
                                     resizable={props.columnsResizable}
-                                    setColumnOrder={setColumnOrder}
+                                    setColumnOrder={(newOrder: Array<IdType<object>>) => {
+                                        setOrder(newOrder);
+                                        setColumnOrder(newOrder);
+                                    }}
                                     setDragOver={setDragOver}
+                                    setSortBy={setSortBy}
                                     sortable={props.columnsSortable}
                                     visibleColumns={visibleColumns}
                                 />
@@ -227,6 +276,7 @@ export function Table<T>(props: TableProps<T>): ReactElement {
                                     allColumns={allColumns}
                                     width={columnSelectorWidth}
                                     setWidth={setColumnSelectorWidth}
+                                    setHiddenColumns={setHiddenColumns}
                                 />
                             )}
                         </div>

--- a/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
@@ -55,7 +55,11 @@ export function Table<T>(props: TableProps<T>): ReactElement {
     const [dragOver, setDragOver] = useState("");
     const [columnSelectorWidth, setColumnSelectorWidth] = useState(0);
     const [columnOrder, setColumnOrder] = useState<Array<IdType<object>>>([]); // TODO: Load config from user
-    const [hiddenColumns, setHiddenColumns] = useState<Array<IdType<object>>>([]); // TODO: Load config from user
+    const [hiddenColumns, setHiddenColumns] = useState<Array<IdType<object>>>(
+        (props.columns
+            .map((c, i) => (c.hidable === "hidden" ? i.toString() : undefined))
+            .filter(Boolean) as string[]) ?? []
+    ); // TODO: Load config from user
     const [paginationIndex, setPaginationIndex] = useState<number>(0); // TODO: Load config from user
     const [sortBy, setSortBy] = useState<Array<SortingRule<object>>>([]); // TODO: Load config from user
     const [filters, setFilters] = useState<Filters<object>>([]); // TODO: Load config from user
@@ -65,8 +69,12 @@ export function Table<T>(props: TableProps<T>): ReactElement {
             text: (rows: Array<Row<object>>, id: IdType<object>, filterValue: FilterValue) => {
                 return rows.filter(row => {
                     const value = props.valueForFilter(row.values[id], Number(id));
-                    if (!value) {
+                    if (!filterValue) {
                         return true;
+                    }
+
+                    if (!value) {
+                        return false;
                     }
 
                     switch (props.filterMethod) {

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/ColumnSelector.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/ColumnSelector.spec.tsx
@@ -27,6 +27,7 @@ function mockColumnSelectorProps(): ColumnSelectorProps<object> {
             }
         ] as Array<ColumnInstance<object>>,
         width: 0,
-        setWidth: jest.fn()
+        setWidth: jest.fn(),
+        setHiddenColumns: jest.fn()
     };
 }

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Header.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Header.spec.tsx
@@ -8,12 +8,91 @@ describe("Header", () => {
 
         expect(component).toMatchSnapshot();
     });
+
+    it("renders the structure correctly when sortable", () => {
+        const props = mockHeaderProps();
+        props.column.canSort = true;
+        props.column.getSortByToggleProps = () => ({ sortableProps: "" });
+        props.sortable = true;
+
+        const component = shallow(<Header {...props} />);
+
+        expect(component).toMatchSnapshot();
+    });
+
+    it("renders the structure correctly when resizable", () => {
+        const props = mockHeaderProps();
+        props.column.canResize = true;
+        props.column.getResizerProps = () => ({ resizableProps: "" });
+        props.resizable = true;
+
+        const component = shallow(<Header {...props} />);
+
+        expect(component).toMatchSnapshot();
+    });
+
+    it("renders the structure correctly when draggable", () => {
+        const props = mockHeaderProps();
+        props.column.canDrag = true;
+        props.draggable = true;
+
+        const component = shallow(<Header {...props} />);
+
+        expect(component).toMatchSnapshot();
+    });
+
+    it("renders the structure correctly when filterable", () => {
+        const props = mockHeaderProps();
+        props.column.canFilter = true;
+        props.filterable = true;
+
+        const component = shallow(<Header {...props} />);
+
+        expect(component).toMatchSnapshot();
+    });
+
+    it("renders the structure correctly when filterable and with custom filter", () => {
+        const props = mockHeaderProps();
+        props.column.canFilter = true;
+        props.column.customFilter = (
+            <div>
+                <label>Date picker filter</label>
+                <input type="date" />
+            </div>
+        );
+        props.filterable = true;
+
+        const component = shallow(<Header {...props} />);
+
+        expect(component).toMatchSnapshot();
+    });
+
+    it("calls setSortBy store function with correct parameters when sortable", () => {
+        const column = {
+            id: "sortable",
+            render: () => "My sortable column",
+            canSort: true,
+            getHeaderProps: () => ({ role: "Test", onClick: jest.fn() } as any),
+            getSortByToggleProps: () => ({})
+        } as any;
+        const mockedFunction = jest.fn();
+        const component = shallow(
+            <Header {...mockHeaderProps()} column={column} sortable setSortBy={mockedFunction} />
+        );
+
+        const clickableRegion = component.find(".column-header");
+
+        expect(clickableRegion).toHaveLength(1);
+
+        clickableRegion.simulate("click");
+        expect(mockedFunction).toBeCalledWith([{ id: "sortable", desc: false }]);
+    });
 });
 
 function mockHeaderProps(): HeaderProps<object> {
     return {
         column: {
-            render: () => <span>Test</span>,
+            render: () => "Test",
             getHeaderProps: () => ({ role: "Test" } as any)
         } as any,
         draggable: false,

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Header.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Header.spec.tsx
@@ -23,6 +23,7 @@ function mockHeaderProps(): HeaderProps<object> {
         sortable: false,
         setColumnOrder: jest.fn(),
         setDragOver: jest.fn(),
-        visibleColumns: []
+        visibleColumns: [],
+        setSortBy: jest.fn()
     };
 }

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Table.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Table.spec.tsx
@@ -86,6 +86,7 @@ function mockTableProps(): TableProps<ObjectItem> {
         pagingPosition: "bottom",
         columnsHidable: false,
         columnsDraggable: false,
+        filterMethod: "startsWith",
         footerWidgets: undefined,
         headerWidgets: undefined,
         className: "test",

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/__snapshots__/Header.spec.tsx.snap
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/__snapshots__/Header.spec.tsx.snap
@@ -10,6 +10,11 @@ exports[`Header renders the structure correctly 1`] = `
       "flex": "1 1 0px",
     }
   }
+  title={
+    <span>
+      Test
+    </span>
+  }
 >
   <div
     className="column-container"

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/__snapshots__/Header.spec.tsx.snap
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/__snapshots__/Header.spec.tsx.snap
@@ -10,11 +10,7 @@ exports[`Header renders the structure correctly 1`] = `
       "flex": "1 1 0px",
     }
   }
-  title={
-    <span>
-      Test
-    </span>
-  }
+  title="Test"
 >
   <div
     className="column-container"
@@ -22,9 +18,175 @@ exports[`Header renders the structure correctly 1`] = `
     <div
       className="column-header"
     >
-      <span>
-        Test
-      </span>
+      Test
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Header renders the structure correctly when draggable 1`] = `
+<div
+  className="th"
+  role="Test"
+  style={
+    Object {
+      "cursor": "unset",
+      "flex": "1 1 0px",
+    }
+  }
+  title="Test"
+>
+  <div
+    className="column-container"
+    draggable={true}
+    onDragEnter={[Function]}
+    onDragOver={[Function]}
+    onDragStart={[Function]}
+    onDrop={[Function]}
+  >
+    <div
+      className="column-header"
+    >
+      Test
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Header renders the structure correctly when filterable 1`] = `
+<div
+  className="th"
+  role="Test"
+  style={
+    Object {
+      "cursor": "unset",
+      "flex": "1 1 0px",
+    }
+  }
+  title="Test"
+>
+  <div
+    className="column-container"
+  >
+    <div
+      className="column-header"
+    >
+      Test
+    </div>
+    Test
+  </div>
+</div>
+`;
+
+exports[`Header renders the structure correctly when filterable and with custom filter 1`] = `
+<div
+  className="th"
+  role="Test"
+  style={
+    Object {
+      "cursor": "unset",
+      "flex": "1 1 0px",
+    }
+  }
+  title="Test"
+>
+  <div
+    className="column-container"
+  >
+    <div
+      className="column-header"
+    >
+      Test
+    </div>
+    <div>
+      <label>
+        Date picker filter
+      </label>
+      <input
+        type="date"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Header renders the structure correctly when resizable 1`] = `
+<div
+  className="th"
+  role="Test"
+  style={
+    Object {
+      "cursor": "unset",
+    }
+  }
+  title="Test"
+>
+  <div
+    className="column-container"
+  >
+    <div
+      className="column-header"
+    >
+      Test
+    </div>
+  </div>
+  <div
+    className="column-resizer "
+    resizableProps=""
+  />
+</div>
+`;
+
+exports[`Header renders the structure correctly when sortable 1`] = `
+<div
+  className="th"
+  role="Test"
+  style={
+    Object {
+      "flex": "1 1 0px",
+    }
+  }
+  title="Test"
+>
+  <div
+    className="column-container"
+  >
+    <div
+      className="column-header clickable"
+      onClick={[Function]}
+    >
+      Test
+      <FontAwesomeIcon
+        border={false}
+        className=""
+        fixedWidth={false}
+        flip={null}
+        icon={
+          Object {
+            "icon": Array [
+              256,
+              512,
+              Array [],
+              "f338",
+              "M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z",
+            ],
+            "iconName": "arrows-alt-v",
+            "prefix": "fas",
+          }
+        }
+        inverse={false}
+        listItem={false}
+        mask={null}
+        pull={null}
+        pulse={false}
+        rotation={null}
+        size={null}
+        spin={false}
+        swapOpacity={false}
+        symbol={false}
+        title=""
+        transform={null}
+      />
     </div>
   </div>
 </div>

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/__snapshots__/Table.spec.tsx.snap
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/__snapshots__/Table.spec.tsx.snap
@@ -169,6 +169,7 @@ exports[`Table renders the structure correctly 1`] = `
           resizable={false}
           setColumnOrder={[Function]}
           setDragOver={[Function]}
+          setSortBy={[Function]}
           sortable={false}
           visibleColumns={
             Array [
@@ -461,6 +462,7 @@ exports[`Table renders the structure correctly 1`] = `
             ]
           }
           allColumnsHidden={false}
+          autoResetSortBy={false}
           canNextPage={false}
           canPreviousPage={false}
           cell={
@@ -2163,7 +2165,12 @@ exports[`Table renders the structure correctly 1`] = `
           }
           initialState={
             Object {
+              "columnOrder": Array [],
+              "filters": Array [],
+              "hiddenColumns": Array [],
+              "pageIndex": 0,
               "pageSize": 10,
+              "sortBy": Array [],
             }
           }
           nextPage={[Function]}
@@ -4107,6 +4114,7 @@ exports[`Table renders the structure correctly with custom filtering 1`] = `
           resizable={false}
           setColumnOrder={[Function]}
           setDragOver={[Function]}
+          setSortBy={[Function]}
           sortable={false}
           visibleColumns={
             Array [
@@ -4405,6 +4413,7 @@ exports[`Table renders the structure correctly with custom filtering 1`] = `
             ]
           }
           allColumnsHidden={false}
+          autoResetSortBy={false}
           canNextPage={false}
           canPreviousPage={false}
           cell={
@@ -6158,7 +6167,12 @@ exports[`Table renders the structure correctly with custom filtering 1`] = `
           }
           initialState={
             Object {
+              "columnOrder": Array [],
+              "filters": Array [],
+              "hiddenColumns": Array [],
+              "pageIndex": 0,
               "pageSize": 10,
+              "sortBy": Array [],
             }
           }
           nextPage={[Function]}
@@ -8168,6 +8182,7 @@ exports[`Table renders the structure correctly with dragging 1`] = `
           resizable={false}
           setColumnOrder={[Function]}
           setDragOver={[Function]}
+          setSortBy={[Function]}
           sortable={false}
           visibleColumns={
             Array [
@@ -8460,6 +8475,7 @@ exports[`Table renders the structure correctly with dragging 1`] = `
             ]
           }
           allColumnsHidden={false}
+          autoResetSortBy={false}
           canNextPage={false}
           canPreviousPage={false}
           cell={
@@ -10162,7 +10178,12 @@ exports[`Table renders the structure correctly with dragging 1`] = `
           }
           initialState={
             Object {
+              "columnOrder": Array [],
+              "filters": Array [],
+              "hiddenColumns": Array [],
+              "pageIndex": 0,
               "pageSize": 10,
+              "sortBy": Array [],
             }
           }
           nextPage={[Function]}
@@ -12103,6 +12124,7 @@ exports[`Table renders the structure correctly with filtering 1`] = `
           resizable={false}
           setColumnOrder={[Function]}
           setDragOver={[Function]}
+          setSortBy={[Function]}
           sortable={false}
           visibleColumns={
             Array [
@@ -12395,6 +12417,7 @@ exports[`Table renders the structure correctly with filtering 1`] = `
             ]
           }
           allColumnsHidden={false}
+          autoResetSortBy={false}
           canNextPage={false}
           canPreviousPage={false}
           cell={
@@ -14097,7 +14120,12 @@ exports[`Table renders the structure correctly with filtering 1`] = `
           }
           initialState={
             Object {
+              "columnOrder": Array [],
+              "filters": Array [],
+              "hiddenColumns": Array [],
+              "pageIndex": 0,
               "pageSize": 10,
+              "sortBy": Array [],
             }
           }
           nextPage={[Function]}
@@ -16038,6 +16066,7 @@ exports[`Table renders the structure correctly with hiding 1`] = `
           resizable={false}
           setColumnOrder={[Function]}
           setDragOver={[Function]}
+          setSortBy={[Function]}
           sortable={false}
           visibleColumns={
             Array [
@@ -16309,6 +16338,7 @@ exports[`Table renders the structure correctly with hiding 1`] = `
               },
             ]
           }
+          setHiddenColumns={[Function]}
           setWidth={[Function]}
           width={0}
         />
@@ -16468,6 +16498,7 @@ exports[`Table renders the structure correctly with hiding 1`] = `
             ]
           }
           allColumnsHidden={false}
+          autoResetSortBy={false}
           canNextPage={false}
           canPreviousPage={false}
           cell={
@@ -18170,7 +18201,12 @@ exports[`Table renders the structure correctly with hiding 1`] = `
           }
           initialState={
             Object {
+              "columnOrder": Array [],
+              "filters": Array [],
+              "hiddenColumns": Array [],
+              "pageIndex": 0,
               "pageSize": 10,
+              "sortBy": Array [],
             }
           }
           nextPage={[Function]}
@@ -20119,6 +20155,7 @@ exports[`Table renders the structure correctly with paging 1`] = `
           resizable={false}
           setColumnOrder={[Function]}
           setDragOver={[Function]}
+          setSortBy={[Function]}
           sortable={false}
           visibleColumns={
             Array [
@@ -20411,6 +20448,7 @@ exports[`Table renders the structure correctly with paging 1`] = `
             ]
           }
           allColumnsHidden={false}
+          autoResetSortBy={false}
           canNextPage={false}
           canPreviousPage={false}
           cell={
@@ -22113,7 +22151,12 @@ exports[`Table renders the structure correctly with paging 1`] = `
           }
           initialState={
             Object {
+              "columnOrder": Array [],
+              "filters": Array [],
+              "hiddenColumns": Array [],
+              "pageIndex": 0,
               "pageSize": 10,
+              "sortBy": Array [],
             }
           }
           nextPage={[Function]}
@@ -24064,6 +24107,7 @@ exports[`Table renders the structure correctly with resizing 1`] = `
           resizable={true}
           setColumnOrder={[Function]}
           setDragOver={[Function]}
+          setSortBy={[Function]}
           sortable={false}
           visibleColumns={
             Array [
@@ -24356,6 +24400,7 @@ exports[`Table renders the structure correctly with resizing 1`] = `
             ]
           }
           allColumnsHidden={false}
+          autoResetSortBy={false}
           canNextPage={false}
           canPreviousPage={false}
           cell={
@@ -26061,7 +26106,12 @@ exports[`Table renders the structure correctly with resizing 1`] = `
           }
           initialState={
             Object {
+              "columnOrder": Array [],
+              "filters": Array [],
+              "hiddenColumns": Array [],
+              "pageIndex": 0,
               "pageSize": 10,
+              "sortBy": Array [],
             }
           }
           nextPage={[Function]}
@@ -28002,6 +28052,7 @@ exports[`Table renders the structure correctly with sorting 1`] = `
           resizable={false}
           setColumnOrder={[Function]}
           setDragOver={[Function]}
+          setSortBy={[Function]}
           sortable={true}
           visibleColumns={
             Array [
@@ -28294,6 +28345,7 @@ exports[`Table renders the structure correctly with sorting 1`] = `
             ]
           }
           allColumnsHidden={false}
+          autoResetSortBy={false}
           canNextPage={false}
           canPreviousPage={false}
           cell={
@@ -29996,7 +30048,12 @@ exports[`Table renders the structure correctly with sorting 1`] = `
           }
           initialState={
             Object {
+              "columnOrder": Array [],
+              "filters": Array [],
+              "hiddenColumns": Array [],
+              "pageIndex": 0,
               "pageSize": 10,
+              "sortBy": Array [],
             }
           }
           nextPage={[Function]}

--- a/packages/pluggableWidgets/datagrid-web/src/ui/Datagrid.scss
+++ b/packages/pluggableWidgets/datagrid-web/src/ui/Datagrid.scss
@@ -139,12 +139,13 @@ $dragging-color-effect: rgba(10, 19, 37, 0.8);
                 border-bottom-width: 1px;
                 border-bottom-style: solid;
                 background-color: $background-color;
+                overflow: hidden;
 
                 &:focus {
                     outline: none;
                 }
 
-                > .td-text {
+                > .td-text, * {
                     text-overflow: ellipsis;
                     overflow: hidden;
                 }

--- a/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
@@ -25,6 +25,8 @@ export interface ColumnsType {
 
 export type PagingPositionEnum = "bottom" | "top";
 
+export type FilterMethodEnum = "startsWith" | "contains" | "endsWith";
+
 export interface ColumnsPreviewType {
     attribute: string;
     header: string;
@@ -54,6 +56,7 @@ export interface DatagridContainerProps {
     pagingPosition: PagingPositionEnum;
     columnsSortable: boolean;
     columnsFilterable: boolean;
+    filterMethod: FilterMethodEnum;
     columnsResizable: boolean;
     columnsDraggable: boolean;
     columnsHidable: boolean;
@@ -73,6 +76,7 @@ export interface DatagridPreviewProps {
     pagingPosition: PagingPositionEnum;
     columnsSortable: boolean;
     columnsFilterable: boolean;
+    filterMethod: FilterMethodEnum;
     columnsResizable: boolean;
     columnsDraggable: boolean;
     columnsHidable: boolean;

--- a/packages/pluggableWidgets/datagrid-web/typings/react-table-config.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/react-table-config.d.ts
@@ -11,7 +11,10 @@ import {
     UseColumnOrderInstanceProps,
     UseResizeColumnsColumnProps,
     UsePaginationInstanceProps,
-    UseFiltersColumnProps
+    UseFiltersColumnProps,
+    UseColumnOrderState,
+    UseSortByState,
+    UseFiltersState
 } from "react-table";
 import { ReactNode } from "react";
 
@@ -33,7 +36,11 @@ declare module "react-table" {
         customFilter?: ReactNode;
     }
 
-    export interface TableState<D extends object = {}> extends UsePaginationState<D> {}
+    export interface TableState<D extends object = {}>
+        extends UsePaginationState<D>,
+            UseColumnOrderState<D>,
+            UseSortByState<D>,
+            UseFiltersState<D> {}
 
     export interface TableInstance<D extends object = {}>
         extends UseSortByInstanceProps<D>,


### PR DESCRIPTION
In this PR I am:

## Features

- Implementing state storing for initial state in sorting, filtering, hiding, paging and reordering
- Implementing filter method (startsWith, endsWith and contains)
- Fixing CSS when columns contains big untruncated texts
- Making it ready to receive custom configuration object from the users/SP
- Renaming properties not complying with Mendix standards

## How to test ?
- Add a column with dynamic custom with a Button that open a popup page receiving a context parameter, then add a datagrid in the new page with editable fields. When you save the Data it should keep the current state of the datagrid. If tested with previous versions it will reset the DG as soon as you save or cancel in the popup. 
- Use variations: Microflow & nanoflow action buttons that change a parameter of a received object