### PR TITLE
[WT-2771] Correct native dropdown menu background color

### DIFF
--- a/packages/theming/atlas/src/native/ts/core/widgets/dropdown.ts
+++ b/packages/theming/atlas/src/native/ts/core/widgets/dropdown.ts
@@ -75,7 +75,8 @@ export const DropDown: DropDownType = {
         shadowColor: "#000",
         shadowOpacity: 0.2,
         shadowRadius: 10,
-        elevation: 16
+        elevation: 16,
+        backgroundColor: input.input.backgroundColor
     },
     itemContainer: {
         // All ViewStyle properties are allowed


### PR DESCRIPTION
The native DropDown (uniform) component defaulted to a white background colour. This change introduces an explit backgroundColor css property.

[Atlas 2 PR](https://github.com/mendix/Atlas-UI-Framework/pull/96)