### PR TITLE
fix(app-events-native): clear subs on background to re-sub on open

### DIFF
--- a/packages/pluggableWidgets/app-events-native/src/AppEvents.tsx
+++ b/packages/pluggableWidgets/app-events-native/src/AppEvents.tsx
@@ -2,8 +2,8 @@ import NetInfo, { NetInfoSubscription, NetInfoState } from "@react-native-commun
 import { Component } from "react";
 import { AppState, AppStateStatus } from "react-native";
 
-import { AppEventsProps } from "../typings/AppEventsProps";
-import { executeAction } from "@mendix/piw-utils-internal";
+import { AppEventsProps, TimerTypeEnum } from "../typings/AppEventsProps";
+import { executeAction } from "@widgets-resources/piw-utils";
 
 export type Props = AppEventsProps<undefined>;
 
@@ -18,59 +18,55 @@ export class AppEvents extends Component<Props> {
     private lastOnOnline = 0;
     private lastOnOffline = 0;
     private onLoadTriggered = false;
-    private timeoutHandle?: any;
+    private onTimeoutAction: ScheduledExecution | undefined;
     private unsubscribeNetworkEventListener?: NetInfoSubscription;
 
     async componentDidMount(): Promise<void> {
-        await this.registerSubscriptions();
-
-        if (!this.onLoadTriggered && this.props.onLoadAction?.canExecute) {
-            this.onLoadTriggered = true;
-            executeAction(this.props.onLoadAction);
-        }
+        AppState.addEventListener("change", this.onAppStateChangeHandler);
+        this.registerScheduledExecution();
+        await this.registerNetworkEvents();
+        this.triggerOnLoadEvent();
     }
 
-    private async registerSubscriptions(): Promise<void> {
+    componentWillUnmount(): void {
+        AppState.removeEventListener("change", this.onAppStateChangeHandler);
+        this.onTimeoutAction?.cancel();
+        this.unRegisterNetworkEvents();
+        // TODO: Suggestion Deprecate this behavior.
+        // Keeping it as most likely someone is misusing this for tracking navigation events.
+        this.triggerOnUnloadEvent();
+    }
+
+    render(): null {
+        return null;
+    }
+
+    private async onResume(): Promise<void> {
         if (this.props.onResumeAction) {
-            AppState.addEventListener("change", this.onAppStateChangeHandler);
+            executeAction(this.props.onResumeAction);
         }
+        this.onTimeoutAction?.schedule();
+        this.lastOnResume = Date.now();
+        // TODO: Not clear if onResume should wait for registerNetworkEvents. This can take a few seconds while app has resumed
+        await this.registerNetworkEvents();
+    }
 
-        if (this.props.onTimeoutAction) {
-            const schedule = this.props.timerType === "once" ? setTimeout : setInterval;
-            this.timeoutHandle = schedule(() => executeAction(this.props.onTimeoutAction), this.props.delayTime * 1000);
-        }
+    private onBackground(): void {
+        this.onTimeoutAction?.cancel();
+        this.unRegisterNetworkEvents();
+        this.triggerOnUnloadEvent();
+    }
 
+    // TODO: Maybe extract this to own widget or js action? It forces an await and makes the whole contract very confusing
+    private async registerNetworkEvents(): Promise<void> {
         if (this.props.onOnlineAction || this.props.onOfflineAction) {
             this.isConnected = (await NetInfo.fetch()).isConnected;
             this.unsubscribeNetworkEventListener = NetInfo.addEventListener(this.onConnectionChangeHandler);
         }
     }
 
-    componentWillUnmount(): void {
-        this.clearSubscriptions();
-    }
-
-    private clearSubscriptions(): void {
-        if (this.props.onUnloadAction && this.props.onUnloadAction.canExecute) {
-            executeAction(this.props.onUnloadAction);
-        }
-
-        if (this.props.onResumeAction) {
-            AppState.removeEventListener("change", this.onAppStateChangeHandler);
-        }
-
-        if (this.unsubscribeNetworkEventListener) {
-            this.unsubscribeNetworkEventListener();
-        }
-
-        if (this.props.onTimeoutAction && this.timeoutHandle != null) {
-            const clear = this.props.timerType === "once" ? clearTimeout : clearInterval;
-            clear(this.timeoutHandle);
-        }
-    }
-
-    render(): null {
-        return null;
+    private unRegisterNetworkEvents(): void {
+        this.unsubscribeNetworkEventListener?.();
     }
 
     private async onAppStateChange(nextAppState: AppStateStatus): Promise<void> {
@@ -79,11 +75,9 @@ export class AppEvents extends Component<Props> {
         }
 
         if (nextAppState === "active" && isPastTimeout(this.lastOnResume, this.props.onResumeTimeout)) {
-            await this.registerSubscriptions();
-            executeAction(this.props.onResumeAction);
-            this.lastOnResume = Date.now();
+            await this.onResume();
         } else if (nextAppState === "background") {
-            this.clearSubscriptions();
+            this.onBackground();
         }
 
         this.appState = nextAppState;
@@ -106,8 +100,109 @@ export class AppEvents extends Component<Props> {
 
         this.isConnected = nextState.isConnected;
     }
+
+    private triggerOnUnloadEvent(): void {
+        if (this.props.onUnloadAction && this.props.onUnloadAction.canExecute) {
+            executeAction(this.props.onUnloadAction);
+        }
+    }
+
+    private triggerOnLoadEvent(): void {
+        if (!this.onLoadTriggered && this.props.onLoadAction?.canExecute) {
+            this.onLoadTriggered = true;
+            executeAction(this.props.onLoadAction);
+        }
+    }
+
+    private registerScheduledExecution(): void {
+        if (this.props.onTimeoutAction) {
+            this.onTimeoutAction = scheduleTask(
+                () => executeAction(this.props.onTimeoutAction),
+                this.props.delayTime * 1000,
+                this.props.timerType
+            );
+        }
+    }
 }
 
 function isPastTimeout(last: number, timeoutSeconds: number): boolean {
     return Date.now() - last >= timeoutSeconds * 1000;
+}
+
+interface ScheduledExecution {
+    cancel: () => boolean;
+    schedule: () => boolean;
+}
+
+class ScheduledOnceExecution {
+    private timeoutHandle: number | undefined;
+    private _finished = false;
+    private _running = false;
+
+    constructor(private readonly fn: () => void, private readonly interval: number) {
+        this.schedule();
+    }
+
+    cancel(): boolean {
+        if (!this._running || this._finished) {
+            return false;
+        }
+
+        clearTimeout(this.timeoutHandle);
+        this._running = false;
+        return true;
+    }
+
+    schedule(): boolean {
+        if (this._running || this._finished) {
+            return false;
+        }
+
+        this.timeoutHandle = setTimeout(() => {
+            this.fn();
+            this._finished = true;
+            this._running = false;
+        }, this.interval);
+        this._running = true;
+        return true;
+    }
+}
+
+class ScheduledIntervalExecution {
+    private timeoutHandle: number | undefined;
+    private _running = false;
+
+    constructor(private readonly fn: () => void, private readonly interval: number) {
+        this.schedule();
+    }
+
+    cancel(): boolean {
+        if (!this._running) {
+            return false;
+        }
+        clearInterval(this.timeoutHandle);
+        this._running = false;
+        return true;
+    }
+
+    schedule(): boolean {
+        if (this._running) {
+            return false;
+        }
+
+        this.timeoutHandle = setInterval(() => {
+            this.fn();
+        }, this.interval);
+        this._running = true;
+        return true;
+    }
+}
+
+function scheduleTask(fn: () => void, timeInMs: number, type: TimerTypeEnum) {
+    switch (type) {
+        case "interval":
+            return new ScheduledIntervalExecution(fn, timeInMs);
+        case "once":
+            return new ScheduledOnceExecution(fn, timeInMs);
+    }
 }

--- a/packages/pluggableWidgets/app-events-native/src/AppEvents.tsx
+++ b/packages/pluggableWidgets/app-events-native/src/AppEvents.tsx
@@ -17,8 +17,7 @@ export class AppEvents extends Component<Props> {
     private isConnected?: boolean;
     private lastOnOnline = 0;
     private lastOnOffline = 0;
-    private onLoadTriggered = false;
-    private onTimeoutAction: ScheduledExecution | undefined;
+    private onTimeoutAction?: ScheduledExecution;
     private unsubscribeNetworkEventListener?: NetInfoSubscription;
 
     async componentDidMount(): Promise<void> {
@@ -104,8 +103,7 @@ export class AppEvents extends Component<Props> {
     }
 
     private triggerOnLoadEvent(): void {
-        if (!this.onLoadTriggered && this.props.onLoadAction?.canExecute) {
-            this.onLoadTriggered = true;
+        if (this.props.onLoadAction?.canExecute) {
             executeAction(this.props.onLoadAction);
         }
     }
@@ -131,7 +129,7 @@ interface ScheduledExecution {
 }
 
 class ScheduledOnceExecution implements ScheduledExecution {
-    private timeoutHandle: number | undefined;
+    private timeoutHandle?: number;
     private _finished = false;
     private _running = false;
 
@@ -163,7 +161,7 @@ class ScheduledOnceExecution implements ScheduledExecution {
 }
 
 class ScheduledIntervalExecution implements ScheduledExecution {
-    private timeoutHandle: number | undefined;
+    private timeoutHandle?: number;
     private _running = false;
 
     constructor(private readonly fn: () => void, private readonly interval: number) {
@@ -183,9 +181,7 @@ class ScheduledIntervalExecution implements ScheduledExecution {
             return;
         }
 
-        this.timeoutHandle = setInterval(() => {
-            this.fn();
-        }, this.interval);
+        this.timeoutHandle = setInterval(() => this.fn(), this.interval);
         this._running = true;
     }
 }

--- a/packages/pluggableWidgets/app-events-native/src/__tests__/AppEvents.spec.tsx
+++ b/packages/pluggableWidgets/app-events-native/src/__tests__/AppEvents.spec.tsx
@@ -189,6 +189,38 @@ describe("AppEvents", () => {
             expect(onTimeoutAction.execute).toHaveBeenCalledTimes(0);
         });
 
+        it("does not execute the on timeout action after the app went to background", () => {
+            const onTimeoutAction = actionValue(true, true);
+            render(<AppEvents {...defaultProps} onTimeoutAction={onTimeoutAction} />);
+
+            expect(onTimeoutAction.execute).not.toHaveBeenCalled();
+
+            expect(appStateChangeHandler).toBeDefined();
+            appStateChangeHandler?.("background");
+
+            jest.advanceTimersByTime(30000);
+            expect(onTimeoutAction.execute).toHaveBeenCalledTimes(0);
+            jest.advanceTimersByTime(30000);
+            expect(onTimeoutAction.execute).toHaveBeenCalledTimes(0);
+        });
+
+        it("executes the on timeout action after the app returns from background if not yet executed", () => {
+            const onTimeoutAction = actionValue();
+            render(<AppEvents {...defaultProps} onTimeoutAction={onTimeoutAction} />);
+
+            expect(onTimeoutAction.execute).not.toHaveBeenCalled();
+
+            expect(appStateChangeHandler).toBeDefined();
+
+            appStateChangeHandler?.("background");
+            jest.advanceTimersByTime(30000);
+            expect(onTimeoutAction.execute).toHaveBeenCalledTimes(0);
+
+            appStateChangeHandler?.("active");
+            jest.advanceTimersByTime(30000);
+            expect(onTimeoutAction.execute).toHaveBeenCalledTimes(1);
+        });
+
         it("executes the interval on timeout action after every interval", () => {
             const onTimeoutAction = actionValue();
             render(<AppEvents {...defaultProps} onTimeoutAction={onTimeoutAction} timerType={"interval"} />);
@@ -219,6 +251,39 @@ describe("AppEvents", () => {
 
             jest.advanceTimersByTime(30000);
             expect(onTimeoutAction.execute).not.toHaveBeenCalled();
+        });
+
+        it("does not execute the interval when the app is in background", () => {
+            const onTimeoutAction = actionValue(true, true);
+            render(<AppEvents {...defaultProps} onTimeoutAction={onTimeoutAction} timerType={"interval"} />);
+
+            expect(onTimeoutAction.execute).not.toHaveBeenCalled();
+
+            expect(appStateChangeHandler).toBeDefined();
+            appStateChangeHandler?.("background");
+
+            jest.advanceTimersByTime(30000);
+            expect(onTimeoutAction.execute).toHaveBeenCalledTimes(0);
+            jest.advanceTimersByTime(30000);
+            expect(onTimeoutAction.execute).toHaveBeenCalledTimes(0);
+        });
+
+        it("executes the interval when the app returns from background", () => {
+            const onTimeoutAction = actionValue();
+            render(<AppEvents {...defaultProps} onTimeoutAction={onTimeoutAction} timerType={"interval"} />);
+
+            expect(onTimeoutAction.execute).not.toHaveBeenCalled();
+
+            expect(appStateChangeHandler).toBeDefined();
+            appStateChangeHandler?.("background");
+            jest.advanceTimersByTime(30000);
+            expect(onTimeoutAction.execute).toHaveBeenCalledTimes(0);
+
+            appStateChangeHandler?.("active");
+            jest.advanceTimersByTime(30000);
+            expect(onTimeoutAction.execute).toHaveBeenCalledTimes(1);
+            jest.advanceTimersByTime(30000);
+            expect(onTimeoutAction.execute).toHaveBeenCalledTimes(2);
         });
     });
 });

--- a/packages/pluggableWidgets/app-events-native/src/__tests__/AppEvents.spec.tsx
+++ b/packages/pluggableWidgets/app-events-native/src/__tests__/AppEvents.spec.tsx
@@ -50,10 +50,11 @@ describe("AppEvents", () => {
     });
 
     describe("with on load action", () => {
-        it("executes the on load action", () => {
+        it("executes the on load action", async () => {
             const onLoadAction = actionValue();
-            const { update } = render(<AppEvents {...defaultProps} onLoadAction={onLoadAction} />);
-            update(<AppEvents {...defaultProps} onLoadAction={onLoadAction} />);
+            const element = <AppEvents {...defaultProps} onLoadAction={onLoadAction} />;
+
+            await render(element);
             expect(onLoadAction.execute).toHaveBeenCalledTimes(1);
         });
     });

--- a/packages/pluggableWidgets/app-events-native/tsconfig.json
+++ b/packages/pluggableWidgets/app-events-native/tsconfig.json
@@ -1,5 +1,8 @@
 {
     "extends": "@mendix/pluggable-widgets-tools/configs/tsconfig.base",
     "baseUrl": "./",
-    "include": ["./src"]
+    "include": ["./src"],
+    "compilerOptions": {
+        "types": ["react-native", "jest"]
+    }
 }


### PR DESCRIPTION
## Why ?

Important fix for making subs cleared out when the app is on background. This will allow it to re-sub when app is active.

