### PR TITLE
Prepare for timeline web 2.0.0 release

### DIFF
--- a/packages/pluggableWidgets/timeline-web/package.json
+++ b/packages/pluggableWidgets/timeline-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "timeline-web",
   "widgetName": "Timeline",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Shows timeline",
   "copyright": "Mendix BV",
   "author": "Mendix",

--- a/packages/pluggableWidgets/timeline-web/src/package.xml
+++ b/packages/pluggableWidgets/timeline-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Timeline" version="1.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Timeline" version="2.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Timeline.xml"/>
         </widgetFiles>


### PR DESCRIPTION
The structure preview changes are not compatible with MX8, therefore this widget is now v2.0.0.