### PR TITLE
feat(datagrid-web): add text template and reorder properties

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datagrid-web",
   "widgetName": "Datagrid",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "copyright": "Mendix B.V.",
   "repository": {

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -175,10 +175,15 @@ export const getPreview = (values: DatagridPreviewProps): StructurePreviewProps 
 export function check(values: DatagridPreviewProps): Problem[] {
     const errors: Problem[] = [];
     values.columns.forEach((column: ColumnsPreviewType) => {
-        if (!column.attribute && (column.sortable || values.columnsFilterable)) {
+        if (column.showContentAs === "attribute" && !column.attribute) {
             errors.push({
                 property: "column.attribute",
-                message: `An attribute is required in order to filter or sort the column ${column.header}`
+                message: `An attribute is required when 'Show' is set to 'Attribute'. Select the 'Attribute' property for column ${column.header}`
+            });
+        } else if (!column.attribute && (column.sortable || values.columnsFilterable)) {
+            errors.push({
+                property: "column.attribute",
+                message: `An attribute is required when filtering or sorting is enabled. Select the 'Attribute' property for column ${column.header}`
             });
         }
     });

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
@@ -18,8 +18,9 @@ export function preview(props: DatagridPreviewProps): ReactElement {
                       columnClass: "",
                       filter: { renderer: () => <div />, widgetCount: 0 },
                       resizable: false,
-                      hasWidgets: false,
+                      showContentAs: "attribute",
                       content: { renderer: () => <div />, widgetCount: 0 },
+                      dynamicText: "Dynamic Text",
                       draggable: false,
                       hidable: "no",
                       size: 1,
@@ -35,18 +36,21 @@ export function preview(props: DatagridPreviewProps): ReactElement {
                 (renderWrapper, _, columnIndex) => {
                     const column = columns[columnIndex];
                     const className = column.alignment ? `align-column-${column.alignment}` : "";
-                    return column.hasWidgets ? (
-                        <column.content.renderer>{renderWrapper(null, className)}</column.content.renderer>
-                    ) : (
-                        renderWrapper(
-                            <span className="td-text">
-                                {"{"}
-                                {column.attribute}
-                                {"}"}
-                            </span>,
-                            className
-                        )
-                    );
+                    switch (column.showContentAs) {
+                        case "attribute":
+                            return renderWrapper(
+                                <span className="td-text">
+                                    {"{"}
+                                    {column.attribute}
+                                    {"}"}
+                                </span>,
+                                className
+                            );
+                        case "dynamicText":
+                            return renderWrapper(<span className="td-text">{column.dynamicText}</span>, className);
+                        case "customContent":
+                            return <column.content.renderer>{renderWrapper(null, className)}</column.content.renderer>;
+                    }
                 },
                 [props.columns]
             )}

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -14,8 +14,48 @@
                     <caption>Columns</caption>
                     <description/>
                     <properties>
-                        <propertyGroup caption="General">
-                            <property key="attribute" type="attribute" dataSource="../datasource">
+                        <propertyGroup caption="Header">
+                            <property key="header" type="textTemplate">
+                                <caption>Caption</caption>
+                                <description/>
+                            </property>
+                            <property key="sortable" type="boolean" defaultValue="true">
+                                <caption>Can sort</caption>
+                                <description/>
+                            </property>
+                            <property key="resizable" type="boolean" defaultValue="true">
+                                <caption>Can resize</caption>
+                                <description/>
+                            </property>
+                            <property key="draggable" type="boolean" defaultValue="true">
+                                <caption>Can reorder</caption>
+                                <description/>
+                            </property>
+                            <property key="hidable" type="enumeration" defaultValue="yes">
+                                <caption>Can hide</caption>
+                                <description/>
+                                <enumerationValues>
+                                    <enumerationValue key="yes">Yes</enumerationValue>
+                                    <enumerationValue key="hidden">Yes, hidden by default</enumerationValue>
+                                    <enumerationValue key="no">No</enumerationValue>
+                                </enumerationValues>
+                            </property>
+                            <property key="filter" type="widgets" required="false">
+                                <caption>Filter</caption>
+                                <description/>
+                            </property>
+                        </propertyGroup>
+                        <propertyGroup caption="Content">
+                            <property key="showContentAs" type="enumeration" defaultValue="attribute">
+                                <caption>Show</caption>
+                                <description/>
+                                <enumerationValues>
+                                    <enumerationValue key="attribute">Attribute</enumerationValue>
+                                    <enumerationValue key="dynamicText">Dynamic text</enumerationValue>
+                                    <enumerationValue key="customContent">Custom content</enumerationValue>
+                                </enumerationValues>
+                            </property>
+                            <property key="attribute" type="attribute" dataSource="../datasource" required="false">
                                 <caption>Attribute</caption>
                                 <description/>
                                 <attributeTypes>
@@ -29,20 +69,12 @@
                                     <attributeType name="Long"/>
                                 </attributeTypes>
                             </property>
-                            <property key="header" type="textTemplate">
-                                <caption>Header</caption>
-                                <description/>
-                            </property>
-                            <property key="hasWidgets" type="boolean" defaultValue="false">
-                                <caption>Dynamic content</caption>
-                                <description/>
-                            </property>
-                            <property key="filter" type="widgets" required="false">
-                                <caption>Filter</caption>
-                                <description/>
-                            </property>
                             <property key="content" type="widgets" dataSource="../datasource" required="false">
-                                <caption>Content</caption>
+                                <caption>Custom content</caption>
+                                <description/>
+                            </property>
+                            <property key="dynamicText" type="textTemplate" dataSource="../datasource" required="false">
+                                <caption>Dynamic text</caption>
                                 <description/>
                             </property>
                             <property key="width" type="enumeration" defaultValue="autoFill">
@@ -71,29 +103,6 @@
                                 <caption>Dynamic cell class</caption>
                                 <description />
                                 <returnType type="String"/>
-                            </property>
-                        </propertyGroup>
-                        <propertyGroup caption="Column capabilities">
-                            <property key="sortable" type="boolean" defaultValue="true">
-                                <caption>Sortable</caption>
-                                <description/>
-                            </property>
-                            <property key="resizable" type="boolean" defaultValue="true">
-                                <caption>Resizable</caption>
-                                <description/>
-                            </property>
-                            <property key="draggable" type="boolean" defaultValue="true">
-                                <caption>Draggable</caption>
-                                <description/>
-                            </property>
-                            <property key="hidable" type="enumeration" defaultValue="yes">
-                                <caption>Hidable</caption>
-                                <description/>
-                                <enumerationValues>
-                                    <enumerationValue key="yes">Yes</enumerationValue>
-                                    <enumerationValue key="hidden">Yes, hidden by default</enumerationValue>
-                                    <enumerationValue key="no">No</enumerationValue>
-                                </enumerationValues>
                             </property>
                         </propertyGroup>
                     </properties>

--- a/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
@@ -19,7 +19,10 @@ import classNames from "classnames";
 import { EditableValue } from "mendix";
 import { useSettings } from "../utils/settings";
 
-export type TableColumn = Omit<ColumnsType | ColumnsPreviewType, "content" | "attribute">;
+export type TableColumn = Omit<
+    ColumnsType | ColumnsPreviewType,
+    "content" | "attribute" | "dynamicText" | "showContentAs"
+>;
 
 export interface TableProps<T> {
     cellRenderer: (

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Table.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Table.spec.tsx
@@ -52,7 +52,6 @@ describe("Table", () => {
                 header: "Test",
                 hasWidgets: false,
                 sortable: false,
-                filterable: "custom" as const,
                 resizable: false,
                 draggable: false,
                 hidable: "no" as const,
@@ -78,9 +77,7 @@ describe("Table", () => {
         const columns = [
             {
                 header: "Test",
-                hasWidgets: false,
                 sortable: false,
-                filterable: "custom" as const,
                 resizable: false,
                 draggable: false,
                 hidable: "no" as const,
@@ -90,9 +87,7 @@ describe("Table", () => {
             },
             {
                 header: "Test 2",
-                hasWidgets: false,
                 sortable: false,
-                filterable: "custom" as const,
                 resizable: false,
                 draggable: false,
                 hidable: "no" as const,
@@ -112,9 +107,7 @@ function mockTableProps(): TableProps<ObjectItem> {
     const columns = [
         {
             header: "Test",
-            hasWidgets: false,
             sortable: false,
-            filterable: "no" as const,
             resizable: false,
             draggable: false,
             hidable: "no" as const,

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="1.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Datagrid.xml"/>
         </widgetFiles>

--- a/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
@@ -6,51 +6,55 @@
 import { ComponentType, CSSProperties, ReactNode } from "react";
 import { ActionValue, DynamicValue, EditableValue, ListValue, ListActionValue, ListAttributeValue, ListExpressionValue, ListWidgetValue } from "mendix";
 
+export type HidableEnum = "yes" | "hidden" | "no";
+
+export type ShowContentAsEnum = "attribute" | "dynamicText" | "customContent";
+
 export type WidthEnum = "autoFill" | "autoFit" | "manual";
 
 export type AlignmentEnum = "left" | "center" | "right";
 
-export type HidableEnum = "yes" | "hidden" | "no";
-
 export interface ColumnsType {
-    attribute: ListAttributeValue<string | BigJs.Big | boolean | Date>;
     header: DynamicValue<string>;
-    hasWidgets: boolean;
-    filter?: ReactNode;
-    content?: ListWidgetValue;
-    width: WidthEnum;
-    size: number;
-    alignment: AlignmentEnum;
-    columnClass?: ListExpressionValue<string>;
     sortable: boolean;
     resizable: boolean;
     draggable: boolean;
     hidable: HidableEnum;
+    filter?: ReactNode;
+    showContentAs: ShowContentAsEnum;
+    attribute?: ListAttributeValue<string | BigJs.Big | boolean | Date>;
+    content?: ListWidgetValue;
+    dynamicText?: ListExpressionValue<string>;
+    width: WidthEnum;
+    size: number;
+    alignment: AlignmentEnum;
+    columnClass?: ListExpressionValue<string>;
 }
 
 export type PagingPositionEnum = "bottom" | "top";
 
 export interface ColumnsPreviewType {
-    attribute: string;
     header: string;
-    hasWidgets: boolean;
-    filter: { widgetCount: number; renderer: ComponentType };
-    content: { widgetCount: number; renderer: ComponentType };
-    width: WidthEnum;
-    size: number | null;
-    alignment: AlignmentEnum;
-    columnClass: string;
     sortable: boolean;
     resizable: boolean;
     draggable: boolean;
     hidable: HidableEnum;
+    filter: { widgetCount: number; renderer: ComponentType };
+    showContentAs: ShowContentAsEnum;
+    attribute: string;
+    content: { widgetCount: number; renderer: ComponentType };
+    dynamicText: string;
+    width: WidthEnum;
+    size: number | null;
+    alignment: AlignmentEnum;
+    columnClass: string;
 }
 
 export interface DatagridContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
     datasource: ListValue;
     columns: ColumnsType[];
     showEmptyPlaceholder: boolean;


### PR DESCRIPTION
**What i am doing in this PR?**
In this PR I am adding a extra property for columns to allow TextTemplate to be added ootb, I am also reordering properties to make usability better. In addition we also renamed sortable, resizable, draggable and hideble to can sort, can resize, can reorder and can hide to sounds better.

**Why?**
Because sometimes users need fast actions, this will prevent them to add manually a text template and them select the attributes that should be part of that. With the reordering it makes more comfortable tabs for Studio and makes things more clear for Studio Pro.

**How to test?**
- Combine with filters, disable filterability and sortability.
Rules:
- If Sorting or Filtering is enable then the columns will always require a attribute (to be able to filter and sort), otherwise it will just hide the property.