### PR TITLE
Fix/calendar event drop

### DIFF
--- a/packages/customWidgets/calendar-web/package.json
+++ b/packages/customWidgets/calendar-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar-web",
   "widgetName": "Calendar",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Display and manage calendar events",
   "copyright": "Mendix BV",
   "repository": {

--- a/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
+++ b/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
@@ -402,11 +402,13 @@ export default class CalendarContainer extends Component<Container.CalendarConta
         this.setState({ events: nextEvents });
         const mxEventObject = this.state.eventCache.filter(object => object.getGuid() === eventInfo.event.guid)[0];
         if (mxEventObject) {
-            mxEventObject.set(this.props.titleAttribute, eventInfo.event.title);
-            mxEventObject.set(this.props.eventColor, eventInfo.event.color);
-            mxEventObject.set(this.props.startAttribute, eventInfo.start);
-            mxEventObject.set(this.props.endAttribute, eventInfo.end);
-            this.executeOnDropAction(mxEventObject);
+            setTimeout(() => {
+                mxEventObject.set(this.props.titleAttribute, eventInfo.event.title);
+                mxEventObject.set(this.props.eventColor, eventInfo.event.color);
+                mxEventObject.set(this.props.startAttribute, eventInfo.start);
+                mxEventObject.set(this.props.endAttribute, eventInfo.end);
+                this.executeOnDropAction(mxEventObject);
+            }, 50);
         }
     };
 

--- a/packages/customWidgets/calendar-web/src/package.xml
+++ b/packages/customWidgets/calendar-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Calendar2" version="1.0.6" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Calendar2" version="1.0.7" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Calendar.xml"/>
         </widgetFiles>

--- a/packages/tools/utils-react-widgets/scripts/gulp.js
+++ b/packages/tools/utils-react-widgets/scripts/gulp.js
@@ -38,7 +38,7 @@ function getProjectPaths() {
     } else if (variables.package.config.testProjects) {
         return variables.package.config.testProjects.map(testProject => fixSlashes(checkPath(testProject.path)));
     }
-    return [fixSlashes(path.join(__dirname, `${variables.path}/tests/TestProject`))];
+    return [fixSlashes(`${variables.path}/tests/testProject`)];
 }
 function fixSlashes(tmpPath) {
     tmpPath = gulpSlash(tmpPath);


### PR DESCRIPTION
## What did I do ?

We fixed an issue where dragging events would break the draggable event functionality on calendar. Fixes: (Ticket [110911](https://mendixsupport.zendesk.com/agent/tickets/110911))

## How to test it ?

Get the project attached in the story (WT-2936), drag an event. This will result on blurred calendar which is a bug.

## Root cause

React big calendar DND has a fragile system where if there is a big time difference between dragging and dropping, it never removes the "rbc-addons-dnd-is-dragging". This can be tested by adding a breakpoint where the action is triggered and waiting couple of seconds.