### PR TITLE
[WT-3097] PIW tools - Generator doesn't include id property in typings (Mx 9)

### DIFF
--- a/packages/pluggableWidgets/video-player-web/src/components/SizeContainer.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/SizeContainer.tsx
@@ -10,7 +10,7 @@ export interface Dimensions {
     width: number;
     heightUnit: HeightUnitType;
     height: number;
-    tabIndex: number;
+    tabIndex?: number;
 }
 
 export interface SizeProps extends Dimensions {

--- a/packages/tools/pluggable-widgets-tools/jest.config.js
+++ b/packages/tools/pluggable-widgets-tools/jest.config.js
@@ -4,7 +4,7 @@ const nativeBaseConfig = require("./test-config/jest.native.config.js");
 const webConfig = {
     ...webBaseConfig,
     rootDir: ".",
-    testMatch: ["<rootDir>/src/{web,typings-generator}/**/*.spec.{ts,tsx}"]
+    testMatch: ["<rootDir>/src/@(web|typings-generator)/**/*.spec.{ts,tsx}"]
 };
 
 const nativeConfig = {

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
@@ -15,10 +15,10 @@ import { datasourceInput, datasourceInputNative } from "./inputs/datasource";
 import { datasourceNativeOutput, datasourceWebOutput } from "./outputs/datasource";
 import { generateForWidget } from "../generate";
 import { generateClientTypes } from "../generateClientTypes";
-import { extractProperties } from "../helpers";
+import { extractProperties, extractSystemProperties } from "../helpers";
 import { WidgetXml } from "../WidgetXml";
 import { content, contentGroup, contentGroupNative, contentNative } from "./inputs";
-import { nativeResult, webResult } from "./outputs";
+import { nativeResult, webResult, webResultGroup } from "./outputs";
 
 describe("Generating tests", () => {
     it("Generates a parsed typing from XML for native", () => {
@@ -38,7 +38,7 @@ describe("Generating tests", () => {
 
     it("Generates a parsed typing from XML for web with groups", () => {
         const newContent = generateFullTypesFor(contentGroup);
-        expect(newContent).toBe(webResult);
+        expect(newContent).toBe(webResultGroup);
     });
 
     it("Generates a parsed typing from XML for native using list of actions", () => {
@@ -118,7 +118,13 @@ function generateFullTypesFor(xml: string) {
 
 function generateNativeTypesFor(xml: string) {
     const widgetXml = convertXmltoJson(xml);
-    return generateClientTypes("MyWidget", extractProperties(widgetXml!.widget!.properties[0]), true).join("\n\n");
+    const properties = widgetXml!.widget!.properties[0];
+    return generateClientTypes(
+        "MyWidget",
+        extractProperties(properties),
+        extractSystemProperties(properties),
+        true
+    ).join("\n\n");
 }
 
 function convertXmltoJson(xml: string): WidgetXml {

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/containment.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/containment.ts
@@ -23,7 +23,7 @@ export const containmentInput = `<?xml version="1.0" encoding="utf-8"?>
             </property>
         </propertyGroup>
         <propertyGroup caption="System Properties">
-            <systemProperty key="Label"></systemProperty>
+            <!-- no "Label" system property -->
             <systemProperty key="TabIndex"></systemProperty>
         </propertyGroup>
     </properties>
@@ -54,7 +54,7 @@ export const containmentInputNative = `<?xml version="1.0" encoding="utf-8"?>
             </property>
         </propertyGroup>
         <propertyGroup caption="System Properties">
-            <systemProperty key="Label"></systemProperty>
+            <!-- no "Label" system property -->
             <systemProperty key="TabIndex"></systemProperty>
         </propertyGroup>
     </properties>

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/file.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/file.ts
@@ -26,9 +26,11 @@ export const fileInput = `<?xml version="1.0" encoding="utf-8"?>
                 <description />
             </property>
         </propertyGroup>
-        <propertyGroup caption="System Properties">
-            <systemProperty key="Label"></systemProperty>
-            <systemProperty key="TabIndex"></systemProperty>
+        <propertyGroup caption="Other">
+            <propertyGroup caption="System Properties">
+                <systemProperty key="Label"></systemProperty>
+                <systemProperty key="TabIndex"></systemProperty>
+            </propertyGroup>
         </propertyGroup>
     </properties>
 </widget>`;
@@ -61,9 +63,11 @@ export const fileInputNative = `<?xml version="1.0" encoding="utf-8"?>
                 <description />
             </property>
         </propertyGroup>
-        <propertyGroup caption="System Properties">
-            <systemProperty key="Label"></systemProperty>
-            <systemProperty key="TabIndex"></systemProperty>
+        <propertyGroup caption="Other">
+            <propertyGroup caption="System Properties">
+                <systemProperty key="Label"></systemProperty>
+                <systemProperty key="TabIndex"></systemProperty>
+            </propertyGroup>
         </propertyGroup>
     </properties>
 </widget>`;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
@@ -10,7 +10,7 @@ export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
     content: ReactNode;
     description: EditableValue<string>;
     action?: ActionValue;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
@@ -22,7 +22,8 @@ export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
+    id: string;
     contentSource: ListValue;
     content: ListWidgetValue;
     markerDataAttribute: ListAttributeValue<string | boolean | BigJs.Big>;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/file.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/file.ts
@@ -10,7 +10,8 @@ export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
+    id: string;
     file: DynamicValue<FileValue>;
     file2?: DynamicValue<FileValue>;
     description: EditableValue<string>;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/icon.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/icon.ts
@@ -20,7 +20,8 @@ export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
+    id: string;
     icons: IconsType[];
 }
 

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
@@ -90,7 +90,73 @@ export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
+    valueAttribute?: EditableValue<string | BigJs.Big>;
+    mywidgetValue: string;
+    valueExpression?: DynamicValue<string>;
+    valueExpressionDecimal?: DynamicValue<BigJs.Big>;
+    file: DynamicValue<FileValue>;
+    bootstrapStyle: BootstrapStyleEnum;
+    mywidgetType: MywidgetTypeEnum;
+    tries?: number;
+    amount?: BigJs.Big;
+    image?: DynamicValue<WebImage>;
+    onClickAction?: ActionValue;
+    onChange?: ActionValue;
+    actions: ActionsType[];
+}
+
+export interface MyWidgetPreviewProps {
+    class: string;
+    style: string;
+    valueAttribute: string;
+    mywidgetValue: string;
+    valueExpression: string;
+    valueExpressionDecimal: string;
+    file: string;
+    bootstrapStyle: BootstrapStyleEnum;
+    mywidgetType: MywidgetTypeEnum;
+    tries: number | null;
+    amount: number | null;
+    image: string;
+    onClickAction: {} | null;
+    onChange: {} | null;
+    actions: ActionsPreviewType[];
+}
+`;
+
+export const webResultGroup = `/**
+ * This file was generated from MyWidget.xml
+ * WARNING: All changes made to this file will be overwritten
+ * @author Mendix UI Content Team
+ */
+import { CSSProperties } from "react";
+import { ActionValue, DynamicValue, EditableValue, FileValue, WebImage } from "mendix";
+
+export type BootstrapStyleEnum = "default" | "primary" | "success" | "info" | "inverse" | "warning" | "danger";
+
+export type MywidgetTypeEnum = "badge" | "label";
+
+export interface ActionsType {
+    name: string;
+    enabled: boolean;
+    action?: ActionValue;
+    image: DynamicValue<WebImage>;
+}
+
+export interface ActionsPreviewType {
+    name: string;
+    enabled: boolean;
+    action: {} | null;
+    image: string;
+}
+
+export interface MyWidgetContainerProps {
+    name: string;
+    class: string;
+    style?: CSSProperties;
+    tabIndex?: number;
+    id: string;
     valueAttribute?: EditableValue<string | BigJs.Big>;
     mywidgetValue: string;
     valueExpression?: DynamicValue<string>;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-action.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-action.ts
@@ -20,7 +20,8 @@ export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
+    id: string;
     actions: ActionsType[];
 }
 

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-files.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-files.ts
@@ -18,7 +18,8 @@ export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
+    id: string;
     actions: ActionsType[];
 }
 

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
@@ -18,7 +18,8 @@ export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
+    id: string;
     actions: ActionsType[];
 }
 

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generate.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generate.ts
@@ -1,6 +1,6 @@
 import { generateClientTypes } from "./generateClientTypes";
 import { generatePreviewTypes } from "./generatePreviewTypes";
-import { extractProperties } from "./helpers";
+import { extractProperties, extractSystemProperties } from "./helpers";
 import { WidgetXml } from "./WidgetXml";
 
 const mxExports = [
@@ -29,12 +29,11 @@ export function generateForWidget(widgetXml: WidgetXml, widgetName: string) {
 
     const isNative = widgetXml.widget.$.supportedPlatform === "Native";
 
-    const properties = (widgetXml.widget.properties.length > 0
-        ? extractProperties(widgetXml.widget.properties[0])
-        : []
-    ).filter(prop => prop && prop.$ && prop.$.key);
+    const propElements = widgetXml.widget.properties[0] ?? [];
+    const properties = extractProperties(propElements).filter(prop => prop?.$?.key);
+    const systemProperties = extractSystemProperties(propElements).filter(prop => prop?.$?.key);
 
-    const clientTypes = generateClientTypes(widgetName, properties, isNative);
+    const clientTypes = generateClientTypes(widgetName, properties, systemProperties, isNative);
     const modelerTypes = generatePreviewTypes(widgetName, properties);
 
     const generatedTypesCode = clientTypes

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
@@ -1,7 +1,13 @@
-import { Property } from "./WidgetXml";
+import { Property, SystemProperty } from "./WidgetXml";
 import { capitalizeFirstLetter, extractProperties } from "./helpers";
 
-export function generateClientTypes(widgetName: string, properties: Property[], isNative: boolean): string[] {
+export function generateClientTypes(
+    widgetName: string,
+    properties: Property[],
+    systemProperties: SystemProperty[],
+    isNative: boolean
+): string[] {
+    const isLabeled = systemProperties.some(p => p.$.key === "Label");
     const results = Array.of<string>();
     results.push(
         isNative
@@ -14,7 +20,12 @@ ${generateClientTypeBody(properties, true, results)}
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;${
+        isLabeled
+            ? `
+    id: string;`
+            : ``
+    }
 ${generateClientTypeBody(properties, false, results)}
 }`
     );

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/helpers.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/helpers.ts
@@ -1,11 +1,17 @@
-import { Properties, Property } from "./WidgetXml";
+import { Properties, Property, SystemProperty } from "./WidgetXml";
 
-export function extractProperties(propElements: Properties): Property[] {
-    if (!propElements.propertyGroup) {
-        return propElements.property ?? [];
-    }
+export function extractProperties(props: Properties): Property[] {
+    return extractProps(props, p => p.property ?? []);
+}
 
-    return (propElements.propertyGroup ?? []).map(pg => extractProperties(pg)).reduce((a, e) => a.concat(e), []);
+export function extractSystemProperties(props: Properties): SystemProperty[] {
+    return extractProps(props, p => p.systemProperty ?? []);
+}
+
+function extractProps<P>(props: Properties, extractor: (props: Properties) => P[]): P[] {
+    return props.propertyGroup
+        ? props.propertyGroup.map(pg => extractProps(pg, extractor)).reduce((a, e) => a.concat(e), [])
+        : extractor(props);
 }
 
 export function capitalizeFirstLetter(text: string): string {

--- a/packages/tools/pluggable-widgets-tools/tests/commands.js
+++ b/packages/tools/pluggable-widgets-tools/tests/commands.js
@@ -70,7 +70,11 @@ async function main() {
     ).filter(f => f);
 
     console.log("All done!");
-    rm("-r", toolsPackagePath, ...workDirs);
+    try {
+        rm("-r", toolsPackagePath, ...workDirs);
+    } catch (error) {
+        console.warn(`Error while removing files: ${error.message}`);
+    }
 
     if (failures.length) {
         failures.forEach(f => console.error(`Test for configuration ${f[0]} failed: ${f[1]}`));


### PR DESCRIPTION
- Add `id` prop for web widgets with system property `Label`
- Bonus fix: properly declare `tabIndex` prop as optional