### PR TITLE
Make e2e test execution configurable

### DIFF
--- a/packages/customWidgets/calendar-web/package.json
+++ b/packages/customWidgets/calendar-web/package.json
@@ -15,7 +15,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/calendar-web/package.json
+++ b/packages/customWidgets/calendar-web/package.json
@@ -15,7 +15,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/carousel-web/package.json
+++ b/packages/customWidgets/carousel-web/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/carousel-web/package.json
+++ b/packages/customWidgets/carousel-web/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/color-picker-web/package.json
+++ b/packages/customWidgets/color-picker-web/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/color-picker-web/package.json
+++ b/packages/customWidgets/color-picker-web/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/image-viewer-web/package.json
+++ b/packages/customWidgets/image-viewer-web/package.json
@@ -15,7 +15,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/image-viewer-web/package.json
+++ b/packages/customWidgets/image-viewer-web/package.json
@@ -15,7 +15,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/progress-bar-web/package.json
+++ b/packages/customWidgets/progress-bar-web/package.json
@@ -15,7 +15,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/progress-bar-web/package.json
+++ b/packages/customWidgets/progress-bar-web/package.json
@@ -15,7 +15,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/progress-circle-web/package.json
+++ b/packages/customWidgets/progress-circle-web/package.json
@@ -13,7 +13,7 @@
     "dev": "utils-react-widgets dev",
     "format": "prettier --config \"../../prettier.config.js\" --write \"{src,test}/**/*.{js,jsx,ts,tsx}\"",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/progress-circle-web/package.json
+++ b/packages/customWidgets/progress-circle-web/package.json
@@ -13,7 +13,7 @@
     "dev": "utils-react-widgets dev",
     "format": "prettier --config \"../../prettier.config.js\" --write \"{src,test}/**/*.{js,jsx,ts,tsx}\"",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/range-slider-web/package.json
+++ b/packages/customWidgets/range-slider-web/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/range-slider-web/package.json
+++ b/packages/customWidgets/range-slider-web/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/rich-text-web/package.json
+++ b/packages/customWidgets/rich-text-web/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/rich-text-web/package.json
+++ b/packages/customWidgets/rich-text-web/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/signature-web/package.json
+++ b/packages/customWidgets/signature-web/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/signature-web/package.json
+++ b/packages/customWidgets/signature-web/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/slider-web/package.json
+++ b/packages/customWidgets/slider-web/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/slider-web/package.json
+++ b/packages/customWidgets/slider-web/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/star-rating-web/package.json
+++ b/packages/customWidgets/star-rating-web/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/star-rating-web/package.json
+++ b/packages/customWidgets/star-rating-web/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test:unit",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/switch-web/package.json
+++ b/packages/customWidgets/switch-web/package.json
@@ -14,7 +14,7 @@
     "test:dev": "utils-react-widgets test:dev",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/customWidgets/switch-web/package.json
+++ b/packages/customWidgets/switch-web/package.json
@@ -14,7 +14,7 @@
     "test:dev": "utils-react-widgets test:dev",
     "test:unit": "..\"/../../node_modules/.bin/jest\" --config ../../../scripts/test/jest.web.config.js",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/pluggableWidgets/badge-button-web/package.json
+++ b/packages/pluggableWidgets/badge-button-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "..\"/../../node_modules/.bin/cross-env\" DEBUG=true node ../../node_modules/.bin/wdio ../../configs/e2e/wdio.conf.js",
     "release": "pluggable-widgets-tools release:web"
   },

--- a/packages/pluggableWidgets/badge-button-web/package.json
+++ b/packages/pluggableWidgets/badge-button-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "..\"/../../node_modules/.bin/cross-env\" DEBUG=true node ../../node_modules/.bin/wdio ../../configs/e2e/wdio.conf.js",
     "release": "pluggable-widgets-tools release:web"
   },

--- a/packages/pluggableWidgets/badge-web/package.json
+++ b/packages/pluggableWidgets/badge-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web"
   },

--- a/packages/pluggableWidgets/badge-web/package.json
+++ b/packages/pluggableWidgets/badge-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web"
   },

--- a/packages/pluggableWidgets/badge-web/typings/BadgeProps.d.ts
+++ b/packages/pluggableWidgets/badge-web/typings/BadgeProps.d.ts
@@ -14,7 +14,7 @@ export interface BadgeContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
     type: TypeEnum;
     value?: DynamicValue<string>;
     brandStyle: BrandStyleEnum;

--- a/packages/pluggableWidgets/datagrid-number-filter-web/package.json
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:ts"
   },

--- a/packages/pluggableWidgets/datagrid-number-filter-web/package.json
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:ts"
   },

--- a/packages/pluggableWidgets/datagrid-text-filter-web/package.json
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:ts"
   },

--- a/packages/pluggableWidgets/datagrid-text-filter-web/package.json
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:ts"
   },

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:ts"
   },

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:ts"
   },

--- a/packages/pluggableWidgets/fieldset-web/package.json
+++ b/packages/pluggableWidgets/fieldset-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "..\"/../../node_modules/.bin/cross-env\" DEBUG=true node ../../node_modules/.bin/wdio ../../configs/e2e/wdio.conf.js",
     "release": "pluggable-widgets-tools release:web"
   },

--- a/packages/pluggableWidgets/fieldset-web/package.json
+++ b/packages/pluggableWidgets/fieldset-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "..\"/../../node_modules/.bin/cross-env\" DEBUG=true node ../../node_modules/.bin/wdio ../../configs/e2e/wdio.conf.js",
     "release": "pluggable-widgets-tools release:web"
   },

--- a/packages/pluggableWidgets/maps-web/package.json
+++ b/packages/pluggableWidgets/maps-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js && rm tests/testProject/widgets/Maps.mpk",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web"
   },

--- a/packages/pluggableWidgets/maps-web/package.json
+++ b/packages/pluggableWidgets/maps-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js && rm tests/testProject/widgets/Maps.mpk",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web"
   },

--- a/packages/pluggableWidgets/popup-menu-web/package.json
+++ b/packages/pluggableWidgets/popup-menu-web/package.json
@@ -21,7 +21,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web"
   },

--- a/packages/pluggableWidgets/popup-menu-web/package.json
+++ b/packages/pluggableWidgets/popup-menu-web/package.json
@@ -21,7 +21,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web"
   },

--- a/packages/pluggableWidgets/timeline-web/package.json
+++ b/packages/pluggableWidgets/timeline-web/package.json
@@ -18,7 +18,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web"
   },

--- a/packages/pluggableWidgets/timeline-web/package.json
+++ b/packages/pluggableWidgets/timeline-web/package.json
@@ -18,7 +18,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web"
   },

--- a/packages/pluggableWidgets/video-player-web/package.json
+++ b/packages/pluggableWidgets/video-player-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web"
   },

--- a/packages/pluggableWidgets/video-player-web/package.json
+++ b/packages/pluggableWidgets/video-player-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-major-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web"
   },

--- a/packages/tools/pluggable-widgets-tools/scripts/e2e.js
+++ b/packages/tools/pluggable-widgets-tools/scripts/e2e.js
@@ -133,7 +133,7 @@ async function exists(filePath) {
 }
 
 async function getMendixVersion() {
-    const mendixMajorVersion = process.argv[process.argv.indexOf("--mx-major-version") + 1];
+    const desiredTestMendixVersion = process.argv[process.argv.indexOf("--mx-version") + 1];
     let mendixVersion;
 
     if (process.env.MENDIX_VERSION) {
@@ -146,11 +146,11 @@ async function getMendixVersion() {
 
         let dockerTagsJson = await dockerTagsResponse.json();
 
-        if (mendixMajorVersion) {
-            dockerTagsJson = dockerTagsJson.filter(r => r.name.startsWith(`${mendixMajorVersion}`));
+        if (desiredTestMendixVersion) {
+            dockerTagsJson = dockerTagsJson.filter(r => r.name.startsWith(desiredTestMendixVersion));
         }
 
-        const runtimeVersions = dockerTagsJson.map(r => r.name.split("-")[0]);
+        const runtimeVersions = dockerTagsJson.map(r => r.name.split("-").shift());
         runtimeVersions.sort((a, b) =>
             semverCompare(a.replace(/^(\d+\.\d+\.\d+).*/, "$1"), b.replace(/^(\d+\.\d+\.\d+).*/, "$1"))
         );

--- a/packages/tools/pluggable-widgets-tools/scripts/e2e.js
+++ b/packages/tools/pluggable-widgets-tools/scripts/e2e.js
@@ -133,7 +133,7 @@ async function exists(filePath) {
 }
 
 async function getMendixVersion() {
-    const desiredTestMendixVersion = process.argv[process.argv.indexOf("--mx-version") + 1];
+    const targetMendixVersion = process.argv[process.argv.indexOf("--mx-version") + 1];
     let mendixVersion;
 
     if (process.env.MENDIX_VERSION) {
@@ -146,8 +146,8 @@ async function getMendixVersion() {
 
         let dockerTagsJson = await dockerTagsResponse.json();
 
-        if (desiredTestMendixVersion) {
-            dockerTagsJson = dockerTagsJson.filter(r => r.name.startsWith(desiredTestMendixVersion));
+        if (targetMendixVersion) {
+            dockerTagsJson = dockerTagsJson.filter(r => r.name.startsWith(targetMendixVersion));
         }
 
         const runtimeVersions = dockerTagsJson.map(r => r.name.split("-").shift());

--- a/packages/tools/pluggable-widgets-tools/scripts/e2e.js
+++ b/packages/tools/pluggable-widgets-tools/scripts/e2e.js
@@ -133,6 +133,7 @@ async function exists(filePath) {
 }
 
 async function getMendixVersion() {
+    const mendixMajorVersion = process.argv[process.argv.indexOf("--mx-major-version") + 1];
     let mendixVersion;
 
     if (process.env.MENDIX_VERSION) {
@@ -142,7 +143,14 @@ async function getMendixVersion() {
         const dockerTagsResponse = await fetch(
             "https://registry.hub.docker.com/v1/repositories/mendix/runtime-base/tags"
         );
-        const runtimeVersions = (await dockerTagsResponse.json()).map(r => r.name.split("-")[0]);
+
+        let dockerTagsJson = await dockerTagsResponse.json();
+
+        if (mendixMajorVersion) {
+            dockerTagsJson = dockerTagsJson.filter(r => r.name.startsWith(`${mendixMajorVersion}`));
+        }
+
+        const runtimeVersions = dockerTagsJson.map(r => r.name.split("-")[0]);
         runtimeVersions.sort((a, b) =>
             semverCompare(a.replace(/^(\d+\.\d+\.\d+).*/, "$1"), b.replace(/^(\d+\.\d+\.\d+).*/, "$1"))
         );

--- a/packages/tools/pluggable-widgets-tools/scripts/e2e.js
+++ b/packages/tools/pluggable-widgets-tools/scripts/e2e.js
@@ -142,9 +142,7 @@ async function getMendixVersion() {
         const dockerTagsResponse = await fetch(
             "https://registry.hub.docker.com/v1/repositories/mendix/runtime-base/tags"
         );
-        const runtimeVersions = (await dockerTagsResponse.json())
-            .filter(r => !r.name.startsWith("9"))
-            .map(r => r.name.split("-")[0]);
+        const runtimeVersions = (await dockerTagsResponse.json()).map(r => r.name.split("-")[0]);
         runtimeVersions.sort((a, b) =>
             semverCompare(a.replace(/^(\d+\.\d+\.\d+).*/, "$1"), b.replace(/^(\d+\.\d+\.\d+).*/, "$1"))
         );

--- a/scripts/test/updateAtlas.js
+++ b/scripts/test/updateAtlas.js
@@ -1,11 +1,16 @@
 const { exec } = require("child_process");
 const {
+    createWriteStream,
     promises: { access }
 } = require("fs");
+const fetch = require("node-fetch");
+const { tmpdir } = require("os");
 const { join } = require("path");
-const { promisify } = require("util");
-const { rm } = require("shelljs");
 const rCopy = require("recursive-copy");
+const semverCompare = require("semver/functions/rcompare");
+const { rm } = require("shelljs");
+const { pipeline } = require("stream");
+const { promisify } = require("util");
 
 main().catch(e => {
     console.error(e);
@@ -16,15 +21,14 @@ async function main() {
     if (!(await exists("tests/testProject"))) {
         throw new Error("Cannot find a tests/testProject. Did you run the script in the widget folder?");
     }
-    try {
-        await promisify(exec)("unzip --help", { stdio: "ignore" });
-    } catch (e) {
-        throw new Error("This script requires unzip command to be available on the PATH!");
-    }
 
     rm("-rf", "tests/testProject/theme", "tests/testProject/themesource");
 
-    await copyLatestAtlas();
+    if (process.argv.includes("--latest-atlas")) {
+        await copyLatestAtlas();
+    } else {
+        await copyLatestReleasedAtlas();
+    }
 }
 
 async function exists(filePath) {
@@ -52,35 +56,49 @@ async function copyLatestAtlas() {
     }
 }
 
-// === Preserved for future use ===
+async function copyLatestReleasedAtlas() {
+    try {
+        await promisify(exec)("unzip --help", { stdio: "ignore" });
+    } catch (e) {
+        throw new Error("This script requires unzip command to be available on the PATH!");
+    }
 
-// async function getLatestAtlasArchive() {
-//     let latestAtlasVersions;
-//     try {
-//         const releasesResponse = await fetch("https://api.github.com/repos/mendix/Atlas-UI-Framework/releases");
-//         const suitableReleases = (await releasesResponse.json()).map(r => r.tag_name).filter(t => t.startsWith("2."));
-//         suitableReleases.sort(semverCompare);
-//         latestAtlasVersions = suitableReleases.slice(0, 2);
-//     } catch (e) {
-//         throw new Error("Couldn't reach api.github.com. Make sure you are connected to internet.");
-//     }
-//     if (!latestAtlasVersions.length) {
-//         throw new Error("Couldn't retrieve latest Atlas package from api.github.com. Try again later.");
-//     }
-//
-//     for (const latestAtlasVersion of latestAtlasVersions) {
-//         const downloadedArchivePath = join(tmpdir(), `${latestAtlasVersion}.mpk`);
-//
-//         const appstoreUrl = `https://files.appstore.mendix.com/5/104730/${latestAtlasVersion}/Atlas_UI_Resources_${latestAtlasVersion}.mpk`;
-//         console.log(`Trying to download Atlas from ${appstoreUrl}`);
-//         try {
-//             await promisify(pipeline)((await fetch(appstoreUrl)).body, createWriteStream(downloadedArchivePath));
-//             return downloadedArchivePath;
-//         } catch (e) {
-//             console.log(`Url is not available :(`);
-//             rm("-f", downloadedArchivePath);
-//         }
-//     }
-//
-//     throw new Error("Cannot find suitable Atlas in appstore.mendix.com. Try again later.");
-// }
+    const atlasArchivePath = await getLatestAtlasArchive();
+
+    try {
+        await promisify(exec)(`unzip -o ${atlasArchivePath} -x '*.mpr' '*.xml' -d tests/testProject`);
+    } catch (e) {
+        throw new Error("Failed to unzip the Atlas mpk into tests/testProject");
+    }
+}
+
+async function getLatestAtlasArchive() {
+    let latestAtlasVersions;
+    try {
+        const releasesResponse = await fetch("https://api.github.com/repos/mendix/Atlas-UI-Framework/releases");
+        const suitableReleases = (await releasesResponse.json()).map(r => r.tag_name).filter(t => t.startsWith("2."));
+        suitableReleases.sort(semverCompare);
+        latestAtlasVersions = suitableReleases.slice(0, 2);
+    } catch (e) {
+        throw new Error("Couldn't reach api.github.com. Make sure you are connected to internet.");
+    }
+    if (!latestAtlasVersions.length) {
+        throw new Error("Couldn't retrieve latest Atlas package from api.github.com. Try again later.");
+    }
+
+    for (const latestAtlasVersion of latestAtlasVersions) {
+        const downloadedArchivePath = join(tmpdir(), `${latestAtlasVersion}.mpk`);
+
+        const appstoreUrl = `https://files.appstore.mendix.com/5/104730/${latestAtlasVersion}/Atlas_UI_Resources_${latestAtlasVersion}.mpk`;
+        console.log(`Trying to download Atlas from ${appstoreUrl}`);
+        try {
+            await promisify(pipeline)((await fetch(appstoreUrl)).body, createWriteStream(downloadedArchivePath));
+            return downloadedArchivePath;
+        } catch (e) {
+            console.log(`Url is not available :(`);
+            rm("-f", downloadedArchivePath);
+        }
+    }
+
+    throw new Error("Cannot find suitable Atlas in appstore.mendix.com. Try again later.");
+}


### PR DESCRIPTION
### Why?
To iteratively convert web test projects to mx 9 and atlas 3, we need to be able to run e2e test on both mx 8 and 9 version as well as Atlas 2 (released) and Atlas 3 changes. Also, we can use this in the future to test web widgets on multiple mx platforms.

### What has been done?
- Add an option `--mx-version` to which a version argument, like `8` or `9`, can be passed.
- Add an option `--latest-atlas` to test with Atlas inside mono repo. Without the option, latest released Atlas from Atlas-UI-Framework is used.
- Update all `test:e2e` scripts for web widgets to use mx major version 8.

### How to test?
- All e2e tests should pass.