### PR TITLE
fix(calendar-web): cancel loading after destroy

### DIFF
--- a/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
+++ b/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
@@ -26,6 +26,7 @@ export default class CalendarContainer extends Component<Container.CalendarConta
     private subscriptionContextHandles: number[] = [];
     private subscriptionEventHandles: number[] = [];
     private progressHandle?: number;
+    private destroyed = false;
 
     readonly state: CalendarContainerState = {
         alertMessage: "",
@@ -86,6 +87,7 @@ export default class CalendarContainer extends Component<Container.CalendarConta
     }
 
     componentWillUnmount(): void {
+        this.destroyed = true;
         this.subscriptionContextHandles.forEach(window.mx.data.unsubscribe);
         this.subscriptionEventHandles.forEach(window.mx.data.unsubscribe);
     }
@@ -137,6 +139,9 @@ export default class CalendarContainer extends Component<Container.CalendarConta
                 mxform: this.props.mxform,
                 nanoflow: this.props.dataSourceNanoflow
             }).then(mxEventObjects => {
+                if (this.destroyed) {
+                    return;
+                }
                 mxEventObjects.forEach(
                     mxEventObject =>
                         (this.subscriptionEventHandles = [


### PR DESCRIPTION
This PR relates to Support Ticket #115446 and 
#115684
When the widget is loaded subscriptions are created for each object in the calendar. On unmount they are unsubscribed. This works fine in most cases. However when the widget is destroyed before the data is retrieved a problem arises. 

When the data comes back after the unmount event, it will never be unsubscribed. When the widget is opened again there will be duplicate subscriptions cause the widget to end up in a refresh loop. (Overloading the Mendix server)

To prevent this, the widget should have an internal state and discard the fetched objects when they are received after the widget is destroyed.