### PR TITLE
[WC-148] Add header to Data grid preview

### DIFF
--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/DatagridDateFilter.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/DatagridDateFilter.editorConfig.ts
@@ -27,6 +27,7 @@ export const getPreview = (values: DatagridDateFilterPreviewProps): StructurePre
         type: "RowLayout",
         borders: true,
         borderRadius: 5,
+        borderWidth: 1,
         columnSize: "grow",
         children: [
             {

--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/DatagridDropdownFilter.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/DatagridDropdownFilter.editorConfig.ts
@@ -12,6 +12,7 @@ export const getPreview = (values: DatagridDropdownFilterPreviewProps): Structur
         type: "RowLayout",
         borders: true,
         borderRadius: 5,
+        borderWidth: 1,
         columnSize: "grow",
         children: [
             {

--- a/packages/pluggableWidgets/datagrid-number-filter-web/src/DatagridNumberFilter.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/src/DatagridNumberFilter.editorConfig.ts
@@ -26,6 +26,7 @@ export const getPreview = (values: DatagridNumberFilterPreviewProps): StructureP
         type: "RowLayout",
         borders: true,
         borderRadius: 5,
+        borderWidth: 1,
         columnSize: "grow",
         children: [
             {

--- a/packages/pluggableWidgets/datagrid-text-filter-web/src/DatagridTextFilter.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/src/DatagridTextFilter.editorConfig.ts
@@ -30,6 +30,7 @@ export const getPreview = (values: DatagridTextFilterPreviewProps): StructurePre
         columnSize: "grow",
         borders: true,
         borderRadius: 5,
+        borderWidth: 1,
         children: [
             {
                 type: "RowLayout",

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -135,6 +135,26 @@ export const getPreview = (values: DatagridPreviewProps): StructurePreviewProps 
                 } as ContainerProps)
         )
     };
+    const titleHeader: RowLayoutProps = {
+        type: "RowLayout",
+        columnSize: "fixed",
+        backgroundColor: "#daeffb",
+        borders: true,
+        borderWidth: 1,
+        children: [
+            {
+                type: "Container",
+                padding: 4,
+                children: [
+                    {
+                        type: "Text",
+                        content: "Data grid 2",
+                        fontColor: "#2074c8"
+                    }
+                ]
+            }
+        ]
+    };
     const headers: RowLayoutProps = {
         type: "RowLayout",
         columnSize: "fixed",
@@ -203,7 +223,7 @@ export const getPreview = (values: DatagridPreviewProps): StructurePreviewProps 
         : [];
     return {
         type: "Container",
-        children: [headers, ...Array.from({ length: 5 }).map(() => columns), ...footer]
+        children: [titleHeader, headers, ...Array.from({ length: 5 }).map(() => columns), ...footer]
     };
 };
 


### PR DESCRIPTION
**Why?**
Users where having problem to find out where the properties of the data grid are reachable. While PE is creating a header component, this will be used. The new one will also show the icon and the source.

**Bonus**
- Adding borders to the filters due to 9.0.3 removed the default border.

![image](https://user-images.githubusercontent.com/45102481/107938147-34acb780-6f85-11eb-88dc-7ef6449db384.png)
