### PR TITLE
Data Grid - Fix wrong context when filter is applied

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -67,7 +67,9 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
                     return renderWrapper(
                         content,
                         classNames(`align-column-${column.alignment}`, column.columnClass?.(value)?.value),
-                        props.onClick ? useCallback(() => props.onClick?.(value).execute(), [props.onClick]) : undefined
+                        props.onClick
+                            ? useCallback(() => props.onClick?.(value).execute(), [props.onClick, value])
+                            : undefined
                     );
                 },
                 [props.columns, props.rowClass, props.onClick]


### PR DESCRIPTION
**What I am doing in this PR?**
In this PR I am fixing an issue when the row contain a click event and also a filter widget is being applied.

**Why?**
The DG was passing the wrong value object to the action (preserving the original state), in this case the filtered object was not being passed to the action.

**How to test?**
Place a DG containing a row click event and drop a filter widget. After filter it should pass the correct object to the action.