### PR TITLE
feat(datagrid-web): adopt datagrid configs to new logic [PAG-1438]

### DIFF
--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/DatagridDateFilter.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/DatagridDateFilter.editorConfig.ts
@@ -25,6 +25,8 @@ export function getProperties(values: DatagridDateFilterPreviewProps, defaultPro
 export const getPreview = (values: DatagridDateFilterPreviewProps): StructurePreviewProps => {
     return {
         type: "RowLayout",
+        borders: true,
+        borderRadius: 5,
         columnSize: "grow",
         children: [
             {

--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/DatagridDropdownFilter.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/DatagridDropdownFilter.editorConfig.ts
@@ -10,6 +10,8 @@ import {
 export const getPreview = (values: DatagridDropdownFilterPreviewProps): StructurePreviewProps => {
     return {
         type: "RowLayout",
+        borders: true,
+        borderRadius: 5,
         columnSize: "grow",
         children: [
             {

--- a/packages/pluggableWidgets/datagrid-number-filter-web/src/DatagridNumberFilter.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/src/DatagridNumberFilter.editorConfig.ts
@@ -24,6 +24,8 @@ export function getProperties(values: DatagridNumberFilterPreviewProps, defaultP
 export const getPreview = (values: DatagridNumberFilterPreviewProps): StructurePreviewProps => {
     return {
         type: "RowLayout",
+        borders: true,
+        borderRadius: 5,
         columnSize: "grow",
         children: [
             {

--- a/packages/pluggableWidgets/datagrid-text-filter-web/src/DatagridTextFilter.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/src/DatagridTextFilter.editorConfig.ts
@@ -28,6 +28,8 @@ export const getPreview = (values: DatagridTextFilterPreviewProps): StructurePre
     return {
         type: "RowLayout",
         columnSize: "grow",
+        borders: true,
+        borderRadius: 5,
         children: [
             {
                 type: "RowLayout",

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -39,26 +39,26 @@ export function getProperties(values: DatagridPreviewProps, defaultProperties: P
 }
 
 export const getPreview = (values: DatagridPreviewProps): StructurePreviewProps => {
-    const columnProps: ColumnsPreviewType[] =
-        values.columns && values.columns.length > 0
-            ? values.columns
-            : [
-                  {
-                      header: "Header",
-                      attribute: "Attribute",
-                      width: "autoFit",
-                      columnClass: "",
-                      filter: { widgetCount: 0, renderer: () => null },
-                      resizable: false,
-                      hasWidgets: false,
-                      content: { widgetCount: 0, renderer: () => null },
-                      draggable: false,
-                      hidable: "no",
-                      size: 1,
-                      sortable: false,
-                      alignment: "left"
-                  }
-              ];
+    const hasColumns = values.columns && values.columns.length > 0;
+    const columnProps: ColumnsPreviewType[] = hasColumns
+        ? values.columns
+        : [
+              {
+                  header: "Header",
+                  attribute: "Attribute",
+                  width: "autoFit",
+                  columnClass: "",
+                  filter: { widgetCount: 0, renderer: () => null },
+                  resizable: false,
+                  hasWidgets: false,
+                  content: { widgetCount: 0, renderer: () => null },
+                  draggable: false,
+                  hidable: "no",
+                  size: 1,
+                  sortable: false,
+                  alignment: "left"
+              }
+          ];
     const columns: RowLayoutProps = {
         type: "RowLayout",
         columnSize: "fixed",
@@ -118,7 +118,7 @@ export const getPreview = (values: DatagridPreviewProps): StructurePreviewProps 
                             }
                         ]
                     },
-                    ...(values.columnsFilterable
+                    ...(hasColumns && values.columnsFilterable
                         ? [
                               {
                                   type: "DropZone",
@@ -157,7 +157,6 @@ export const getPreview = (values: DatagridPreviewProps): StructurePreviewProps 
         : [];
     return {
         type: "Container",
-        borders: true,
         children: [headers, ...Array.from({ length: 5 }).map(() => columns), ...footer]
     };
 };


### PR DESCRIPTION
In story PAG-1438 we removed the borders to be rendered by default. This PR adds rounded borders to the dg filters. Also includes a little fix when no columns exist but columnsFilterable == true.
I also removed the border around the data grid because the double border looked sorta weird. If you want it back, be my guest.

Can wait for Diego to come back from his holiday.

Here is a little screenshot (with parallels and weird dpi) of what it will look like

![Screenshot 2020-12-31 at 17 53 59](https://user-images.githubusercontent.com/62058583/103419676-40d6e400-4b94-11eb-9f4f-f03442d33028.png)
