### PR TITLE
Add missing colour styling property for Dropdown Uniform icon

### DIFF
--- a/packages/theming/atlas/src/native/ts/core/widgets/dropdown.ts
+++ b/packages/theming/atlas/src/native/ts/core/widgets/dropdown.ts
@@ -79,6 +79,7 @@ export const DropDown: DropDownType = {
     },
     iconStyle: {
         // All TextStyle properties are allowed
+        color: input.input.color
     },
     menuWrapper: {
         // All ViewStyle properties are allowed


### PR DESCRIPTION
The Reference Selector styles are spread out from Dropdown's, meaning this change will cover the icon color for Reference Selector.