### PR TITLE
[WT-3116] Fix header day formatting for calendar-web widget

### DIFF
--- a/packages/customWidgets/calendar-web/package.json
+++ b/packages/customWidgets/calendar-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar-web",
   "widgetName": "Calendar",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Display and manage calendar events",
   "copyright": "Mendix BV",
   "repository": {

--- a/packages/customWidgets/calendar-web/src/Calendar.xml
+++ b/packages/customWidgets/calendar-web/src/Calendar.xml
@@ -195,11 +195,7 @@
                 <property key="headerFormat" type="translatableString" required="false">
                     <caption>Header day format</caption>
                     <category>Custom formats</category>
-                    <description>Header date shown in the top row of the month, week and day view. Use Mendix date formats. e.g. 'EEEE dd/MM'</description>
-                    <translations>
-                        <translation lang="en_US">EEE</translation>
-                        <translation lang="nl_NL">EEE</translation>
-                    </translations>
+                    <description>Format of date(s) in the header above the day, week, month, work week or Agenda view. Use Mendix date formats. e.g. 'EEEE dd/MM'</description>
                 </property>
                 <property key="cellDateFormat" type="translatableString" required="false">
                     <caption>Cell date format</caption>

--- a/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
+++ b/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
@@ -293,23 +293,22 @@ export default class CalendarContainer extends Component<Container.CalendarConta
                     ? this.customFormat(customView.gutterTimeFormat, "timeGutter")
                     : calendarFormats.timeGutterFormat;
 
-            if (customView.customView === "day" && customView.headerFormat) {
-                calendarFormats.dayHeaderFormat = this.customFormat(customView.headerFormat);
-            }
-
-            if (
-                (customView.customView === "week" || customView.customView === "work_week") &&
-                customView.headerFormat
-            ) {
-                calendarFormats.dayRangeHeaderFormat = this.customRangeFormat(customView.headerFormat);
-            }
-
-            if (customView.customView === "month" && customView.headerFormat) {
-                calendarFormats.monthHeaderFormat = this.customFormat(customView.headerFormat);
-            }
-
-            if (customView.customView === "agenda" && customView.headerFormat) {
-                calendarFormats.agendaHeaderFormat = this.customRangeFormat(customView.headerFormat);
+            if (customView.headerFormat) {
+                switch (customView.customView) {
+                    case "day":
+                        calendarFormats.dayHeaderFormat = this.customFormat(customView.headerFormat);
+                        break;
+                    case "week":
+                    case "work_week":
+                        calendarFormats.dayRangeHeaderFormat = this.customRangeFormat(customView.headerFormat);
+                        break;
+                    case "month":
+                        calendarFormats.monthHeaderFormat = this.customFormat(customView.headerFormat);
+                        break;
+                    case "agenda":
+                        calendarFormats.agendaHeaderFormat = this.customRangeFormat(customView.headerFormat);
+                        break;
+                }
             }
         });
 

--- a/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
+++ b/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
@@ -268,50 +268,53 @@ export default class CalendarContainer extends Component<Container.CalendarConta
         );
     };
 
-    private setCalendarFormats = (): Container.ViewOptions =>
-        this.props.customViews.reduce((accumulator: Container.ViewOptions, customView: Container.CustomViews) => {
-            accumulator.dateFormat =
+    private setCalendarFormats = (): Container.ViewOptions => {
+        const calendarFormats: Container.ViewOptions = {};
+
+        this.props.customViews.forEach((customView: Container.CustomViews) => {
+            calendarFormats.dateFormat =
                 customView.customView === "month"
                     ? this.customFormat(customView.cellDateFormat, "date")
-                    : accumulator.dateFormat;
-            accumulator.dayFormat =
+                    : calendarFormats.dateFormat;
+            calendarFormats.dayFormat =
                 customView.customView === "day" ||
                 customView.customView === "week" ||
                 customView.customView === "work_week"
                     ? this.customFormat(customView.gutterDateFormat, "day")
-                    : accumulator.dayFormat;
-            accumulator.weekdayFormat =
+                    : calendarFormats.dayFormat;
+            calendarFormats.weekdayFormat =
                 customView.customView === "month"
                     ? this.customFormat(customView.headerFormat, "weekday")
-                    : accumulator.weekdayFormat;
-            accumulator.timeGutterFormat =
+                    : calendarFormats.weekdayFormat;
+            calendarFormats.timeGutterFormat =
                 customView.customView === "week" ||
                 customView.customView === "day" ||
                 customView.customView === "work_week"
                     ? this.customFormat(customView.gutterTimeFormat, "timeGutter")
-                    : accumulator.timeGutterFormat;
+                    : calendarFormats.timeGutterFormat;
 
             if (customView.customView === "day" && customView.headerFormat) {
-                accumulator.dayHeaderFormat = this.customFormat(customView.headerFormat);
+                calendarFormats.dayHeaderFormat = this.customFormat(customView.headerFormat);
             }
 
             if (
                 (customView.customView === "week" || customView.customView === "work_week") &&
                 customView.headerFormat
             ) {
-                accumulator.dayRangeHeaderFormat = this.customRangeFormat(customView.headerFormat);
+                calendarFormats.dayRangeHeaderFormat = this.customRangeFormat(customView.headerFormat);
             }
 
             if (customView.customView === "month" && customView.headerFormat) {
-                accumulator.monthHeaderFormat = this.customFormat(customView.headerFormat);
+                calendarFormats.monthHeaderFormat = this.customFormat(customView.headerFormat);
             }
 
             if (customView.customView === "agenda" && customView.headerFormat) {
-                accumulator.agendaHeaderFormat = this.customRangeFormat(customView.headerFormat);
+                calendarFormats.agendaHeaderFormat = this.customRangeFormat(customView.headerFormat);
             }
+        });
 
-            return accumulator;
-        }, {});
+        return calendarFormats;
+    };
 
     private customFormat = (dateFormat: string, dateType?: Container.DateType): ((date: Date) => string) => {
         let datePattern = "";

--- a/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
+++ b/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
@@ -335,8 +335,6 @@ export default class CalendarContainer extends Component<Container.CalendarConta
     private customRangeFormat = (dateFormat: string): ((dateRange: { start: Date; end: Date }) => string) => {
         const datePattern = dateFormat;
         return (dateRange: { start: Date; end: Date }) => {
-            console.log("start", dateRange.start);
-            console.log("end", dateRange.end);
             return `${window.mx.parser.formatValue(dateRange.start, "datetime", {
                 datePattern
             })} - ${window.mx.parser.formatValue(dateRange.end, "datetime", { datePattern })}`;

--- a/packages/customWidgets/calendar-web/src/package.xml
+++ b/packages/customWidgets/calendar-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Calendar2" version="1.0.7" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Calendar2" version="1.0.8" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Calendar.xml"/>
         </widgetFiles>

--- a/packages/customWidgets/calendar-web/src/utils/namespaces.ts
+++ b/packages/customWidgets/calendar-web/src/utils/namespaces.ts
@@ -108,6 +108,10 @@ export namespace Container {
         dayFormat?: functionType | string;
         weekdayFormat?: functionType | string;
         timeGutterFormat?: functionType | string;
+        dayHeaderFormat?: functionType | string;
+        dayRangeHeaderFormat?: ((dateRange: { start: Date; end: Date }) => string) | string;
+        monthHeaderFormat?: functionType | string;
+        agendaHeaderFormat?: ((dateRange: { start: Date; end: Date }) => string) | string;
     }
 
     export type DataSource = "context" | "XPath" | "microflow" | "nanoflow";

--- a/packages/customWidgets/calendar-web/src/utils/validation.ts
+++ b/packages/customWidgets/calendar-web/src/utils/validation.ts
@@ -54,7 +54,9 @@ export function validateCustomFormats(props: Container.CalendarContainerProps): 
             props.customViews.forEach(customView => {
                 window.mx.parser.formatValue(date, "datetime", { datePattern: customView.cellDateFormat });
                 window.mx.parser.formatValue(date, "datetime", { datePattern: customView.gutterDateFormat });
-                window.mx.parser.formatValue(date, "datetime", { datePattern: customView.headerFormat });
+                if (customView.headerFormat) {
+                    window.mx.parser.formatValue(date, "datetime", { datePattern: customView.headerFormat });
+                }
                 window.mx.parser.formatValue(date, "datetime", { datePattern: customView.gutterTimeFormat });
             });
         }


### PR DESCRIPTION
### Why?
There are widget config properties present to alter the date formatting of dates inside the header of the day, week, work week, month and agenda view. This didn't work, because there was no logic passed to `react-big-calendar`.

### What?
- Pass custom header formatters for day, week, month, work week and agenda view.
- Remove default value for `headerFormat` widget config property to allow for default `react-big-calendar` notations.
- Improve `headerFormat` property description.
- Only validate `headerFormat` value when it's not an empty.

### How to test?
- Check the header of the views: day, week, work week, month and agenda view. 
- Check the default header when no value is configured for the `headerFormat` (Header day format) widget config property.
- Check custom formats and that they are only applied to the appropriate views.
- Check that `headerFormat` only works voor view buttons (not previous, next, or title) in toolbar.
- Check that the custom format is applied of the last view button in the "Custom top bar view" object list when multiple buttons of the same kind are added (e.g. Two day buttons with each their own custom format). Also, check that an empty string as last custom format isn't overruling the custom format before that when it's specified.