### PR TITLE
[WC-140] Transform groups into tabs for Studio - Apply to Data Grid

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -6,11 +6,16 @@ import {
     Problem,
     Properties,
     RowLayoutProps,
-    StructurePreviewProps
+    StructurePreviewProps,
+    transformGroupsIntoTabs
 } from "@widgets-resources/piw-utils";
 import { ColumnsPreviewType, DatagridPreviewProps } from "../typings/DatagridProps";
 
-export function getProperties(values: DatagridPreviewProps, defaultProperties: Properties): Properties {
+export function getProperties(
+    values: DatagridPreviewProps,
+    defaultProperties: Properties,
+    platform: "web" | "desktop"
+): Properties {
     values.columns.forEach((column, index) => {
         if (column.showContentAs !== "attribute" && !column.sortable && !values.columnsFilterable) {
             hidePropertyIn(defaultProperties, values, "columns", index, "attribute");
@@ -69,6 +74,9 @@ export function getProperties(values: DatagridPreviewProps, defaultProperties: P
         },
         "columns"
     );
+    if (platform === "web") {
+        transformGroupsIntoTabs(defaultProperties);
+    }
     return defaultProperties;
 }
 

--- a/packages/tools/piw-utils/src/utils/PageEditorUtils.ts
+++ b/packages/tools/piw-utils/src/utils/PageEditorUtils.ts
@@ -71,6 +71,17 @@ export function changePropertyIn<T, TKey extends keyof T>(
     modifyProperty(modify, propertyGroups, key, nestedPropIndex, nestedPropKey);
 }
 
+export function transformGroupsIntoTabs(properties: Properties) {
+    const groups: PropertyGroup[] = [];
+    properties.forEach(property => {
+        if (property.propertyGroups) {
+            groups.push(...property.propertyGroups);
+            property.propertyGroups = [];
+        }
+    });
+    properties.push(...groups);
+}
+
 function modifyProperty(
     modify: (prop: Property, index: number, container: Property[]) => void,
     propertyGroups: PropertyGroup[],


### PR DESCRIPTION
**In this PR I am:**
Adding a method that converts property groups into tabs to be used in Studio.

**Why?**
Because in Studio groups are not being rendered as fieldsets.

**How to test?**
Run a project in the cloud and test in Studio (Applies only to 8.18.1), in SP it should remains the same.