### PR TITLE
Native dropdown menu items styling

### DIFF
--- a/packages/theming/atlas/src/native/ts/app/custom-variables.ts
+++ b/packages/theming/atlas/src/native/ts/app/custom-variables.ts
@@ -248,6 +248,7 @@ export const input: VariablesInput = {
         maxWidth: 500,
         paddingVertical: 12,
         paddingHorizontal: spacing.regular,
+        borderRadius: border.radiusLarge,
         backgroundColor: background.primary
     },
     item: {

--- a/packages/theming/atlas/src/native/ts/app/custom-variables.ts
+++ b/packages/theming/atlas/src/native/ts/app/custom-variables.ts
@@ -1,6 +1,6 @@
 import { NativeModules, Platform } from "react-native";
 import adjustFont from "../core/helpers/_functions/adjustfont";
-import { setContrastScale } from "../core/helpers/_functions/convertcolors";
+import { anyColorToRgbString, setContrastScale } from "../core/helpers/_functions/convertcolors";
 import {
     VariablesBackground,
     VariablesBadge,
@@ -223,6 +223,9 @@ export const input: VariablesInput = {
         minHeight: 48,
         paddingVertical: spacing.small,
         paddingHorizontal: spacing.small
+    },
+    inputContainer: {
+        underlayColor: `rgba(${anyColorToRgbString(contrast.low)},0.4)`
     },
     inputDisabled: {
         color: font.colorDisabled,

--- a/packages/theming/atlas/src/native/ts/app/custom-variables.ts
+++ b/packages/theming/atlas/src/native/ts/app/custom-variables.ts
@@ -248,7 +248,6 @@ export const input: VariablesInput = {
         maxWidth: 500,
         paddingVertical: 12,
         paddingHorizontal: spacing.regular,
-        borderRadius: border.radiusLarge,
         backgroundColor: background.primary
     },
     item: {

--- a/packages/theming/atlas/src/native/ts/core/variables.ts
+++ b/packages/theming/atlas/src/native/ts/core/variables.ts
@@ -221,6 +221,9 @@ let input: VariablesInput = {
         paddingVertical: spacing.small,
         paddingHorizontal: spacing.small
     },
+    inputContainer: {
+        underlayColor: `rgba(${anyColorToRgbString(contrast.low)},0.4)`
+    },
     inputDisabled: {
         color: font.colorDisabled,
         borderColor: border.color,

--- a/packages/theming/atlas/src/native/ts/core/variables.ts
+++ b/packages/theming/atlas/src/native/ts/core/variables.ts
@@ -244,6 +244,7 @@ let input: VariablesInput = {
     itemContainer: {
         maxWidth: 500,
         paddingVertical: 12,
+        borderRadius: border.radiusLarge,
         paddingHorizontal: spacing.regular,
         backgroundColor: background.primary
     },

--- a/packages/theming/atlas/src/native/ts/core/variables.ts
+++ b/packages/theming/atlas/src/native/ts/core/variables.ts
@@ -244,7 +244,6 @@ let input: VariablesInput = {
     itemContainer: {
         maxWidth: 500,
         paddingVertical: 12,
-        borderRadius: border.radiusLarge,
         paddingHorizontal: spacing.regular,
         backgroundColor: background.primary
     },

--- a/packages/theming/atlas/src/native/ts/core/widgets/dropdown.ts
+++ b/packages/theming/atlas/src/native/ts/core/widgets/dropdown.ts
@@ -60,7 +60,7 @@ export const DropDown: DropDownType = {
     },
     /*  New dropdown styles start */
     valueContainer: {
-        // All ViewStyle properties & rippleColor are allowed
+        // All ViewStyle properties & rippleColor & activeOpacity & underlayColor are allowed
         flexDirection: "row",
         justifyContent: "space-between",
         alignItems: "center",
@@ -92,7 +92,7 @@ export const DropDown: DropDownType = {
         backgroundColor: input.input.backgroundColor
     },
     itemContainer: {
-        // All ViewStyle properties are allowed
+        // All ViewStyle properties & rippleColor & activeOpacity & underlayColor are allowed
         maxWidth: input.itemContainer.maxWidth,
         paddingVertical: input.itemContainer.paddingVertical,
         paddingHorizontal: input.itemContainer.paddingHorizontal,

--- a/packages/theming/atlas/src/native/ts/core/widgets/dropdown.ts
+++ b/packages/theming/atlas/src/native/ts/core/widgets/dropdown.ts
@@ -1,7 +1,6 @@
 import { font, input } from "../variables";
 import { TextBox, TextBoxVertical } from "./textbox";
 import { DropDownType } from "../../types/widgets";
-import { contrast } from "../../app/custom-variables";
 /*
 
 DISCLAIMER:
@@ -97,7 +96,7 @@ export const DropDown: DropDownType = {
         paddingVertical: input.itemContainer.paddingVertical,
         paddingHorizontal: input.itemContainer.paddingHorizontal,
         backgroundColor: input.itemContainer.backgroundColor,
-        underlayColor: contrast.low,
+        underlayColor: input.inputContainer.underlayColor,
         overflow: "hidden"
     },
     item: {

--- a/packages/theming/atlas/src/native/ts/core/widgets/dropdown.ts
+++ b/packages/theming/atlas/src/native/ts/core/widgets/dropdown.ts
@@ -97,7 +97,6 @@ export const DropDown: DropDownType = {
         paddingVertical: input.itemContainer.paddingVertical,
         paddingHorizontal: input.itemContainer.paddingHorizontal,
         backgroundColor: input.itemContainer.backgroundColor,
-        borderRadius: input.itemContainer.borderRadius,
         underlayColor: contrast.low,
         overflow: "hidden"
     },

--- a/packages/theming/atlas/src/native/ts/core/widgets/dropdown.ts
+++ b/packages/theming/atlas/src/native/ts/core/widgets/dropdown.ts
@@ -1,6 +1,7 @@
 import { font, input } from "../variables";
 import { TextBox, TextBoxVertical } from "./textbox";
 import { DropDownType } from "../../types/widgets";
+import { background } from "../../app/custom-variables";
 /*
 
 DISCLAIMER:
@@ -113,7 +114,7 @@ export const DropDown: DropDownType = {
         borderWidth: input.selectedItemContainer.borderWidth,
         borderRadius: input.selectedItemContainer.borderRadius,
         borderColor: input.selectedItemContainer.borderColor,
-        backgroundColor: input.selectedItemContainer.backgroundColor
+        backgroundColor: background.primary
     },
     /*  New dropdown styles end */
     useUniformDesign: true,

--- a/packages/theming/atlas/src/native/ts/core/widgets/dropdown.ts
+++ b/packages/theming/atlas/src/native/ts/core/widgets/dropdown.ts
@@ -1,7 +1,7 @@
 import { font, input } from "../variables";
 import { TextBox, TextBoxVertical } from "./textbox";
 import { DropDownType } from "../../types/widgets";
-import { background } from "../../app/custom-variables";
+import { contrast } from "../../app/custom-variables";
 /*
 
 DISCLAIMER:
@@ -96,7 +96,10 @@ export const DropDown: DropDownType = {
         maxWidth: input.itemContainer.maxWidth,
         paddingVertical: input.itemContainer.paddingVertical,
         paddingHorizontal: input.itemContainer.paddingHorizontal,
-        backgroundColor: input.itemContainer.backgroundColor
+        backgroundColor: input.itemContainer.backgroundColor,
+        borderRadius: input.itemContainer.borderRadius,
+        underlayColor: contrast.low,
+        overflow: "hidden"
     },
     item: {
         // All TextStyle properties are allowed
@@ -114,7 +117,7 @@ export const DropDown: DropDownType = {
         borderWidth: input.selectedItemContainer.borderWidth,
         borderRadius: input.selectedItemContainer.borderRadius,
         borderColor: input.selectedItemContainer.borderColor,
-        backgroundColor: background.primary
+        backgroundColor: input.selectedItemContainer.backgroundColor
     },
     /*  New dropdown styles end */
     useUniformDesign: true,

--- a/packages/theming/atlas/src/native/ts/types/variables.d.ts
+++ b/packages/theming/atlas/src/native/ts/types/variables.d.ts
@@ -188,7 +188,6 @@ export interface VariablesInput {
         paddingVertical: number;
         paddingHorizontal: number;
         backgroundColor: string;
-        borderRadius: number;
     };
     item: {
         color: string;

--- a/packages/theming/atlas/src/native/ts/types/variables.d.ts
+++ b/packages/theming/atlas/src/native/ts/types/variables.d.ts
@@ -163,6 +163,9 @@ export interface VariablesInput {
         paddingVertical: number;
         paddingHorizontal: number;
     };
+    inputContainer: {
+        underlayColor: string;
+    };
     inputDisabled: {
         color: string;
         borderColor: string;

--- a/packages/theming/atlas/src/native/ts/types/variables.d.ts
+++ b/packages/theming/atlas/src/native/ts/types/variables.d.ts
@@ -188,6 +188,7 @@ export interface VariablesInput {
         paddingVertical: number;
         paddingHorizontal: number;
         backgroundColor: string;
+        borderRadius: number;
     };
     item: {
         color: string;

--- a/packages/theming/atlas/src/native/ts/types/widgets.d.ts
+++ b/packages/theming/atlas/src/native/ts/types/widgets.d.ts
@@ -174,15 +174,21 @@ export interface DropDownType {
     valueFocused?: ViewStyle;
     validationMessage?: TextStyle;
     /*  New dropdown styles start */
-    valueContainer?: {
+    valueContainer?: ViewStyle & {
         rippleColor?: string;
-    } & ViewStyle;
+        underlayColor?: string;
+        activeOpacity?: number;
+    };
     valueContainerDisabled?: ViewStyle;
     valueContainerFocused?: ViewStyle;
     iconStyle?: TextStyle;
     menuWrapper?: ViewStyle;
     item?: TextStyle;
-    itemContainer?: ViewStyle;
+    itemContainer?: ViewStyle & {
+        rippleColor?: string;
+        underlayColor?: string;
+        activeOpacity?: number;
+    };
     selectedItem?: TextStyle;
     selectedItemContainer?: ViewStyle;
     /*  New dropdown styles end */


### PR DESCRIPTION
# Overview

Native Dropdown (Uniform) menu items on iOS in dark mode had two issues:

- if you pressed the selected item it would flash white, essentially due to Atlas missing an `underlayColor` property and the 3rd-party component previously defaulting this to white-ish. 

- the `underlayColor` would "bleed" out of the edges, essentially due to how the previously used 3rd-party component would include a `View` component as a child to the `TouchableHighlight`. 

This has been corrected with this changeset, by correcting styling and introducing an implementation of MenuItem.

# To Test

- Android and iOS (light + dark) native Dropdown styling (Atlas 3)
- No regression in native ReferenceSelector styling (which used DropdownUniform)

NN