### PR TITLE
fix(notifications-native): fixing attributes in loading state

### DIFF
--- a/packages/pluggableWidgets/notifications-native/package.json
+++ b/packages/pluggableWidgets/notifications-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notifications-native",
   "widgetName": "Notifications",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/pluggableWidgets/notifications-native/src/package.xml
+++ b/packages/pluggableWidgets/notifications-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Notifications" version="1.0.6" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Notifications" version="1.0.7" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Notifications.xml"/>
         </widgetFiles>


### PR DESCRIPTION
Why?
This fix an issue where an attribute was still loading the was receiving notifications at the same time, which could cause the attribute to not be set and you loose the notification.

How?
- I moved the code to functional component to keep the consistency of other widgets and added extra checks if an attribute is set and the status is not available then it waits to subscribe for notifications only when the attributes are ready to be used.

How to test?
You need to set a project in firebase, configure a project using Native Builder UI an onOpen set a nanoflow that takes time or even nanoflow with subnanoflows.