### PR TITLE
Data grid - Empty header & placeholder fix

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -15,7 +15,7 @@
                     <description/>
                     <properties>
                         <propertyGroup caption="Header">
-                            <property key="header" type="textTemplate">
+                            <property key="header" type="textTemplate" required="false">
                                 <caption>Caption</caption>
                                 <description/>
                             </property>

--- a/packages/pluggableWidgets/datagrid-web/src/components/Header.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Header.tsx
@@ -55,6 +55,8 @@ export function Header<D extends object>(props: HeaderProps<D>): ReactElement {
             : faArrowsAltV
         : undefined;
 
+    const caption = props.column.render("Header") as string;
+
     return (
         <div
             className="th"
@@ -63,7 +65,7 @@ export function Header<D extends object>(props: HeaderProps<D>): ReactElement {
                 ...style,
                 ...(!props.sortable || !props.column.canSort ? { cursor: "unset" } : undefined)
             }}
-            title={props.column.render("Header") as string}
+            title={caption}
         >
             <div
                 id={props.column.id}
@@ -111,7 +113,7 @@ export function Header<D extends object>(props: HeaderProps<D>): ReactElement {
                     role={canSort ? "button" : undefined}
                     tabIndex={canSort ? 0 : undefined}
                 >
-                    <span>{props.column.render("Header")}</span>
+                    <span>{caption.length > 0 ? caption : "\u00a0"}</span>
                     {sortIcon && <FontAwesomeIcon icon={sortIcon} />}
                 </div>
                 {props.filterable && props.column.customFilter ? props.column.customFilter : null}

--- a/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
@@ -336,7 +336,7 @@ export function Table<T>(props: TableProps<T>): ReactElement {
                                     gridColumn: `span ${props.columns.length + (props.columnsHidable ? 1 : 0)}`
                                 }}
                             >
-                                {children}
+                                <div className="empty-placeholder">{children}</div>
                             </div>
                         ))}
                 </InfiniteBody>

--- a/packages/pluggableWidgets/datagrid-web/src/ui/Datagrid.scss
+++ b/packages/pluggableWidgets/datagrid-web/src/ui/Datagrid.scss
@@ -184,6 +184,10 @@ $dragging-color-effect: rgba(10, 19, 37, 0.8);
             text-overflow: ellipsis;
             overflow: hidden;
         }
+
+        > .empty-placeholder {
+            width: 100%;
+        }
     }
 
     & *:focus {

--- a/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
@@ -15,7 +15,7 @@ export type WidthEnum = "autoFill" | "autoFit" | "manual";
 export type AlignmentEnum = "left" | "center" | "right";
 
 export interface ColumnsType {
-    header: DynamicValue<string>;
+    header?: DynamicValue<string>;
     sortable: boolean;
     resizable: boolean;
     draggable: boolean;


### PR DESCRIPTION
**What I am doing in this PR?**
I am fixing the alignments in the empty placeholder dropzone (container) by adding a div filling the whole space. I am also adding the capability to use headers without a caption.

**Why?**
Because sometimes users dont need to define a header caption, also the alignments in the empty placeholder were wrong due to flex.

**How to test?**
Drag in things in the empty placeholder without add an extra container and set the alignment of its elements to center and check if it behaves as expected. To test the empty caption.. well, just remove the caption :P 