### PR TITLE
maps-web: fix error using mx version 9

### DIFF
--- a/packages/pluggableWidgets/maps-web/package.json
+++ b/packages/pluggableWidgets/maps-web/package.json
@@ -22,7 +22,7 @@
     "lint": "..\"/../../node_modules/.bin/eslint\" --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js && rm tests/testProject/widgets/Maps.mpk",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 9",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web"
   },


### PR DESCRIPTION
There's a bug when running e2e tests for maps-web using mx-8.18. However, now is possible to define which version to use when running the e2e tests(https://github.com/mendix/widgets-resources/pull/439). I did that, changing this specs for maps-web to run using mx-9 image.