### PR TITLE
[WT-2723] Data grid - User custom configuration

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -33,6 +33,8 @@
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
+    "@native-mobile-resources/util-widgets": "1.0.0",
+    "@testing-library/react-hooks": "^3.4.2",
     "@types/react-table": "^7.0.20"
   }
 }

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -91,6 +91,7 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
                 },
                 [props.columns]
             )}
+            settings={props.configurationAttribute}
         />
     );
 }

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -145,7 +145,7 @@
                 </property>
             </propertyGroup>
         </propertyGroup>
-        <propertyGroup caption="Capabilities">
+        <propertyGroup caption="Personalization">
             <propertyGroup caption="Capabilities">
                 <property key="columnsSortable" type="boolean" defaultValue="true">
                     <caption>Sorting</caption>
@@ -175,6 +175,15 @@
                 <property key="columnsHidable" type="boolean" defaultValue="false">
                     <caption>Hiding</caption>
                     <description />
+                </property>
+            </propertyGroup>
+            <propertyGroup caption="Configuration">
+                <property key="configurationAttribute" type="attribute" required="false">
+                    <caption>Attribute</caption>
+                    <description>Attribute containing the personalized configuration of the capabilities. This configuration is automatically stored and loaded. The attribute requires Unlimited String.</description>
+                    <attributeTypes>
+                        <attributeType name="String" />
+                    </attributeTypes>
                 </property>
             </propertyGroup>
         </propertyGroup>

--- a/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
@@ -1,0 +1,209 @@
+import { useSettings } from "../settings";
+import { ColumnWidth, TableColumn } from "../../components/Table";
+import { EditableValueBuilder } from "@native-mobile-resources/util-widgets";
+import { HidableEnum } from "../../../typings/DatagridProps";
+import { renderHook } from "@testing-library/react-hooks";
+
+describe("useSettings Hook", () => {
+    it("should load correct values into hooks", () => {
+        const props = mockProperties();
+
+        renderHook(() =>
+            useSettings(
+                props.settings,
+                props.columns,
+                props.columnOrder,
+                props.setColumnOrder,
+                props.hiddenColumns,
+                props.setHiddenColumns,
+                props.sortBy,
+                props.setSortBy,
+                props.filters,
+                props.setFilters,
+                props.widths,
+                props.setWidths
+            )
+        );
+        expect(props.setColumnOrder).toHaveBeenCalledTimes(1);
+        expect(props.setHiddenColumns).toHaveBeenCalledTimes(1);
+        expect(props.setSortBy).toHaveBeenCalledTimes(1);
+        expect(props.setFilters).toHaveBeenCalledTimes(1);
+        expect(props.setWidths).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call state functions with correct values", () => {
+        const props = mockProperties();
+        const columns = [
+            {
+                header: "Column 1",
+                hidable: "yes" as HidableEnum
+            },
+            {
+                header: "Column 2",
+                hidable: "hidden" as HidableEnum
+            }
+        ] as TableColumn[];
+        const settings = new EditableValueBuilder<string>()
+            .withValue(
+                JSON.stringify([
+                    {
+                        column: "Column 1",
+                        sort: true,
+                        sortMethod: "desc",
+                        filter: "ABC",
+                        hidden: false,
+                        order: 1,
+                        width: undefined
+                    },
+                    {
+                        column: "Column 2",
+                        sort: false,
+                        sortMethod: "asc",
+                        filter: "",
+                        hidden: true,
+                        order: 0,
+                        width: 120
+                    }
+                ])
+            )
+            .build();
+
+        renderHook(() =>
+            useSettings(
+                settings,
+                columns,
+                props.columnOrder,
+                props.setColumnOrder,
+                props.hiddenColumns,
+                props.setHiddenColumns,
+                props.sortBy,
+                props.setSortBy,
+                props.filters,
+                props.setFilters,
+                props.widths,
+                props.setWidths
+            )
+        );
+        expect(props.setColumnOrder).toHaveBeenCalledWith(["1", "0"]);
+        expect(props.setHiddenColumns).toHaveBeenCalledWith(["1"]);
+        expect(props.setSortBy).toHaveBeenCalledWith([{ id: "0", desc: true }]);
+        expect(props.setFilters).toHaveBeenCalledWith([{ id: "0", value: "ABC" }]);
+        expect(props.setWidths).toHaveBeenCalledWith({ "0": undefined, "1": 120 });
+    });
+
+    it("should change the settings when some property changes", () => {
+        const props = mockProperties();
+
+        const { rerender } = renderHook(
+            ({
+                settings,
+                columns,
+                columnOrder,
+                setColumnOrder,
+                hiddenColumns,
+                setHiddenColumns,
+                sortBy,
+                setSortBy,
+                filters,
+                setFilters,
+                widths,
+                setWidths
+            }) =>
+                useSettings(
+                    settings,
+                    columns,
+                    columnOrder,
+                    setColumnOrder,
+                    hiddenColumns,
+                    setHiddenColumns,
+                    sortBy,
+                    setSortBy,
+                    filters,
+                    setFilters,
+                    widths,
+                    setWidths
+                ),
+            {
+                initialProps: {
+                    settings: props.settings,
+                    columns: props.columns,
+                    columnOrder: ["0"],
+                    setColumnOrder: props.setColumnOrder,
+                    hiddenColumns: [],
+                    setHiddenColumns: props.setHiddenColumns,
+                    sortBy: [{ id: "0", desc: true }],
+                    setSortBy: props.setSortBy,
+                    filters: [{ id: "0", value: "ABC" }],
+                    setFilters: props.setFilters,
+                    widths: { "0": undefined } as ColumnWidth,
+                    setWidths: props.setWidths
+                }
+            }
+        );
+        expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+        rerender({
+            settings: props.settings,
+            columns: props.columns,
+            columnOrder: ["0"],
+            setColumnOrder: props.setColumnOrder,
+            hiddenColumns: [],
+            setHiddenColumns: props.setHiddenColumns,
+            sortBy: [{ id: "0", desc: false }],
+            setSortBy: props.setSortBy,
+            filters: [{ id: "0", value: "A" }],
+            setFilters: props.setFilters,
+            widths: { "0": 130 },
+            setWidths: props.setWidths
+        });
+        expect(props.settings.setValue).toHaveBeenCalledTimes(1);
+        expect(props.settings.setValue).toHaveBeenCalledWith(
+            JSON.stringify([
+                {
+                    column: "Column 1",
+                    sort: true,
+                    sortMethod: "asc",
+                    filter: "A",
+                    hidden: false,
+                    order: 0,
+                    width: 130
+                }
+            ])
+        );
+    });
+});
+
+function mockProperties(): any {
+    return {
+        settings: new EditableValueBuilder<string>()
+            .withValue(
+                JSON.stringify([
+                    {
+                        column: "Column 1",
+                        sort: true,
+                        sortMethod: "desc",
+                        filter: "ABC",
+                        hidden: false,
+                        order: 0,
+                        width: undefined
+                    }
+                ])
+            )
+            .build(),
+        columns: [
+            {
+                header: "Column 1",
+                hidable: "yes" as HidableEnum
+            }
+        ] as TableColumn[],
+        columnOrder: [],
+        setColumnOrder: jest.fn(),
+        hiddenColumns: [],
+        setHiddenColumns: jest.fn(),
+        sortBy: [],
+        setSortBy: jest.fn(),
+        filters: [],
+        setFilters: jest.fn(),
+        widths: { "0": undefined },
+        setWidths: jest.fn()
+    };
+}

--- a/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
@@ -5,7 +5,7 @@ import { HidableEnum } from "../../../typings/DatagridProps";
 import { renderHook } from "@testing-library/react-hooks";
 
 describe("useSettings Hook", () => {
-    it("should load correct values into hooks", () => {
+    it("loads correct values into hooks", () => {
         const props = mockProperties();
 
         renderHook(() =>
@@ -31,7 +31,7 @@ describe("useSettings Hook", () => {
         expect(props.setWidths).toHaveBeenCalledTimes(1);
     });
 
-    it("should call state functions with correct values", () => {
+    it("calls state functions with correct values", () => {
         const props = mockProperties();
         const columns = [
             {
@@ -91,7 +91,7 @@ describe("useSettings Hook", () => {
         expect(props.setWidths).toHaveBeenCalledWith({ "0": undefined, "1": 120 });
     });
 
-    it("should change the settings when some property changes", () => {
+    it("changes the settings when some property changes", () => {
         const props = mockProperties();
 
         const { rerender } = renderHook(

--- a/packages/pluggableWidgets/datagrid-web/src/utils/settings.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/settings.ts
@@ -1,0 +1,116 @@
+import { Filters, IdType, SortingRule } from "react-table";
+import { Dispatch, SetStateAction, useEffect, useMemo, useState } from "react";
+import { EditableValue, ValueStatus } from "mendix";
+import deepEqual from "deep-equal";
+import { ColumnWidth, TableColumn } from "../components/Table";
+
+declare type Option<T> = T | undefined;
+
+interface Settings {
+    columnOrder: Array<IdType<object>>;
+    hiddenColumns: Array<IdType<object>>;
+    sortBy: Array<SortingRule<object>>;
+    filters: Filters<object>;
+    widths: ColumnWidth;
+}
+
+interface PersistedSettings {
+    column: string;
+    sort: boolean;
+    sortMethod: "asc" | "desc";
+    filter: string;
+    hidden: boolean;
+    order: number;
+    width: number | undefined;
+}
+
+export function createSettings(
+    { columnOrder, hiddenColumns, sortBy, filters, widths }: Settings,
+    columns: Array<{ header: string; id: string }>
+): PersistedSettings[] {
+    return columns.map(column => ({
+        column: column.header,
+        sort: !!sortBy.find(s => s.id === column.id),
+        sortMethod: sortBy.find(s => s.id === column.id)?.desc ? "desc" : "asc",
+        filter: filters.find(f => f.id === column.id)?.value ?? "",
+        hidden: !!hiddenColumns.find(h => h === column.id),
+        order: columnOrder.findIndex(o => o === column.id),
+        width: widths[column.id]
+    }));
+}
+
+export function useSettings(
+    settings: Option<EditableValue<string>>,
+    columns: TableColumn[],
+    columnOrder: Array<IdType<object>>,
+    setColumnOrder: Dispatch<SetStateAction<Array<IdType<object>>>>,
+    hiddenColumns: Array<IdType<object>>,
+    setHiddenColumns: Dispatch<SetStateAction<Array<IdType<object>>>>,
+    sortBy: Array<SortingRule<object>>,
+    setSortBy: Dispatch<SetStateAction<Array<SortingRule<object>>>>,
+    filters: Filters<object>,
+    setFilters: Dispatch<SetStateAction<Filters<object>>>,
+    widths: ColumnWidth,
+    setWidths: Dispatch<SetStateAction<ColumnWidth>>
+): void {
+    const [loaded, setLoaded] = useState(false);
+
+    const filteredColumns = useMemo(
+        () =>
+            columns.map((c, index) => ({
+                header: typeof c.header === "object" ? c.header.value : c.header,
+                id: index.toString(),
+                hidable: c.hidable
+            })) as Array<{ header: string; id: string; hidable: string }>,
+        [columns]
+    );
+
+    useEffect(() => {
+        if (settings && settings.status !== ValueStatus.Loading && settings.value && !loaded) {
+            const newSettings = JSON.parse(settings.value) as PersistedSettings[];
+            const columns = newSettings.map(columnSettings => ({
+                ...columnSettings,
+                columnId: filteredColumns.find(c => c.header === columnSettings.column)?.id || ""
+            }));
+
+            const extractedSettings = {
+                columnOrder: columns.sort((a, b) => a.order - b.order).map(s => s.columnId),
+                hiddenColumns: columns.filter(s => s.hidden).map(s => s.columnId),
+                sortBy: columns
+                    .filter(s => s.sort)
+                    .map(s => ({
+                        id: s.columnId,
+                        desc: s.sortMethod === "desc"
+                    })),
+                filters: columns.filter(s => s.filter).map(s => ({ id: s.columnId, value: s.filter })),
+                widths: Object.fromEntries(columns.map(s => [s.columnId, s.width]))
+            };
+            setColumnOrder(extractedSettings.columnOrder);
+            setHiddenColumns(extractedSettings.hiddenColumns);
+            setSortBy(extractedSettings.sortBy);
+            setFilters(extractedSettings.filters);
+            setWidths(extractedSettings.widths);
+            setLoaded(true);
+        }
+    }, [settings, loaded, filteredColumns]);
+
+    useEffect(() => {
+        if (settings && settings.status === ValueStatus.Available) {
+            const newSettings = JSON.stringify(
+                createSettings(
+                    {
+                        columnOrder,
+                        hiddenColumns,
+                        sortBy,
+                        filters,
+                        widths
+                    },
+                    filteredColumns
+                ) ?? []
+            );
+            if (!deepEqual(settings.value, newSettings, { strict: true })) {
+                settings.setValue(newSettings);
+            }
+        }
+    }, [columnOrder, hiddenColumns, sortBy, filters, widths]);
+}

--- a/packages/pluggableWidgets/datagrid-web/src/utils/settings.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/settings.ts
@@ -112,5 +112,5 @@ export function useSettings(
                 settings.setValue(newSettings);
             }
         }
-    }, [columnOrder, hiddenColumns, sortBy, filters, widths]);
+    }, [columnOrder, hiddenColumns, sortBy, filters, widths, settings]);
 }

--- a/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
@@ -4,7 +4,7 @@
  * @author Mendix UI Content Team
  */
 import { ComponentType, CSSProperties, ReactNode } from "react";
-import { DynamicValue, ListValue, ListAttributeValue, ListExpressionValue, ListWidgetValue } from "mendix";
+import { DynamicValue, EditableValue, ListValue, ListAttributeValue, ListExpressionValue, ListWidgetValue } from "mendix";
 
 export type WidthEnum = "autoFill" | "autoFit" | "manual";
 
@@ -69,6 +69,7 @@ export interface DatagridContainerProps {
     columnsResizable: boolean;
     columnsDraggable: boolean;
     columnsHidable: boolean;
+    configurationAttribute?: EditableValue<string>;
 }
 
 export interface DatagridPreviewProps {
@@ -90,4 +91,5 @@ export interface DatagridPreviewProps {
     columnsResizable: boolean;
     columnsDraggable: boolean;
     columnsHidable: boolean;
+    configurationAttribute: string;
 }


### PR DESCRIPTION
**In this PR I am:**
- Introducing custom user settings attribute

**What does it mean?**
It means that from now one you can save your current DataGrid configurations like: applied filters, sort, columns order, hidden columns and column width (if you resized) in an attribute that will be loaded once the DG is ready to render.

**IMPORTANT**
The attribute should be of type unlimited string, otherwise it will not be able to perform all the settings if you have a good amount of columns.

**How to test**
To be able to test your need to use RC or Master, because of WTF-551