### PR TITLE
[NC-155] VIdeo Player - Fix aspect ratio

### DIFF
--- a/packages/pluggableWidgets/video-player-native/src/VideoPlayer.tsx
+++ b/packages/pluggableWidgets/video-player-native/src/VideoPlayer.tsx
@@ -35,7 +35,16 @@ export class VideoPlayer extends Component<Props, State> {
         const styles = { ...this.styles.container };
 
         if (this.props.aspectRatio && this.state.aspectRatio) {
+            this.styles.video.aspectRatio = this.state.aspectRatio;
             styles.aspectRatio = this.state.aspectRatio;
+        } else if (!this.props.aspectRatio) {
+            styles.aspectRatio = undefined;
+            if (this.styles.video.width) {
+                styles.width = this.styles.video.width;
+            }
+            if (this.styles.video.height) {
+                styles.height = this.styles.video.height;
+            }
         }
 
         return (
@@ -58,14 +67,14 @@ export class VideoPlayer extends Component<Props, State> {
                     onError={this.onErrorHandler}
                     style={this.state.status !== StatusEnum.READY ? { height: 0 } : this.styles.video}
                     useTextureView={false}
-                    resizeMode="contain"
+                    resizeMode={this.props.aspectRatio ? "contain" : "stretch"}
                 />
             </View>
         );
     }
 
     private onLoadStart(): void {
-        this.setState({ status: StatusEnum.LOADING, aspectRatio: undefined });
+        this.setState({ status: StatusEnum.LOADING });
     }
 
     private onLoad(data: OnLoadData): void {
@@ -73,6 +82,6 @@ export class VideoPlayer extends Component<Props, State> {
     }
 
     private onError(): void {
-        this.setState({ status: StatusEnum.ERROR, aspectRatio: undefined });
+        this.setState({ status: StatusEnum.ERROR });
     }
 }

--- a/packages/pluggableWidgets/video-player-native/src/VideoPlayer.tsx
+++ b/packages/pluggableWidgets/video-player-native/src/VideoPlayer.tsx
@@ -5,6 +5,7 @@ import Video from "react-native-video";
 import { VideoPlayerProps } from "../typings/VideoPlayerProps";
 import { defaultVideoStyle, VideoStyle } from "./ui/Styles";
 import { isAvailable } from "@widgets-resources/piw-utils";
+import deepmerge from "deepmerge";
 
 const enum StatusEnum {
     ERROR = "error",
@@ -19,7 +20,7 @@ export function VideoPlayer(props: VideoPlayerProps<VideoStyle>): ReactElement {
     const [videoAspectRatio, setVideoAspectRatio] = useState(0);
 
     useEffect(() => {
-        const alteredStyles = JSON.parse(JSON.stringify(styles));
+        const alteredStyles = deepmerge({}, styles);
         if (props.aspectRatio && videoAspectRatio !== 0) {
             alteredStyles.video.aspectRatio = videoAspectRatio;
             alteredStyles.container.aspectRatio = videoAspectRatio;

--- a/packages/pluggableWidgets/video-player-native/src/VideoPlayer.xml
+++ b/packages/pluggableWidgets/video-player-native/src/VideoPlayer.xml
@@ -27,9 +27,9 @@
                 </property>
             </propertyGroup>
             <propertyGroup caption="Display">
-                <property key="aspectRatio" type="boolean" defaultValue="false">
+                <property key="aspectRatio" type="boolean" defaultValue="true">
                     <caption>Keep aspect ratio</caption>
-                    <description>Base aspect ratio on video height</description>
+                    <description>Base aspect ratio on video height. If set to false, make sure to add height and width to the 'video' style property.</description>
                 </property>
                 <property key="showControls" type="boolean" defaultValue="true">
                     <caption>Show controls</caption>

--- a/packages/pluggableWidgets/video-player-native/src/__tests__/VideoPlayer.spec.tsx
+++ b/packages/pluggableWidgets/video-player-native/src/__tests__/VideoPlayer.spec.tsx
@@ -4,12 +4,14 @@ import { Text, View } from "react-native";
 import { fireEvent, render } from "react-native-testing-library";
 import { VideoProperties } from "react-native-video";
 
-import { Props, VideoPlayer } from "../VideoPlayer";
+import { VideoPlayer } from "../VideoPlayer";
+import { VideoPlayerProps } from "../../typings/VideoPlayerProps";
+import { VideoStyle } from "../ui/Styles";
 
 jest.mock("react-native-video", () => "Video");
 
 describe("VideoPlayer", () => {
-    let defaultProps: Props;
+    let defaultProps: VideoPlayerProps<VideoStyle>;
 
     beforeEach(() => {
         defaultProps = {
@@ -48,7 +50,7 @@ describe("VideoPlayer", () => {
         fireEvent(component.getByTestId("video-player-test"), "load", { naturalSize: { width: 640, height: 360 } });
 
         expect(component.toJSON()).toMatchSnapshot();
-        expect(component.getByTestId("video-player-test").props.style).toEqual({ width: "100%", height: "100%" });
+        expect(component.getByTestId("video-player-test").props.style).toEqual({ width: "100%", height: undefined });
     });
 
     it("shows the loading indicator if the source changes", () => {

--- a/packages/pluggableWidgets/video-player-native/src/__tests__/__snapshots__/VideoPlayer.spec.tsx.snap
+++ b/packages/pluggableWidgets/video-player-native/src/__tests__/__snapshots__/VideoPlayer.spec.tsx.snap
@@ -5,9 +5,10 @@ exports[`VideoPlayer hides the loading indicator after load 1`] = `
   style={
     Object {
       "alignItems": "center",
-      "aspectRatio": 1.7777777777777777,
+      "aspectRatio": undefined,
       "backgroundColor": "black",
       "justifyContent": "center",
+      "width": "100%",
     }
   }
 >
@@ -19,7 +20,7 @@ exports[`VideoPlayer hides the loading indicator after load 1`] = `
     onLoadStart={[Function]}
     paused={true}
     repeat={false}
-    resizeMode="contain"
+    resizeMode="stretch"
     source={
       Object {
         "uri": "https://mendix.com/video.mp4",
@@ -27,7 +28,6 @@ exports[`VideoPlayer hides the loading indicator after load 1`] = `
     }
     style={
       Object {
-        "height": "100%",
         "width": "100%",
       }
     }
@@ -64,7 +64,7 @@ exports[`VideoPlayer load a video and calculate the aspect ratio 1`] = `
     }
     style={
       Object {
-        "height": "100%",
+        "aspectRatio": 1.9494584837545126,
         "width": "100%",
       }
     }
@@ -79,9 +79,10 @@ exports[`VideoPlayer renders a loading indicator 1`] = `
   style={
     Object {
       "alignItems": "center",
-      "aspectRatio": 1.7777777777777777,
+      "aspectRatio": undefined,
       "backgroundColor": "black",
       "justifyContent": "center",
+      "width": "100%",
     }
   }
 >
@@ -93,7 +94,7 @@ exports[`VideoPlayer renders a loading indicator 1`] = `
     onLoadStart={[Function]}
     paused={true}
     repeat={false}
-    resizeMode="contain"
+    resizeMode="stretch"
     source={
       Object {
         "uri": "https://mendix.com/video.mp4",
@@ -115,9 +116,10 @@ exports[`VideoPlayer shows the loading indicator if the source changes 1`] = `
   style={
     Object {
       "alignItems": "center",
-      "aspectRatio": 1.7777777777777777,
+      "aspectRatio": undefined,
       "backgroundColor": "black",
       "justifyContent": "center",
+      "width": "100%",
     }
   }
 >
@@ -135,7 +137,7 @@ exports[`VideoPlayer shows the loading indicator if the source changes 1`] = `
     onLoadStart={[Function]}
     paused={true}
     repeat={false}
-    resizeMode="contain"
+    resizeMode="stretch"
     source={
       Object {
         "uri": "https://mendix.com/video.mp4",

--- a/packages/pluggableWidgets/video-player-native/src/__tests__/__snapshots__/VideoPlayer.spec.tsx.snap
+++ b/packages/pluggableWidgets/video-player-native/src/__tests__/__snapshots__/VideoPlayer.spec.tsx.snap
@@ -28,6 +28,7 @@ exports[`VideoPlayer hides the loading indicator after load 1`] = `
     }
     style={
       Object {
+        "height": undefined,
         "width": "100%",
       }
     }
@@ -65,6 +66,7 @@ exports[`VideoPlayer load a video and calculate the aspect ratio 1`] = `
     style={
       Object {
         "aspectRatio": 1.9494584837545126,
+        "height": undefined,
         "width": "100%",
       }
     }

--- a/packages/pluggableWidgets/video-player-native/src/ui/Styles.ts
+++ b/packages/pluggableWidgets/video-player-native/src/ui/Styles.ts
@@ -1,7 +1,7 @@
 import { Style } from "@native-mobile-resources/util-widgets";
 import { TextStyle, ViewStyle } from "react-native";
 
-interface VideoStyle extends Style {
+export interface VideoStyle extends Style {
     container: ViewStyle;
     indicator: {
         color: string;

--- a/packages/pluggableWidgets/video-player-native/src/ui/Styles.ts
+++ b/packages/pluggableWidgets/video-player-native/src/ui/Styles.ts
@@ -22,7 +22,7 @@ export const defaultVideoStyle: VideoStyle = {
     },
     video: {
         width: "100%",
-        height: "100%"
+        height: undefined
     },
     errorMessage: {
         color: "white"


### PR DESCRIPTION
`property => Aspect ratio boolean property`

## Why ?

Property was not making any difference in the video presentation. Not sure how many people were switching this property off but it wasn't working correctly.

## What did i do?

- Depending on the property, we now set the resize mode of the video (contain, stretch). This will actually allow video to resize as expected. 
- Since we are not setting `aspectRatio` style property when the property set to false, we extended the helper text so people should add "height" and "width" to have the best result.
- Before the surrounding container was not respecting the size of the video, now it does.


## Bonus

Converted to functional component