### PR TITLE
Fixing DG custom settings

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
@@ -170,6 +170,61 @@ describe("useSettings Hook", () => {
             ])
         );
     });
+
+    it("doesnt change the settings when same properties are applied", () => {
+        const props = mockProperties();
+        const initialProps = {
+            settings: props.settings,
+            columns: props.columns,
+            columnOrder: ["0"],
+            setColumnOrder: props.setColumnOrder,
+            hiddenColumns: [],
+            setHiddenColumns: props.setHiddenColumns,
+            sortBy: [{ id: "0", desc: true }],
+            setSortBy: props.setSortBy,
+            filters: [{ id: "0", value: "ABC" }],
+            setFilters: props.setFilters,
+            widths: { "0": undefined } as ColumnWidth,
+            setWidths: props.setWidths
+        };
+
+        const { rerender } = renderHook(
+            ({
+                settings,
+                columns,
+                columnOrder,
+                setColumnOrder,
+                hiddenColumns,
+                setHiddenColumns,
+                sortBy,
+                setSortBy,
+                filters,
+                setFilters,
+                widths,
+                setWidths
+            }) =>
+                useSettings(
+                    settings,
+                    columns,
+                    columnOrder,
+                    setColumnOrder,
+                    hiddenColumns,
+                    setHiddenColumns,
+                    sortBy,
+                    setSortBy,
+                    filters,
+                    setFilters,
+                    widths,
+                    setWidths
+                ),
+            {
+                initialProps
+            }
+        );
+        expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+        rerender(initialProps);
+        expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+    });
 });
 
 function mockProperties(): any {

--- a/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
@@ -94,52 +94,20 @@ describe("useSettings Hook", () => {
     it("changes the settings when some property changes", () => {
         const props = mockProperties();
 
-        const { rerender } = renderHook(
-            ({
-                settings,
-                columns,
-                columnOrder,
-                setColumnOrder,
-                hiddenColumns,
-                setHiddenColumns,
-                sortBy,
-                setSortBy,
-                filters,
-                setFilters,
-                widths,
-                setWidths
-            }) =>
-                useSettings(
-                    settings,
-                    columns,
-                    columnOrder,
-                    setColumnOrder,
-                    hiddenColumns,
-                    setHiddenColumns,
-                    sortBy,
-                    setSortBy,
-                    filters,
-                    setFilters,
-                    widths,
-                    setWidths
-                ),
-            {
-                initialProps: {
-                    settings: props.settings,
-                    columns: props.columns,
-                    columnOrder: ["0"],
-                    setColumnOrder: props.setColumnOrder,
-                    hiddenColumns: [],
-                    setHiddenColumns: props.setHiddenColumns,
-                    sortBy: [{ id: "0", desc: true }],
-                    setSortBy: props.setSortBy,
-                    filters: [{ id: "0", value: "ABC" }],
-                    setFilters: props.setFilters,
-                    widths: { "0": undefined } as ColumnWidth,
-                    setWidths: props.setWidths
-                }
-            }
-        );
+        const { rerender } = renderUseSettingsHook({
+            settings: props.settings,
+            columns: props.columns,
+            columnOrder: ["0"],
+            setColumnOrder: props.setColumnOrder,
+            hiddenColumns: [],
+            setHiddenColumns: props.setHiddenColumns,
+            sortBy: [{ id: "0", desc: true }],
+            setSortBy: props.setSortBy,
+            filters: [{ id: "0", value: "ABC" }],
+            setFilters: props.setFilters,
+            widths: { "0": undefined } as ColumnWidth,
+            setWidths: props.setWidths
+        });
         expect(props.settings.setValue).toHaveBeenCalledTimes(0);
         rerender({
             settings: props.settings,
@@ -188,39 +156,7 @@ describe("useSettings Hook", () => {
             setWidths: props.setWidths
         };
 
-        const { rerender } = renderHook(
-            ({
-                settings,
-                columns,
-                columnOrder,
-                setColumnOrder,
-                hiddenColumns,
-                setHiddenColumns,
-                sortBy,
-                setSortBy,
-                filters,
-                setFilters,
-                widths,
-                setWidths
-            }) =>
-                useSettings(
-                    settings,
-                    columns,
-                    columnOrder,
-                    setColumnOrder,
-                    hiddenColumns,
-                    setHiddenColumns,
-                    sortBy,
-                    setSortBy,
-                    filters,
-                    setFilters,
-                    widths,
-                    setWidths
-                ),
-            {
-                initialProps
-            }
-        );
+        const { rerender } = renderUseSettingsHook(initialProps);
         expect(props.settings.setValue).toHaveBeenCalledTimes(0);
         rerender(initialProps);
         expect(props.settings.setValue).toHaveBeenCalledTimes(0);
@@ -243,39 +179,7 @@ describe("useSettings Hook", () => {
             setWidths: props.setWidths
         };
 
-        const { rerender } = renderHook(
-            ({
-                settings,
-                columns,
-                columnOrder,
-                setColumnOrder,
-                hiddenColumns,
-                setHiddenColumns,
-                sortBy,
-                setSortBy,
-                filters,
-                setFilters,
-                widths,
-                setWidths
-            }) =>
-                useSettings(
-                    settings,
-                    columns,
-                    columnOrder,
-                    setColumnOrder,
-                    hiddenColumns,
-                    setHiddenColumns,
-                    sortBy,
-                    setSortBy,
-                    filters,
-                    setFilters,
-                    widths,
-                    setWidths
-                ),
-            {
-                initialProps
-            }
-        );
+        const { rerender } = renderUseSettingsHook(initialProps);
         // Initiates the hooks with values from settings once
         expect(props.setColumnOrder).toHaveBeenCalledTimes(1);
         expect(props.setHiddenColumns).toHaveBeenCalledTimes(1);
@@ -296,39 +200,7 @@ describe("useSettings Hook", () => {
         const props = mockProperties();
         props.settings = new EditableValueBuilder<string>().withValue("").build();
 
-        const { rerender } = renderHook(
-            ({
-                settings,
-                columns,
-                columnOrder,
-                setColumnOrder,
-                hiddenColumns,
-                setHiddenColumns,
-                sortBy,
-                setSortBy,
-                filters,
-                setFilters,
-                widths,
-                setWidths
-            }) =>
-                useSettings(
-                    settings,
-                    columns,
-                    columnOrder,
-                    setColumnOrder,
-                    hiddenColumns,
-                    setHiddenColumns,
-                    sortBy,
-                    setSortBy,
-                    filters,
-                    setFilters,
-                    widths,
-                    setWidths
-                ),
-            {
-                initialProps: props
-            }
-        );
+        const { rerender } = renderUseSettingsHook(props);
         expect(props.settings.setValue).toHaveBeenCalledTimes(1);
         expect(props.settings.setValue).toHaveBeenCalledWith(
             JSON.stringify([
@@ -381,4 +253,53 @@ function mockProperties(): any {
         widths: { "0": undefined },
         setWidths: jest.fn()
     };
+}
+
+function renderUseSettingsHook(initialProps: {
+    settings: any;
+    hiddenColumns: any[];
+    columnOrder: string[];
+    columns: any;
+    setFilters: any;
+    setHiddenColumns: any;
+    sortBy: Array<{ id: string; desc: boolean }>;
+    widths: ColumnWidth;
+    filters: Array<{ id: string; value: string }>;
+    setSortBy: any;
+    setWidths: any;
+    setColumnOrder: any;
+}) {
+    return renderHook(
+        ({
+            settings,
+            columns,
+            columnOrder,
+            setColumnOrder,
+            hiddenColumns,
+            setHiddenColumns,
+            sortBy,
+            setSortBy,
+            filters,
+            setFilters,
+            widths,
+            setWidths
+        }) =>
+            useSettings(
+                settings,
+                columns,
+                columnOrder,
+                setColumnOrder,
+                hiddenColumns,
+                setHiddenColumns,
+                sortBy,
+                setSortBy,
+                filters,
+                setFilters,
+                widths,
+                setWidths
+            ),
+        {
+            initialProps
+        }
+    );
 }

--- a/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
@@ -225,6 +225,126 @@ describe("useSettings Hook", () => {
         rerender(initialProps);
         expect(props.settings.setValue).toHaveBeenCalledTimes(0);
     });
+
+    it("doesnt change the hooks when same properties are applied", () => {
+        const props = mockProperties();
+        const initialProps = {
+            settings: props.settings,
+            columns: props.columns,
+            columnOrder: ["0"],
+            setColumnOrder: props.setColumnOrder,
+            hiddenColumns: [],
+            setHiddenColumns: props.setHiddenColumns,
+            sortBy: [{ id: "0", desc: true }],
+            setSortBy: props.setSortBy,
+            filters: [{ id: "0", value: "ABC" }],
+            setFilters: props.setFilters,
+            widths: { "0": undefined } as ColumnWidth,
+            setWidths: props.setWidths
+        };
+
+        const { rerender } = renderHook(
+            ({
+                settings,
+                columns,
+                columnOrder,
+                setColumnOrder,
+                hiddenColumns,
+                setHiddenColumns,
+                sortBy,
+                setSortBy,
+                filters,
+                setFilters,
+                widths,
+                setWidths
+            }) =>
+                useSettings(
+                    settings,
+                    columns,
+                    columnOrder,
+                    setColumnOrder,
+                    hiddenColumns,
+                    setHiddenColumns,
+                    sortBy,
+                    setSortBy,
+                    filters,
+                    setFilters,
+                    widths,
+                    setWidths
+                ),
+            {
+                initialProps
+            }
+        );
+        // Initiates the hooks with values from settings once
+        expect(props.setColumnOrder).toHaveBeenCalledTimes(1);
+        expect(props.setHiddenColumns).toHaveBeenCalledTimes(1);
+        expect(props.setSortBy).toHaveBeenCalledTimes(1);
+        expect(props.setFilters).toHaveBeenCalledTimes(1);
+        expect(props.setWidths).toHaveBeenCalledTimes(1);
+        expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+        rerender(initialProps);
+        expect(props.setColumnOrder).toHaveBeenCalledTimes(1);
+        expect(props.setHiddenColumns).toHaveBeenCalledTimes(1);
+        expect(props.setSortBy).toHaveBeenCalledTimes(1);
+        expect(props.setFilters).toHaveBeenCalledTimes(1);
+        expect(props.setWidths).toHaveBeenCalledTimes(1);
+        expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+    });
+
+    it("applies changes to settings when receiving external prop changes", () => {
+        const props = mockProperties();
+        props.settings = new EditableValueBuilder<string>().withValue("").build();
+
+        const { rerender } = renderHook(
+            ({
+                settings,
+                columns,
+                columnOrder,
+                setColumnOrder,
+                hiddenColumns,
+                setHiddenColumns,
+                sortBy,
+                setSortBy,
+                filters,
+                setFilters,
+                widths,
+                setWidths
+            }) =>
+                useSettings(
+                    settings,
+                    columns,
+                    columnOrder,
+                    setColumnOrder,
+                    hiddenColumns,
+                    setHiddenColumns,
+                    sortBy,
+                    setSortBy,
+                    filters,
+                    setFilters,
+                    widths,
+                    setWidths
+                ),
+            {
+                initialProps: props
+            }
+        );
+        expect(props.settings.setValue).toHaveBeenCalledTimes(1);
+        expect(props.settings.setValue).toHaveBeenCalledWith(
+            JSON.stringify([
+                { column: "Column 1", sort: false, sortMethod: "asc", filter: "", hidden: false, order: 0 }
+            ])
+        );
+        rerender({ ...props, sortBy: [{ id: "0", desc: true }] });
+        expect(props.settings.setValue).toHaveBeenCalledTimes(2);
+        expect(props.settings.setValue).toHaveBeenCalledWith(
+            JSON.stringify([
+                { column: "Column 1", sort: true, sortMethod: "desc", filter: "", hidden: false, order: 0 }
+            ])
+        );
+        rerender({ ...props, sortBy: [{ id: "0", desc: true }] });
+        expect(props.settings.setValue).toHaveBeenCalledTimes(2);
+    });
 });
 
 function mockProperties(): any {


### PR DESCRIPTION
Why?
Currently we check if is the first load then load the settings, but in some cases users needs to change dynamically the settings.