### PR TITLE
[W] Data grid - Add on configuration change property

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -36,6 +36,10 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
         [props.datasource, props.pageSize, isInfiniteLoad, currentPage]
     );
 
+    const onConfigurationChange = useCallback(() => {
+        props.onConfigurationChange?.execute();
+    }, [props.onConfigurationChange]);
+
     const customFiltersState = props.columns.map(() => useState<FilterFunction>());
     const items = (props.datasource.items ?? []).filter(item =>
         customFiltersState.every(
@@ -95,6 +99,7 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
             paging={props.pagingEnabled}
             pagingPosition={props.pagingPosition}
             settings={props.configurationAttribute}
+            onSettingsChange={onConfigurationChange}
             setPage={setPage}
             styles={props.style}
             valueForSort={useCallback(

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -99,7 +99,7 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
             paging={props.pagingEnabled}
             pagingPosition={props.pagingPosition}
             settings={props.configurationAttribute}
-            onSettingsChange={onConfigurationChange}
+            onSettingsChange={props.onConfigurationChange ? onConfigurationChange : undefined}
             setPage={setPage}
             styles={props.style}
             valueForSort={useCallback(

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<widget id="com.mendix.widget.web.datagrid.Datagrid" pluginWidget="true" offlineCapable="true"
-        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../../node_modules/mendix/custom_widget.xsd">
+<widget id="com.mendix.widget.web.datagrid.Datagrid" pluginWidget="true" offlineCapable="true" xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../../node_modules/mendix/custom_widget.xsd">
     <name>Data grid 2</name>
     <description/>
     <icon>iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAQKADAAQAAAABAAAAQAAAAABGUUKwAAADXUlEQVR4Ae1aS2sUQRCeh+Ii/oIlwYs/ICieRLyIsAjxEPYh6EGUvXiWXFcQPQsSJaCehH3gJYgJwf+gNx9X9w8sHkwuM37d6e50ZmeWHnd2tjNdDbPVVf2qqv66u6Z3PI+S2x7wpfntdrsRRdE2+BUpqygdB0HQHQwGu8y+QBrpiPHM3BVhKzddOYAVcIkbP8pW3QFumJ6w8kyCV+xoNFL7gxIaZJrNZqxX+99+ZB9F9ZfsR/bvPALIARIKrlJCgKszL+0mBEhPuErVWZ91TlbVMTI+oSVQ1Rk2tct5BNC7gClUqlovEwG6wY2dg4YXxdt4zVPv0aL8d+D73c93ant6/dOUN9sD0o1ndq5Gccyu0U5tMkJAyswfG+z7SVQcl6XkZtw9nrirS2k6JcpCJoKbsRf43d31Gr/3m2qoCcwQoDWYNzvj7vHEXZ3ROBnI5BOGMpM+SneAiVJl1indAexKGgaOU4zkSyBFni0CzDncEzXkEkiIU1mjPYB1mLkPxHGaMamDMaG4j1/NrJCjQKzxufoyQ0CGp6ErPwZz6GxdVSMEFOFp6ywXCpkhwFbtC9DLCAFZ5y3Gp0iQIkGKBPMtRIoE8/lr4bVLPwUoEjz6MmOu6E3Cooj4xAwBFAny9+pCZk3Oni3UDAG2aLsAPSgSNHJqxs0L2tKdoEeRoBGGVCWKBJUr7MiUfgpQJEiRoB3Ql1oYxQFFxNxyQNto6XuAbQ7Alf9Rom+EpCcco/oSGDtku7JVOWDG+Vw1v+T/D7JqHiB7NA+oU0CTLTXbarU24jh+iSW5iX+SP4B/Df6qVMr3/Y/gR+Df4Tkv5Iegj1F2DWUPhAwvqv6P4XB4DyfcOmRPwT8B/0WWM2oUCOkNFpmHovdhwHuMEeKtscbGAv8Q5CzLswSeydkmdp3xWrqBsg3wl/HwiQV/pYs0mUwuor818J8wRgufye7IdmoTlIIl0xcYP8SzDyXfCl3waUKuNFW/3++/Qg/7eM7h2dJ7s8oBgP1zKMcMuAXo3xWK5l2mU/U7nc5twP8m6w/0jeiXE6scgDW/BQUfQbM/eC4IRb8JygnKv4Zh+AvMX01+COd9RxmrqzvgZ71eP4DsEuAfo3wTe8AzrZ2d2V6vV/jEYO1Lh9ppNGm1JA/8A329cJKt+cZjAAAAAElFTkSuQmCC</icon>
@@ -163,12 +161,16 @@
                 </property>
             </propertyGroup>
             <propertyGroup caption="Configuration">
-                <property key="configurationAttribute" type="attribute" required="false">
+                <property key="configurationAttribute" type="attribute" required="false" onChange="onConfigurationChange">
                     <caption>Attribute</caption>
                     <description>Attribute containing the personalized configuration of the capabilities. This configuration is automatically stored and loaded. The attribute requires Unlimited String.</description>
                     <attributeTypes>
                         <attributeType name="String" />
                     </attributeTypes>
+                </property>
+                <property key="onConfigurationChange" type="action">
+                    <caption>On change</caption>
+                    <description/>
                 </property>
             </propertyGroup>
         </propertyGroup>

--- a/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
@@ -46,6 +46,7 @@ export interface TableProps<T> {
     preview?: boolean;
     setPage?: (computePage: (prevPage: number) => number) => void;
     settings?: EditableValue<string>;
+    onSettingsChange?: () => void;
     styles?: CSSProperties;
     valueForSort: (value: T, columnIndex: number) => string | BigJs.Big | boolean | Date | undefined;
 }
@@ -73,6 +74,7 @@ export function Table<T>(props: TableProps<T>): ReactElement {
 
     useSettings(
         props.settings,
+        props.onSettingsChange,
         props.columns,
         columnOrder,
         setColumnOrder,

--- a/packages/pluggableWidgets/datagrid-web/src/ui/Datagrid.scss
+++ b/packages/pluggableWidgets/datagrid-web/src/ui/Datagrid.scss
@@ -26,6 +26,7 @@ $dragging-color-effect: rgba(10, 19, 37, 0.8);
         display: flex;
         align-items: flex-start;
         font-weight: 600;
+        background-color: $background-color;
         padding: 16px 8px 0 8px;
         margin-bottom: 16px;
         position: -webkit-sticky; /* Safari */

--- a/packages/pluggableWidgets/datagrid-web/src/ui/Datagrid.scss
+++ b/packages/pluggableWidgets/datagrid-web/src/ui/Datagrid.scss
@@ -26,7 +26,6 @@ $dragging-color-effect: rgba(10, 19, 37, 0.8);
         display: flex;
         align-items: flex-start;
         font-weight: 600;
-        background-color: $background-color;
         padding: 16px 8px 0 8px;
         margin-bottom: 16px;
         position: -webkit-sticky; /* Safari */
@@ -163,7 +162,6 @@ $dragging-color-effect: rgba(10, 19, 37, 0.8);
         border-color: $border-color;
         border-bottom-width: 1px;
         border-bottom-style: solid;
-        background-color: $background-color;
         overflow: hidden;
 
         &.td-borders {

--- a/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
@@ -11,6 +11,7 @@ describe("useSettings Hook", () => {
         renderHook(() =>
             useSettings(
                 props.settings,
+                props.onSettingsChange,
                 props.columns,
                 props.columnOrder,
                 props.setColumnOrder,
@@ -66,6 +67,7 @@ describe("useSettings Hook", () => {
         renderHook(() =>
             useSettings(
                 settings,
+                props.onSettingsChange,
                 columns,
                 props.columnOrder,
                 props.setColumnOrder,
@@ -88,6 +90,7 @@ describe("useSettings Hook", () => {
 
         const { rerender } = renderUseSettingsHook({
             settings: props.settings,
+            onSettingsChange: props.onSettingsChange,
             columns: props.columns,
             columnOrder: ["0"],
             setColumnOrder: props.setColumnOrder,
@@ -101,6 +104,7 @@ describe("useSettings Hook", () => {
         expect(props.settings.setValue).toHaveBeenCalledTimes(0);
         rerender({
             settings: props.settings,
+            onSettingsChange: props.onSettingsChange,
             columns: props.columns,
             columnOrder: ["0"],
             setColumnOrder: props.setColumnOrder,
@@ -130,6 +134,7 @@ describe("useSettings Hook", () => {
         const props = mockProperties();
         const initialProps = {
             settings: props.settings,
+            onSettingsChange: props.onSettingsChange,
             columns: props.columns,
             columnOrder: ["0"],
             setColumnOrder: props.setColumnOrder,
@@ -151,6 +156,7 @@ describe("useSettings Hook", () => {
         const props = mockProperties();
         const initialProps = {
             settings: props.settings,
+            onSettingsChange: props.onSettingsChange,
             columns: props.columns,
             columnOrder: ["0"],
             setColumnOrder: props.setColumnOrder,
@@ -212,6 +218,7 @@ function mockProperties(): any {
                 ])
             )
             .build(),
+        onSettingsChange: jest.fn(),
         columns: [
             {
                 header: "Column 1",
@@ -231,6 +238,7 @@ function mockProperties(): any {
 
 function renderUseSettingsHook(initialProps: {
     settings: any;
+    onSettingsChange: () => void;
     hiddenColumns: any[];
     columnOrder: string[];
     columns: any;
@@ -244,6 +252,7 @@ function renderUseSettingsHook(initialProps: {
     return renderHook(
         ({
             settings,
+            onSettingsChange,
             columns,
             columnOrder,
             setColumnOrder,
@@ -256,6 +265,7 @@ function renderUseSettingsHook(initialProps: {
         }) =>
             useSettings(
                 settings,
+                onSettingsChange,
                 columns,
                 columnOrder,
                 setColumnOrder,

--- a/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
@@ -102,6 +102,7 @@ describe("useSettings Hook", () => {
             setWidths: props.setWidths
         });
         expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
         rerender({
             settings: props.settings,
             onSettingsChange: props.onSettingsChange,
@@ -128,6 +129,7 @@ describe("useSettings Hook", () => {
                 }
             ])
         );
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(1);
     });
 
     it("doesnt change the settings when same properties are applied", () => {
@@ -148,8 +150,10 @@ describe("useSettings Hook", () => {
 
         const { rerender } = renderUseSettingsHook(initialProps);
         expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
         rerender(initialProps);
         expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
     });
 
     it("doesnt change the hooks when same properties are applied", () => {
@@ -175,12 +179,14 @@ describe("useSettings Hook", () => {
         expect(props.setSortBy).toHaveBeenCalledTimes(1);
         expect(props.setWidths).toHaveBeenCalledTimes(1);
         expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
         rerender(initialProps);
         expect(props.setColumnOrder).toHaveBeenCalledTimes(1);
         expect(props.setHiddenColumns).toHaveBeenCalledTimes(1);
         expect(props.setSortBy).toHaveBeenCalledTimes(1);
         expect(props.setWidths).toHaveBeenCalledTimes(1);
         expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
     });
 
     it("applies changes to settings when receiving external prop changes", () => {
@@ -192,13 +198,16 @@ describe("useSettings Hook", () => {
         expect(props.settings.setValue).toHaveBeenCalledWith(
             JSON.stringify([{ column: "Column 1", sort: false, sortMethod: "asc", hidden: false, order: 0 }])
         );
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(1);
         rerender({ ...props, sortBy: [{ id: "0", desc: true }] });
         expect(props.settings.setValue).toHaveBeenCalledTimes(2);
         expect(props.settings.setValue).toHaveBeenCalledWith(
             JSON.stringify([{ column: "Column 1", sort: true, sortMethod: "desc", hidden: false, order: 0 }])
         );
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(2);
         rerender({ ...props, sortBy: [{ id: "0", desc: true }] });
         expect(props.settings.setValue).toHaveBeenCalledTimes(2);
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(2);
     });
 });
 

--- a/packages/pluggableWidgets/datagrid-web/src/utils/settings.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/settings.ts
@@ -40,6 +40,7 @@ export function createSettings(
 
 export function useSettings(
     settings: Option<EditableValue<string>>,
+    onSettingsChange: Option<() => void>,
     columns: TableColumn[],
     columnOrder: Array<IdType<object>>,
     setColumnOrder: Dispatch<SetStateAction<Array<IdType<object>>>>,
@@ -108,8 +109,9 @@ export function useSettings(
             );
             if (previousLoadedSettings.current !== newSettings && settings.value !== newSettings) {
                 settings.setValue(newSettings);
+                onSettingsChange?.();
                 previousLoadedSettings.current = newSettings;
             }
         }
-    }, [columnOrder, hiddenColumns, sortBy, widths, settings, previousLoadedSettings.current]);
+    }, [columnOrder, hiddenColumns, sortBy, widths, settings, onSettingsChange, previousLoadedSettings.current]);
 }

--- a/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
@@ -4,7 +4,16 @@
  * @author Mendix UI Content Team
  */
 import { ComponentType, CSSProperties, ReactNode } from "react";
-import { DynamicValue, EditableValue, ListValue, ListActionValue, ListAttributeValue, ListExpressionValue, ListWidgetValue } from "mendix";
+import {
+    ActionValue,
+    DynamicValue,
+    EditableValue,
+    ListValue,
+    ListActionValue,
+    ListAttributeValue,
+    ListExpressionValue,
+    ListWidgetValue
+} from "mendix";
 
 export type WidthEnum = "autoFill" | "autoFit" | "manual";
 
@@ -66,6 +75,7 @@ export interface DatagridContainerProps {
     columnsDraggable: boolean;
     columnsHidable: boolean;
     configurationAttribute?: EditableValue<string>;
+    onConfigurationChange?: ActionValue;
 }
 
 export interface DatagridPreviewProps {
@@ -86,4 +96,5 @@ export interface DatagridPreviewProps {
     columnsDraggable: boolean;
     columnsHidable: boolean;
     configurationAttribute: string;
+    onConfigurationChange: {} | null;
 }


### PR DESCRIPTION
### Why?
To persist new configuration changes of users, mx devs should be able to trigger an action after these changes occur.

### What has been done?
- An `On change` action property has been added to the `Configuration` property group to trigger an action after the settings attribute value has been updated.
- Include some background style improvements.

### How to test?
Check whether action is triggered correctly and if style changes don't break the widget.