### PR TITLE
[N] Line chart - Add separate axis labels

### DIFF
--- a/packages/pluggableWidgets/line-chart-native/src/LineChart.tsx
+++ b/packages/pluggableWidgets/line-chart-native/src/LineChart.tsx
@@ -7,7 +7,7 @@ import { LineChartStyle, defaultLineChartStyle } from "./ui/Styles";
 import { useSeries } from "./utils/SeriesLoader";
 
 export function LineChart(props: LineChartProps<LineChartStyle>): ReactElement | null {
-    const { series, showLegend, style, xAxisLabel, yAxisLabel } = props;
+    const { name, series, showLegend, style, xAxisLabel, yAxisLabel } = props;
 
     const customStyles = style ? style.filter(o => o != null) : [];
     const styles = all<LineChartStyle>([defaultLineChartStyle, ...customStyles]);
@@ -25,6 +25,7 @@ export function LineChart(props: LineChartProps<LineChartStyle>): ReactElement |
             showLegend={showLegend}
             xAxisLabel={xAxisLabel?.value}
             yAxisLabel={yAxisLabel?.value}
+            warningPrefix={`[${name}]: `}
         />
     );
 }

--- a/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
+++ b/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
@@ -111,7 +111,7 @@ export function LineChart(props: LineChartProps): ReactElement | null {
                 <Text>{dataTypesResult.message}</Text>
             ) : (
                 <View style={style.chart}>
-                    <View style={style.gridLabelCol}>
+                    <View style={style.gridAndLabelsRow}>
                         {yAxisLabel && yAxisLabelRelativePositionGrid === "top" ? (
                             <Text style={yAxisLabelStyle}>{yAxisLabel}</Text>
                         ) : null}

--- a/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
+++ b/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
@@ -89,8 +89,13 @@ export function LineChart(props: LineChartProps): ReactElement | null {
             ) : (
                 <View style={style.chart}>
                     <View style={style.gridLabelCol}>
+                        {yAxisLabel && style.yAxisLabel?.relativePositionGrid === "top" ? (
+                            <Text style={style.yAxisLabel}>{yAxisLabel}</Text>
+                        ) : null}
                         <View style={style.gridRow}>
-                            {yAxisLabel ? <Text style={style.yAxisLabel}>{yAxisLabel}</Text> : null}
+                            {yAxisLabel && style.yAxisLabel?.relativePositionGrid === "left" ? (
+                                <Text style={style.yAxisLabel}>{yAxisLabel}</Text>
+                            ) : null}
 
                             <View onLayout={updateChartDimensions} style={{ flex: 1 }}>
                                 {chartDimensions ? (
@@ -128,8 +133,13 @@ export function LineChart(props: LineChartProps): ReactElement | null {
                                 ) : null}
                             </View>
 
-                            {xAxisLabel ? <Text style={style.xAxisLabel}>{xAxisLabel}</Text> : null}
+                            {xAxisLabel && style.xAxisLabel?.relativePositionGrid === "right" ? (
+                                <Text style={style.xAxisLabel}>{xAxisLabel}</Text>
+                            ) : null}
                         </View>
+                        {xAxisLabel && style.xAxisLabel?.relativePositionGrid === "bottom" ? (
+                            <Text style={style.xAxisLabel}>{xAxisLabel}</Text>
+                        ) : null}
                     </View>
 
                     {showLegend ? <Legend style={style} series={series} /> : null}

--- a/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
+++ b/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
@@ -40,6 +40,8 @@ export interface LineChartDataPoint<X extends number | Date, Y extends number | 
 export function LineChart(props: LineChartProps): ReactElement | null {
     const { series, showLegend, style, warningPrefix, xAxisLabel, yAxisLabel } = props;
 
+    const warningMessagePrefix = useMemo(() => (warningPrefix ? warningPrefix + "i" : "I"), [warningPrefix]);
+
     const dataTypesResult = useMemo(() => getDataTypes(series), [series]);
 
     const chartLines = useMemo(() => {
@@ -59,9 +61,7 @@ export function LineChart(props: LineChartProps): ReactElement | null {
                 !(displayMarker === "false" || displayMarker === "underneath" || displayMarker === "onTop")
             ) {
                 console.warn(
-                    `${
-                        warningPrefix ? warningPrefix + "i" : "I"
-                    }nvalid value for series marker style property, display, valid values are "false", "underneath" and "onTop".`
+                    `${warningMessagePrefix}nvalid value for series marker style property, display, valid values are "false", "underneath" and "onTop".`
                 );
             }
 
@@ -83,7 +83,7 @@ export function LineChart(props: LineChartProps): ReactElement | null {
                 </VictoryGroup>
             );
         });
-    }, [dataTypesResult, series, style]);
+    }, [dataTypesResult, series, style, warningMessagePrefix]);
 
     const [firstSeries] = series;
 
@@ -99,9 +99,7 @@ export function LineChart(props: LineChartProps): ReactElement | null {
         ) {
             if (extractedXAxisLabelStyle.relativePositionGrid !== undefined) {
                 console.warn(
-                    `${
-                        warningPrefix ? warningPrefix + "i" : "I"
-                    }nvalid value for X axis label style property, relativePositionGrid, valid values are "bottom" and "right".`
+                    `${warningMessagePrefix}nvalid value for X axis label style property, relativePositionGrid, valid values are "bottom" and "right".`
                 );
             }
 
@@ -116,9 +114,7 @@ export function LineChart(props: LineChartProps): ReactElement | null {
         ) {
             if (extractedYAxisLabelStyle.relativePositionGrid !== undefined) {
                 console.warn(
-                    `${
-                        warningPrefix ? warningPrefix + "i" : "I"
-                    }nvalid value for Y axis label style property, relativePositionGrid, valid values are "top" and "left".`
+                    `${warningMessagePrefix}nvalid value for Y axis label style property, relativePositionGrid, valid values are "top" and "left".`
                 );
             }
 
@@ -131,7 +127,7 @@ export function LineChart(props: LineChartProps): ReactElement | null {
             extractedYAxisLabelStyle,
             yAxisLabelStyle
         };
-    }, [style]);
+    }, [style, warningMessagePrefix]);
 
     const xAxisLabelComponent = xAxisLabel ? <Text style={axisLabelStyles.xAxisLabelStyle}>{xAxisLabel}</Text> : null;
     const yAxisLabelComponent = yAxisLabel ? <Text style={axisLabelStyles.yAxisLabelStyle}>{yAxisLabel}</Text> : null;

--- a/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
+++ b/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
@@ -1,7 +1,7 @@
 import { createElement, ReactElement, useMemo, useCallback, useState, Fragment } from "react";
 import { View, LayoutChangeEvent, Text } from "react-native";
 import { InterpolationPropType } from "victory-core";
-import { VictoryChart, VictoryLine, VictoryGroup, VictoryScatter, VictoryAxis, VictoryLabel } from "victory-native";
+import { VictoryChart, VictoryLine, VictoryGroup, VictoryScatter, VictoryAxis } from "victory-native";
 
 import { LineChartStyle } from "../ui/Styles";
 import { Legend } from "./Legend";
@@ -106,34 +106,12 @@ export function LineChart(props: LineChartProps): ReactElement | null {
                             >
                                 <VictoryAxis
                                     style={style.xAxis}
-                                    axisLabelComponent={
-                                        xAxisLabel ? (
-                                            <VictoryLabel
-                                                dx={style.xAxis?.axisLabel?.horizontalOffset}
-                                                dy={style.xAxis?.axisLabel?.verticalOffset}
-                                            />
-                                        ) : (
-                                            undefined
-                                        )
-                                    }
-                                    label={xAxisLabel}
                                     orientation={"bottom"}
                                     {...(firstSeries?.xFormatter ? { tickFormat: firstSeries.xFormatter } : undefined)}
                                 />
                                 <VictoryAxis
                                     dependentAxis
                                     style={style.yAxis}
-                                    axisLabelComponent={
-                                        yAxisLabel ? (
-                                            <VictoryLabel
-                                                dx={style.yAxis?.axisLabel?.verticalOffset}
-                                                dy={style.yAxis?.axisLabel?.horizontalOffset}
-                                            />
-                                        ) : (
-                                            undefined
-                                        )
-                                    }
-                                    label={yAxisLabel}
                                     orientation={"left"}
                                     {...(firstSeries.yFormatter ? { tickFormat: firstSeries.yFormatter } : undefined)}
                                 />
@@ -142,6 +120,8 @@ export function LineChart(props: LineChartProps): ReactElement | null {
                         ) : null}
                     </View>
 
+                    {xAxisLabel ? <Text>{xAxisLabel}</Text> : null}
+                    {yAxisLabel ? <Text>{yAxisLabel}</Text> : null}
                     {showLegend ? <Legend style={style} series={series} /> : null}
                 </Fragment>
             )}

--- a/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
+++ b/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
@@ -52,7 +52,7 @@ export function LineChart(props: LineChartProps): ReactElement | null {
 
             const markers =
                 lineStyle === "lineWithMarkers" ||
-                (lineStyle === "custom" && seriesStyle?.markers?.display !== "false") ? (
+                (lineStyle === "custom" && seriesStyle?.markers?.display && seriesStyle.markers.display !== "false") ? (
                     <VictoryScatter data={dataPoints} style={seriesStyle?.markers} size={seriesStyle?.markers?.size} />
                 ) : (
                     undefined
@@ -60,11 +60,11 @@ export function LineChart(props: LineChartProps): ReactElement | null {
 
             return (
                 <VictoryGroup key={index}>
-                    {markers && (!seriesStyle?.markers?.display || seriesStyle.markers.display !== "onTop")
+                    {markers && seriesStyle?.markers?.display === "underneath" ? markers : null}
+                    <VictoryLine style={seriesStyle?.line} data={dataPoints} interpolation={interpolation} />
+                    {markers && (!seriesStyle?.markers?.display || seriesStyle?.markers?.display !== "underneath")
                         ? markers
                         : null}
-                    <VictoryLine style={seriesStyle?.line} data={dataPoints} interpolation={interpolation} />
-                    {markers && seriesStyle?.markers?.display === "onTop" ? markers : null}
                 </VictoryGroup>
             );
         });

--- a/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
+++ b/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
@@ -87,47 +87,49 @@ export function LineChart(props: LineChartProps): ReactElement | null {
             {dataTypesResult instanceof Error ? (
                 <Text>{dataTypesResult.message}</Text>
             ) : (
-                <View style={{ ...style.chart, flex: 1 }}>
-                    <View style={{ ...style.gridLabelWrapper, flex: 1 }}>
-                        {yAxisLabel ? <Text style={style.yAxisLabel}>{yAxisLabel}</Text> : null}
+                <View style={style.chart}>
+                    <View style={style.gridLabelCol}>
+                        <View style={style.gridRow}>
+                            {yAxisLabel ? <Text style={style.yAxisLabel}>{yAxisLabel}</Text> : null}
 
-                        <View onLayout={updateChartDimensions} style={{ flex: 1 }}>
-                            {chartDimensions ? (
-                                <VictoryChart
-                                    height={chartDimensions?.height}
-                                    width={chartDimensions?.width}
-                                    padding={style.grid?.padding}
-                                    scale={
-                                        dataTypesResult
-                                            ? {
-                                                  x: dataTypesResult.x === "number" ? "linear" : "time",
-                                                  y: dataTypesResult.y === "number" ? "linear" : "time"
-                                              }
-                                            : undefined
-                                    }
-                                    style={style.grid}
-                                >
-                                    <VictoryAxis
-                                        style={style.grid?.xAxis}
-                                        orientation={"bottom"}
-                                        {...(firstSeries?.xFormatter
-                                            ? { tickFormat: firstSeries.xFormatter }
-                                            : undefined)}
-                                    />
-                                    <VictoryAxis
-                                        dependentAxis
-                                        style={style.grid?.yAxis}
-                                        orientation={"left"}
-                                        {...(firstSeries.yFormatter
-                                            ? { tickFormat: firstSeries.yFormatter }
-                                            : undefined)}
-                                    />
-                                    {chartLines}
-                                </VictoryChart>
-                            ) : null}
+                            <View onLayout={updateChartDimensions} style={{ flex: 1 }}>
+                                {chartDimensions ? (
+                                    <VictoryChart
+                                        height={chartDimensions?.height}
+                                        width={chartDimensions?.width}
+                                        padding={style.grid?.padding}
+                                        scale={
+                                            dataTypesResult
+                                                ? {
+                                                      x: dataTypesResult.x === "number" ? "linear" : "time",
+                                                      y: dataTypesResult.y === "number" ? "linear" : "time"
+                                                  }
+                                                : undefined
+                                        }
+                                        style={style.grid}
+                                    >
+                                        <VictoryAxis
+                                            style={style.grid?.xAxis}
+                                            orientation={"bottom"}
+                                            {...(firstSeries?.xFormatter
+                                                ? { tickFormat: firstSeries.xFormatter }
+                                                : undefined)}
+                                        />
+                                        <VictoryAxis
+                                            dependentAxis
+                                            style={style.grid?.yAxis}
+                                            orientation={"left"}
+                                            {...(firstSeries.yFormatter
+                                                ? { tickFormat: firstSeries.yFormatter }
+                                                : undefined)}
+                                        />
+                                        {chartLines}
+                                    </VictoryChart>
+                                ) : null}
+                            </View>
+
+                            {xAxisLabel ? <Text style={style.xAxisLabel}>{xAxisLabel}</Text> : null}
                         </View>
-
-                        {xAxisLabel ? <Text style={style.xAxisLabel}>{xAxisLabel}</Text> : null}
                     </View>
 
                     {showLegend ? <Legend style={style} series={series} /> : null}

--- a/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
+++ b/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
@@ -1,4 +1,4 @@
-import { createElement, ReactElement, useMemo, useCallback, useState, Fragment } from "react";
+import { createElement, ReactElement, useMemo, useCallback, useState } from "react";
 import { View, LayoutChangeEvent, Text } from "react-native";
 import { InterpolationPropType } from "victory-core";
 import { VictoryChart, VictoryLine, VictoryGroup, VictoryScatter, VictoryAxis } from "victory-native";
@@ -87,43 +87,51 @@ export function LineChart(props: LineChartProps): ReactElement | null {
             {dataTypesResult instanceof Error ? (
                 <Text>{dataTypesResult.message}</Text>
             ) : (
-                <Fragment>
-                    <View onLayout={updateChartDimensions} style={{ flex: 1 }}>
-                        {chartDimensions ? (
-                            <VictoryChart
-                                height={chartDimensions?.height}
-                                width={chartDimensions?.width}
-                                padding={style.chart?.padding}
-                                scale={
-                                    dataTypesResult
-                                        ? {
-                                              x: dataTypesResult.x === "number" ? "linear" : "time",
-                                              y: dataTypesResult.y === "number" ? "linear" : "time"
-                                          }
-                                        : undefined
-                                }
-                                style={style.chart}
-                            >
-                                <VictoryAxis
-                                    style={style.xAxis}
-                                    orientation={"bottom"}
-                                    {...(firstSeries?.xFormatter ? { tickFormat: firstSeries.xFormatter } : undefined)}
-                                />
-                                <VictoryAxis
-                                    dependentAxis
-                                    style={style.yAxis}
-                                    orientation={"left"}
-                                    {...(firstSeries.yFormatter ? { tickFormat: firstSeries.yFormatter } : undefined)}
-                                />
-                                {chartLines}
-                            </VictoryChart>
-                        ) : null}
+                <View style={{ ...style.chart, flex: 1 }}>
+                    <View style={{ ...style.gridLabelWrapper, flex: 1 }}>
+                        {yAxisLabel ? <Text style={style.yAxisLabel}>{yAxisLabel}</Text> : null}
+
+                        <View onLayout={updateChartDimensions} style={{ flex: 1 }}>
+                            {chartDimensions ? (
+                                <VictoryChart
+                                    height={chartDimensions?.height}
+                                    width={chartDimensions?.width}
+                                    padding={style.grid?.padding}
+                                    scale={
+                                        dataTypesResult
+                                            ? {
+                                                  x: dataTypesResult.x === "number" ? "linear" : "time",
+                                                  y: dataTypesResult.y === "number" ? "linear" : "time"
+                                              }
+                                            : undefined
+                                    }
+                                    style={style.grid}
+                                >
+                                    <VictoryAxis
+                                        style={style.grid?.xAxis}
+                                        orientation={"bottom"}
+                                        {...(firstSeries?.xFormatter
+                                            ? { tickFormat: firstSeries.xFormatter }
+                                            : undefined)}
+                                    />
+                                    <VictoryAxis
+                                        dependentAxis
+                                        style={style.grid?.yAxis}
+                                        orientation={"left"}
+                                        {...(firstSeries.yFormatter
+                                            ? { tickFormat: firstSeries.yFormatter }
+                                            : undefined)}
+                                    />
+                                    {chartLines}
+                                </VictoryChart>
+                            ) : null}
+                        </View>
+
+                        {xAxisLabel ? <Text style={style.xAxisLabel}>{xAxisLabel}</Text> : null}
                     </View>
 
-                    {xAxisLabel ? <Text>{xAxisLabel}</Text> : null}
-                    {yAxisLabel ? <Text>{yAxisLabel}</Text> : null}
                     {showLegend ? <Legend style={style} series={series} /> : null}
-                </Fragment>
+                </View>
             )}
         </View>
     );

--- a/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
+++ b/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
@@ -72,6 +72,29 @@ export function LineChart(props: LineChartProps): ReactElement | null {
 
     const [firstSeries] = series;
 
+    let xAxisLabelStyle;
+    let yAxisLabelStyle;
+    let xAxisLabelRelativePositionGrid;
+    let yAxisLabelRelativePositionGrid;
+
+    if (style.xAxisLabel?.relativePositionGrid) {
+        const { relativePositionGrid: _xAxisLabelRelativePositionGrid, ..._xAxisLabelStyle } = style.xAxisLabel;
+        xAxisLabelStyle = _xAxisLabelStyle;
+        xAxisLabelRelativePositionGrid = _xAxisLabelRelativePositionGrid;
+    } else {
+        xAxisLabelStyle = style.xAxisLabel;
+        xAxisLabelRelativePositionGrid = "bottom";
+    }
+
+    if (style.yAxisLabel?.relativePositionGrid) {
+        const { relativePositionGrid: _yAxisLabelRelativePositionGrid, ..._yAxisLabelStyle } = style.yAxisLabel;
+        yAxisLabelStyle = _yAxisLabelStyle;
+        yAxisLabelRelativePositionGrid = _yAxisLabelRelativePositionGrid;
+    } else {
+        yAxisLabelStyle = style.yAxisLabel;
+        yAxisLabelRelativePositionGrid = "top";
+    }
+
     const [chartDimensions, setChartDimensions] = useState<{ height: number; width: number }>();
 
     const updateChartDimensions = useCallback(
@@ -89,12 +112,12 @@ export function LineChart(props: LineChartProps): ReactElement | null {
             ) : (
                 <View style={style.chart}>
                     <View style={style.gridLabelCol}>
-                        {yAxisLabel && style.yAxisLabel?.relativePositionGrid === "top" ? (
-                            <Text style={style.yAxisLabel}>{yAxisLabel}</Text>
+                        {yAxisLabel && yAxisLabelRelativePositionGrid === "top" ? (
+                            <Text style={yAxisLabelStyle}>{yAxisLabel}</Text>
                         ) : null}
                         <View style={style.gridRow}>
-                            {yAxisLabel && style.yAxisLabel?.relativePositionGrid === "left" ? (
-                                <Text style={style.yAxisLabel}>{yAxisLabel}</Text>
+                            {yAxisLabel && yAxisLabelRelativePositionGrid === "left" ? (
+                                <Text style={yAxisLabelStyle}>{yAxisLabel}</Text>
                             ) : null}
 
                             <View onLayout={updateChartDimensions} style={{ flex: 1 }}>
@@ -133,12 +156,12 @@ export function LineChart(props: LineChartProps): ReactElement | null {
                                 ) : null}
                             </View>
 
-                            {xAxisLabel && style.xAxisLabel?.relativePositionGrid === "right" ? (
-                                <Text style={style.xAxisLabel}>{xAxisLabel}</Text>
+                            {xAxisLabel && xAxisLabelRelativePositionGrid === "right" ? (
+                                <Text style={xAxisLabelStyle}>{xAxisLabel}</Text>
                             ) : null}
                         </View>
-                        {xAxisLabel && style.xAxisLabel?.relativePositionGrid === "bottom" ? (
-                            <Text style={style.xAxisLabel}>{xAxisLabel}</Text>
+                        {xAxisLabel && xAxisLabelRelativePositionGrid === "bottom" ? (
+                            <Text style={xAxisLabelStyle}>{xAxisLabel}</Text>
                         ) : null}
                     </View>
 

--- a/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
+++ b/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
@@ -52,6 +52,19 @@ export function LineChart(props: LineChartProps): ReactElement | null {
 
             const seriesStyle = style.series && stylePropertyName ? style.series[stylePropertyName] : undefined;
 
+            const displayMarker = seriesStyle?.markers?.display;
+
+            if (
+                displayMarker !== undefined &&
+                !(displayMarker === "false" || displayMarker === "underneath" || displayMarker === "onTop")
+            ) {
+                console.warn(
+                    `${
+                        warningPrefix ? warningPrefix + "i" : "I"
+                    }nvalid value for series marker style property, display, valid values are "false", "underneath" and "onTop".`
+                );
+            }
+
             const markers =
                 lineStyle === "lineWithMarkers" ||
                 (lineStyle === "custom" && seriesStyle?.markers?.display && seriesStyle.markers.display !== "false") ? (
@@ -88,7 +101,7 @@ export function LineChart(props: LineChartProps): ReactElement | null {
                 console.warn(
                     `${
                         warningPrefix ? warningPrefix + "i" : "I"
-                    }nvalid value for x axis label style property, relativePositionGrid, valid values are "bottom" and "right".`
+                    }nvalid value for X axis label style property, relativePositionGrid, valid values are "bottom" and "right".`
                 );
             }
 
@@ -105,7 +118,7 @@ export function LineChart(props: LineChartProps): ReactElement | null {
                 console.warn(
                     `${
                         warningPrefix ? warningPrefix + "i" : "I"
-                    }nvalid value for y axis label style property, relativePositionGrid, valid values are "top" and "left".`
+                    }nvalid value for Y axis label style property, relativePositionGrid, valid values are "top" and "left".`
                 );
             }
 

--- a/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
+++ b/packages/pluggableWidgets/line-chart-native/src/components/LineChart.tsx
@@ -2,6 +2,7 @@ import { createElement, ReactElement, useMemo, useCallback, useState } from "rea
 import { View, LayoutChangeEvent, Text } from "react-native";
 import { InterpolationPropType } from "victory-core";
 import { VictoryChart, VictoryLine, VictoryGroup, VictoryScatter, VictoryAxis } from "victory-native";
+import { extractStyles } from "@mendix/pluggable-widgets-tools";
 
 import { LineChartStyle } from "../ui/Styles";
 import { Legend } from "./Legend";
@@ -72,28 +73,19 @@ export function LineChart(props: LineChartProps): ReactElement | null {
 
     const [firstSeries] = series;
 
-    let xAxisLabelStyle;
-    let yAxisLabelStyle;
-    let xAxisLabelRelativePositionGrid;
-    let yAxisLabelRelativePositionGrid;
+    const [extractedXAxisLabelStyle, xAxisLabelStyle] = extractStyles(style.xAxisLabel, ["relativePositionGrid"]);
+    const [extractedYAxisLabelStyle, yAxisLabelStyle] = extractStyles(style.yAxisLabel, ["relativePositionGrid"]);
 
-    if (style.xAxisLabel?.relativePositionGrid) {
-        const { relativePositionGrid: _xAxisLabelRelativePositionGrid, ..._xAxisLabelStyle } = style.xAxisLabel;
-        xAxisLabelStyle = _xAxisLabelStyle;
-        xAxisLabelRelativePositionGrid = _xAxisLabelRelativePositionGrid;
-    } else {
-        xAxisLabelStyle = style.xAxisLabel;
-        xAxisLabelRelativePositionGrid = "bottom";
+    if (!extractedXAxisLabelStyle.relativePositionGrid) {
+        extractedXAxisLabelStyle.relativePositionGrid = "bottom";
     }
 
-    if (style.yAxisLabel?.relativePositionGrid) {
-        const { relativePositionGrid: _yAxisLabelRelativePositionGrid, ..._yAxisLabelStyle } = style.yAxisLabel;
-        yAxisLabelStyle = _yAxisLabelStyle;
-        yAxisLabelRelativePositionGrid = _yAxisLabelRelativePositionGrid;
-    } else {
-        yAxisLabelStyle = style.yAxisLabel;
-        yAxisLabelRelativePositionGrid = "top";
+    if (!extractedYAxisLabelStyle.relativePositionGrid) {
+        extractedYAxisLabelStyle.relativePositionGrid = "top";
     }
+
+    const xAxisLabelComponent = xAxisLabel ? <Text style={xAxisLabelStyle}>{xAxisLabel}</Text> : null;
+    const yAxisLabelComponent = yAxisLabel ? <Text style={yAxisLabelStyle}>{yAxisLabel}</Text> : null;
 
     const [chartDimensions, setChartDimensions] = useState<{ height: number; width: number }>();
 
@@ -112,13 +104,9 @@ export function LineChart(props: LineChartProps): ReactElement | null {
             ) : (
                 <View style={style.chart}>
                     <View style={style.gridAndLabelsRow}>
-                        {yAxisLabel && yAxisLabelRelativePositionGrid === "top" ? (
-                            <Text style={yAxisLabelStyle}>{yAxisLabel}</Text>
-                        ) : null}
+                        {extractedYAxisLabelStyle.relativePositionGrid === "top" ? yAxisLabelComponent : null}
                         <View style={style.gridRow}>
-                            {yAxisLabel && yAxisLabelRelativePositionGrid === "left" ? (
-                                <Text style={yAxisLabelStyle}>{yAxisLabel}</Text>
-                            ) : null}
+                            {extractedYAxisLabelStyle.relativePositionGrid === "left" ? yAxisLabelComponent : null}
 
                             <View onLayout={updateChartDimensions} style={{ flex: 1 }}>
                                 {chartDimensions ? (
@@ -156,13 +144,9 @@ export function LineChart(props: LineChartProps): ReactElement | null {
                                 ) : null}
                             </View>
 
-                            {xAxisLabel && xAxisLabelRelativePositionGrid === "right" ? (
-                                <Text style={xAxisLabelStyle}>{xAxisLabel}</Text>
-                            ) : null}
+                            {extractedXAxisLabelStyle.relativePositionGrid === "right" ? xAxisLabelComponent : null}
                         </View>
-                        {xAxisLabel && xAxisLabelRelativePositionGrid === "bottom" ? (
-                            <Text style={xAxisLabelStyle}>{xAxisLabel}</Text>
-                        ) : null}
+                        {extractedXAxisLabelStyle.relativePositionGrid === "bottom" ? xAxisLabelComponent : null}
                     </View>
 
                     {showLegend ? <Legend style={style} series={series} /> : null}

--- a/packages/pluggableWidgets/line-chart-native/src/ui/Styles.ts
+++ b/packages/pluggableWidgets/line-chart-native/src/ui/Styles.ts
@@ -53,12 +53,6 @@ export const defaultLineChartStyle: LineChartStyle = {
         flex: 1,
         flexDirection: "row"
     },
-    xAxisLabel: {
-        relativePositionGrid: "bottom"
-    },
-    yAxisLabel: {
-        relativePositionGrid: "top"
-    },
     legend: {
         container: {
             borderColor: "black",

--- a/packages/pluggableWidgets/line-chart-native/src/ui/Styles.ts
+++ b/packages/pluggableWidgets/line-chart-native/src/ui/Styles.ts
@@ -22,7 +22,8 @@ export interface LineChartSeriesStyle {
 export interface LineChartStyle {
     container?: ViewStyle;
     chart?: ViewStyle;
-    gridLabelWrapper?: ViewStyle;
+    gridLabelCol?: ViewStyle;
+    gridRow?: ViewStyle;
     grid?: VictoryChartProps["style"] & {
         padding?: VictoryCommonProps["padding"];
         xAxis?: VictoryAxisCommonProps["style"];
@@ -38,14 +39,16 @@ export const defaultLineChartStyle: LineChartStyle = {
     container: {
         flex: 1
     },
-    chart: {},
-    gridLabelWrapper: {
+    chart: {
+        flex: 1
+    },
+    gridLabelCol: {
+        flex: 1
+    },
+    gridRow: {
+        flex: 1,
         flexDirection: "row"
     },
-    xAxisLabel: {
-        // alignSelf: "center"
-    },
-    yAxisLabel: {},
     legend: {
         container: {
             borderColor: "black",

--- a/packages/pluggableWidgets/line-chart-native/src/ui/Styles.ts
+++ b/packages/pluggableWidgets/line-chart-native/src/ui/Styles.ts
@@ -29,8 +29,12 @@ export interface LineChartStyle {
         xAxis?: VictoryAxisCommonProps["style"];
         yAxis?: VictoryAxisCommonProps["style"];
     };
-    xAxisLabel?: TextStyle;
-    yAxisLabel?: TextStyle;
+    xAxisLabel?: TextStyle & {
+        relativePositionGrid?: "bottom" | "right";
+    };
+    yAxisLabel?: TextStyle & {
+        relativePositionGrid?: "top" | "left";
+    };
     legend?: LineChartLegendStyle;
     series?: { [key: string]: LineChartSeriesStyle };
 }
@@ -48,6 +52,12 @@ export const defaultLineChartStyle: LineChartStyle = {
     gridRow: {
         flex: 1,
         flexDirection: "row"
+    },
+    xAxisLabel: {
+        relativePositionGrid: "bottom"
+    },
+    yAxisLabel: {
+        relativePositionGrid: "top"
     },
     legend: {
         container: {
@@ -68,8 +78,5 @@ export const defaultLineChartStyle: LineChartStyle = {
             height: 5,
             width: 10
         }
-    },
-    grid: {
-        padding: { left: 75, top: 25, bottom: 50, right: 25 }
     }
 };

--- a/packages/pluggableWidgets/line-chart-native/src/ui/Styles.ts
+++ b/packages/pluggableWidgets/line-chart-native/src/ui/Styles.ts
@@ -21,14 +21,16 @@ export interface LineChartSeriesStyle {
 
 export interface LineChartStyle {
     container?: ViewStyle;
+    chart?: ViewStyle;
+    gridLabelWrapper?: ViewStyle;
+    grid?: VictoryChartProps["style"] & {
+        padding?: VictoryCommonProps["padding"];
+        xAxis?: VictoryAxisCommonProps["style"];
+        yAxis?: VictoryAxisCommonProps["style"];
+    };
+    xAxisLabel?: TextStyle;
+    yAxisLabel?: TextStyle;
     legend?: LineChartLegendStyle;
-    chart?: VictoryChartProps["style"] & { padding?: VictoryCommonProps["padding"] };
-    xAxis?: VictoryAxisCommonProps["style"] & {
-        axisLabel?: TextStyle;
-    };
-    yAxis?: VictoryAxisCommonProps["style"] & {
-        axisLabel?: TextStyle;
-    };
     series?: { [key: string]: LineChartSeriesStyle };
 }
 
@@ -36,6 +38,14 @@ export const defaultLineChartStyle: LineChartStyle = {
     container: {
         flex: 1
     },
+    chart: {},
+    gridLabelWrapper: {
+        flexDirection: "row"
+    },
+    xAxisLabel: {
+        // alignSelf: "center"
+    },
+    yAxisLabel: {},
     legend: {
         container: {
             borderColor: "black",
@@ -56,13 +66,7 @@ export const defaultLineChartStyle: LineChartStyle = {
             width: 10
         }
     },
-    chart: {
+    grid: {
         padding: { left: 75, top: 25, bottom: 50, right: 25 }
-    },
-    xAxis: {
-        // axisLabel: { verticalOffset: 10 }
-    },
-    yAxis: {
-        // axisLabel: { horizontalOffset: -10 }
     }
 };

--- a/packages/pluggableWidgets/line-chart-native/src/ui/Styles.ts
+++ b/packages/pluggableWidgets/line-chart-native/src/ui/Styles.ts
@@ -22,7 +22,7 @@ export interface LineChartSeriesStyle {
 export interface LineChartStyle {
     container?: ViewStyle;
     chart?: ViewStyle;
-    gridLabelCol?: ViewStyle;
+    gridAndLabelsRow?: ViewStyle;
     gridRow?: ViewStyle;
     grid?: VictoryChartProps["style"] & {
         padding?: VictoryCommonProps["padding"];
@@ -46,7 +46,7 @@ export const defaultLineChartStyle: LineChartStyle = {
     chart: {
         flex: 1
     },
-    gridLabelCol: {
+    gridAndLabelsRow: {
         flex: 1
     },
     gridRow: {

--- a/packages/pluggableWidgets/line-chart-native/src/ui/Styles.ts
+++ b/packages/pluggableWidgets/line-chart-native/src/ui/Styles.ts
@@ -1,6 +1,6 @@
 import { TextStyle, ViewStyle } from "react-native";
 import { VictoryChartProps } from "victory-chart";
-import { VictoryAxisCommonProps, VictoryCommonProps, VictoryLabelProps } from "victory-core";
+import { VictoryAxisCommonProps, VictoryCommonProps } from "victory-core";
 import { VictoryLineProps } from "victory-line";
 import { VictoryScatterProps } from "victory-scatter";
 
@@ -24,10 +24,10 @@ export interface LineChartStyle {
     legend?: LineChartLegendStyle;
     chart?: VictoryChartProps["style"] & { padding?: VictoryCommonProps["padding"] };
     xAxis?: VictoryAxisCommonProps["style"] & {
-        axisLabel?: { horizontalOffset?: VictoryLabelProps["dx"]; verticalOffset?: VictoryLabelProps["dy"] };
+        axisLabel?: TextStyle;
     };
     yAxis?: VictoryAxisCommonProps["style"] & {
-        axisLabel?: { horizontalOffset?: VictoryLabelProps["dy"]; verticalOffset?: VictoryLabelProps["dx"] };
+        axisLabel?: TextStyle;
     };
     series?: { [key: string]: LineChartSeriesStyle };
 }
@@ -60,9 +60,9 @@ export const defaultLineChartStyle: LineChartStyle = {
         padding: { left: 75, top: 25, bottom: 50, right: 25 }
     },
     xAxis: {
-        axisLabel: { verticalOffset: 10 }
+        // axisLabel: { verticalOffset: 10 }
     },
     yAxis: {
-        axisLabel: { horizontalOffset: -10 }
+        // axisLabel: { horizontalOffset: -10 }
     }
 };


### PR DESCRIPTION
### Why
The axis label functionality of Victory JS is to limited with regard to positioning and flexibel grid resizing.

### What has been done
- Separate labels as RN `Text` components
- Restructure RN `View` components to facilitate flexible label positioning
- Add style property `positionRelativeToGrid` to `xAxisLabel` and `yAxisLabel` (both `TextStyle`). `xAxisLabel` has positions `bottom` (default) and `right`, `yAxisLabel` has `top` (default) and `left`.
- Add warning for invalid `positionRelativeToGrid` label style property and `display` marker style property.

Bonus:
- Render markerts by default on top

### How to test
- Adjust the styling related to labels to see it's capabilities.