### PR TITLE
fix: fixing rule to fetch master branch only if PR triggered it

### DIFF
--- a/.github/workflows/ScriptTests.yml
+++ b/.github/workflows/ScriptTests.yml
@@ -28,6 +28,7 @@ jobs:
               with:
                   submodules: false
             - name: "Fetching master to compare"
+              if: github.event_name == 'pull_request'
               run: git fetch --no-tags --prune --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
             - name: "Defining environment variables"
               if: startsWith(matrix.os, 'windows')

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -20,6 +20,7 @@ jobs:
               with:
                   submodules: false
             - name: "Fetching master to compare"
+              if: github.event_name == 'pull_request'
               run: git fetch --no-tags --prune --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
             - name: "Defining environment variables"
               id: variables

--- a/.github/workflows/WebAutomatedTests.yml
+++ b/.github/workflows/WebAutomatedTests.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           submodules: true
       - name: "Fetching master to compare"
+        if: github.event_name == 'pull_request'
         run: git fetch --no-tags --prune --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
       - name: "Defining environment variables"
         id: variables


### PR DESCRIPTION
In this PR I am:
Adding extra rule to only fetch target branch if is a PR (push should always execute full builds)