### PR TITLE
fix(native-mobile-resources): ParseUrlToObject

### DIFF
--- a/packages/jsActions/native-mobile-resources/src/deeplink/ParseUrlToObject.ts
+++ b/packages/jsActions/native-mobile-resources/src/deeplink/ParseUrlToObject.ts
@@ -23,9 +23,10 @@ async function createParamObject(entity: string, url: string): Promise<mendix.li
 }
 
 function splitUrlToObject(url: string): Records {
-    const urlObject = new UrlParse(url, true);
-    const queryValues: Records = {};
-    const query = urlObject.query;
+    const urlObject = new UrlParse(url);
+    const parsedUrlObject = new UrlParse(url, true);
+    const queryValues = {};
+    const query = parsedUrlObject.query;
 
     for (const [key, value] of Object.entries(query)) {
         queryValues[key.toLowerCase()] = value !== undefined ? value : "";

--- a/packages/jsActions/native-mobile-resources/src/deeplink/ParseUrlToObject.ts
+++ b/packages/jsActions/native-mobile-resources/src/deeplink/ParseUrlToObject.ts
@@ -23,7 +23,7 @@ async function createParamObject(entity: string, url: string): Promise<mendix.li
 }
 
 function splitUrlToObject(url: string): Records {
-    const urlObject = new UrlParse(url);
+    const urlObject = new UrlParse(url, true);
     const queryValues: Records = {};
     const query = urlObject.query;
 


### PR DESCRIPTION
The call to UrlParse was missing a second parameter. Without it, the query string does not get parsed.
Documentation here: https://www.npmjs.com/package/url-parse