### PR TITLE
[WT-2992] Data grid - Fix preview when no data is set

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
@@ -1,5 +1,5 @@
 import { createElement, ReactElement, useCallback } from "react";
-import { DatagridPreviewProps } from "../typings/DatagridProps";
+import { ColumnsPreviewType, DatagridPreviewProps } from "../typings/DatagridProps";
 
 import "./ui/Datagrid.scss";
 import { Table } from "./components/Table";
@@ -7,11 +7,31 @@ import { parseStyle } from "@widgets-resources/piw-utils";
 
 export function preview(props: DatagridPreviewProps): ReactElement {
     const data = Array.from({ length: props.pageSize ?? 5 }).map(() => ({}));
+    const columns: ColumnsPreviewType[] =
+        props.columns.length > 0
+            ? props.columns
+            : [
+                  {
+                      header: "Header",
+                      attribute: "{Attribute}",
+                      width: "autoFill",
+                      columnClass: "",
+                      filterable: "no",
+                      customFilter: { renderer: () => <div />, widgetCount: 0 },
+                      resizable: false,
+                      hasWidgets: false,
+                      content: { renderer: () => <div />, widgetCount: 0 },
+                      draggable: false,
+                      hidable: "no",
+                      size: 1,
+                      sortable: false
+                  }
+              ];
 
     return (
         <Table
             className={props.class}
-            columns={props.columns}
+            columns={columns}
             columnsDraggable={props.columnsDraggable}
             columnsFilterable={props.columnsFilterable}
             columnsHidable={props.columnsHidable}
@@ -37,7 +57,7 @@ export function preview(props: DatagridPreviewProps): ReactElement {
             styles={parseStyle(props.style)}
             cellRenderer={useCallback(
                 (renderWrapper, _, columnIndex) => {
-                    const column = props.columns[columnIndex];
+                    const column = columns[columnIndex];
                     return column.hasWidgets ? (
                         <column.content.renderer>{renderWrapper(null)}</column.content.renderer>
                     ) : (
@@ -51,8 +71,12 @@ export function preview(props: DatagridPreviewProps): ReactElement {
             filterMethod={props.filterMethod}
             filterRenderer={useCallback(
                 (renderWrapper, columnIndex) => {
-                    const column = props.columns[columnIndex];
-                    return <column.customFilter.renderer>{renderWrapper(null)}</column.customFilter.renderer>;
+                    const column = columns[columnIndex];
+                    return column.customFilter ? (
+                        <column.customFilter.renderer>{renderWrapper(null)}</column.customFilter.renderer>
+                    ) : (
+                        renderWrapper(null)
+                    );
                 },
                 [props.columns]
             )}


### PR DESCRIPTION
In this PR we are fixing the preview (Design mode) when a Data grid is dropped without any data.