### PR TITLE
test(datagrid-number-filter-web): add e2e test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -90,3 +90,7 @@
 	path = packages/pluggableWidgets/datagrid-text-filter-web/tests/testProject
 	url = https://github.com/mendix/testProjects.git
 	branch = datagrid-text-filter-web
+[submodule "packages/pluggableWidgets/datagrid-number-filter-web/tests/testProject"]
+	path = packages/pluggableWidgets/datagrid-number-filter-web/tests/testProject
+	url = https://github.com/mendix/testProjects.git
+	branch = datagrid-number-filter-web

--- a/packages/pluggableWidgets/datagrid-number-filter-web/package.json
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/package.json
@@ -21,6 +21,9 @@
     "format": "pluggable-widgets-tools format",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
+    "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:ts"
   },
   "dependencies": {

--- a/packages/pluggableWidgets/datagrid-number-filter-web/tests/e2e/objects/datagrid.widget.ts
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/tests/e2e/objects/datagrid.widget.ts
@@ -1,0 +1,7 @@
+class Datagrid {
+    getAllRows(items: WebdriverIO.ElementArray): string[] {
+        /* TODO: When I tried to use getText() in a loop to get the text it's taking almost 1min to process. So instead of using getText I am using getHTML with replace for this case. Maybe in the future will be possible to back to getText() */
+        return items.map(item => item.getHTML().replace(/(<([^>]+)>)/gi, ""));
+    }
+}
+export default new Datagrid();

--- a/packages/pluggableWidgets/datagrid-number-filter-web/tests/e2e/specs/DataGridNumberFilter.spec.ts
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/tests/e2e/specs/DataGridNumberFilter.spec.ts
@@ -1,0 +1,27 @@
+import page from "../../../../../../configs/e2e/src/pages/page";
+import datagrid from "../objects/datagrid.widget";
+
+describe("datagrid-number-filter-web", () => {
+    beforeEach(() => {
+        page.open(); // resets page
+    });
+
+    describe("number filtering", () => {
+        it("shows correct result", () => {
+            const grid = page.getWidget("datagrid1");
+            const input = page.getElement(".filter-input", grid);
+            input.setValue("12");
+            grid.waitUntil(
+                () => {
+                    return datagrid.getAllRows(page.getElements(".mx-name-datagrid1 .td")).length !== 12;
+                },
+                {
+                    timeout: 3000,
+                    timeoutMsg: "expected result to be different after 3s"
+                }
+            );
+            const items = page.getElements(".td", grid);
+            expect(datagrid.getAllRows(items)).toEqual(["12", "test3", "test3", ""]);
+        });
+    });
+});

--- a/packages/pluggableWidgets/datagrid-number-filter-web/tests/e2e/tsconfig.json
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/tests/e2e/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../../../../configs/e2e/tsconfig.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "rootDir": "./"
+    },
+    "include": ["*.spec.ts"],
+    "exclude": ["../../node_modules", "../../../../node_modules"]
+}


### PR DESCRIPTION
Why?

Adding e2e tests to cover datagrid-text-filter-web widget.