### PR TITLE
feat(datagrid-web): add requestTotalCount

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -13,6 +13,9 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
         ? props.datasource.limit / props.pageSize
         : props.datasource.offset / props.pageSize;
 
+    // @ts-ignore // TODO: Remove when Studio Pro 9.0.5 typings are released
+    props.datasource.requestTotalCount?.(isServerSide);
+
     useState(() => {
         if (isServerSide) {
             if (props.datasource.limit === Number.POSITIVE_INFINITY) {


### PR DESCRIPTION
**Why?**
Practice shows that pluggable widgets rarely use `ListValue.totalCount`, but currently its value is requested from the runtime for all data sources. This is unfortunate, since computing `totalCount` can be expensive.

What I did in this PR?
- Added a backwards compatible call to `requestTotalCount`

How to test?
- To force the datasource to request totalCount the DG should be configured without Sorting or Filtering.