### PR TITLE
[WC-98] Update atlas style variations

### DIFF
--- a/packages/theming/atlas/src/theme/web/custom-variables.scss
+++ b/packages/theming/atlas/src/theme/web/custom-variables.scss
@@ -19,8 +19,6 @@ $gray-lighter: #f8f8f8;
 //== Step 1: Brand Colors
 $brand-default: $gray-primary;
 $brand-primary: #264ae5;
-$brand-inverse: #24276c;
-$brand-info: #0086d9;
 $brand-success: #3cb33d;
 $brand-warning: #eca51c;
 $brand-danger: #e33f4e;
@@ -49,9 +47,6 @@ $m-header-height: 45px;
 $m-header-bg: $topbar-bg;
 $m-header-color: #555;
 $m-header-title-size: 17px;
-
-// Sidebar
-$sidebar-bg: $brand-inverse;
 
 // Navbar Brand Name / For your company, product, or project name (used in layouts/base/)
 $navbar-brand-name: $font-color-default;
@@ -129,7 +124,6 @@ $navigation-font-size: $font-size-default;
 $navigation-sub-font-size: $font-size-small;
 $navigation-glyph-size: 20px; // For glyphicons that you can select in the Mendix Modeler
 
-$navigation-bg: $brand-inverse;
 $navigation-bg-hover: lighten($navigation-bg, 4);
 $navigation-bg-active: lighten($navigation-bg, 8);
 $navigation-color: #fff;
@@ -239,27 +233,21 @@ $btn-border-radius: $border-radius-default;
 
 // Button Background Color
 $btn-default-bg: #fff;
-$btn-inverse-bg: $brand-inverse;
 $btn-primary-bg: $brand-primary;
-$btn-info-bg: $brand-info;
 $btn-success-bg: $brand-success;
 $btn-warning-bg: $brand-warning;
 $btn-danger-bg: $brand-danger;
 
 // Button Border Color
 $btn-default-border-color: $gray-primary;
-$btn-inverse-border-color: $brand-inverse;
 $btn-primary-border-color: $brand-primary;
-$btn-info-border-color: $brand-info;
 $btn-success-border-color: $brand-success;
 $btn-warning-border-color: $brand-warning;
 $btn-danger-border-color: $brand-danger;
 
 // Button Text Color
 $btn-default-color: $brand-primary;
-$btn-inverse-color: #fff;
 $btn-primary-color: #fff;
-$btn-info-color: #fff;
 $btn-success-color: #fff;
 $btn-warning-color: #fff;
 $btn-danger-color: #fff;
@@ -269,9 +257,7 @@ $btn-default-icon-color: $gray;
 
 // Button Background Color
 $btn-default-bg-hover: $btn-default-border-color;
-$btn-inverse-bg-hover: mix($btn-inverse-bg, white, 80%);
 $btn-primary-bg-hover: mix($btn-primary-bg, black, 80%);
-$btn-info-bg-hover: mix($btn-info-bg, black, 80%);
 $btn-success-bg-hover: mix($btn-success-bg, black, 80%);
 $btn-warning-bg-hover: mix($btn-warning-bg, black, 80%);
 $btn-danger-bg-hover: mix($btn-danger-bg, black, 80%);
@@ -304,20 +290,10 @@ $color-default-dark: mix($brand-default, black, 70%);
 $color-default-light: mix($brand-default, white, 60%);
 $color-default-lighter: mix($brand-default, white, 20%);
 
-$color-inverse-darker: mix($brand-inverse, black, 60%);
-$color-inverse-dark: mix($brand-inverse, black, 70%);
-$color-inverse-light: mix($brand-inverse, white, 60%);
-$color-inverse-lighter: mix($brand-inverse, white, 20%);
-
 $color-primary-darker: mix($brand-primary, black, 60%);
 $color-primary-dark: mix($brand-primary, black, 70%);
 $color-primary-light: mix($brand-primary, white, 60%);
 $color-primary-lighter: mix($brand-primary, white, 20%);
-
-$color-info-darker: mix($brand-info, black, 60%);
-$color-info-dark: mix($brand-info, black, 70%);
-$color-info-light: mix($brand-info, white, 60%);
-$color-info-lighter: mix($brand-info, white, 20%);
 
 $color-success-darker: mix($brand-success, black, 60%);
 $color-success-dark: mix($brand-success, black, 70%);
@@ -426,19 +402,16 @@ $dataview-emptymessage-color: $font-color-default;
 //## Default Bootstrap alerts, not a widget in the Modeler (used in components/alerts)
 
 // Background Color
-$alert-info-bg: $color-primary-lighter;
 $alert-success-bg: $color-success-lighter;
 $alert-warning-bg: $color-warning-lighter;
 $alert-danger-bg: $color-danger-lighter;
 
 // Text Color
-$alert-info-color: $color-primary-darker;
 $alert-success-color: $color-success-darker;
 $alert-warning-color: $color-warning-darker;
 $alert-danger-color: $color-danger-darker;
 
 // Border Color
-$alert-info-border-color: $color-primary-dark;
 $alert-success-border-color: $color-success-dark;
 $alert-warning-border-color: $color-warning-dark;
 $alert-danger-border-color: $color-danger-dark;
@@ -471,8 +444,6 @@ $wizard-visited-border-color: $color-success-dark;
 // Background Color
 $label-default-bg: $brand-default;
 $label-primary-bg: $brand-primary;
-$label-info-bg: $brand-info;
-$label-inverse-bg: $brand-inverse;
 $label-success-bg: $brand-success;
 $label-warning-bg: $brand-warning;
 $label-danger-bg: $brand-danger;
@@ -480,8 +451,6 @@ $label-danger-bg: $brand-danger;
 // Border Color
 $label-default-border-color: $brand-default;
 $label-primary-border-color: $brand-primary;
-$label-info-border-color: $brand-info;
-$label-inverse-border-color: $brand-inverse;
 $label-success-border-color: $brand-success;
 $label-warning-border-color: $brand-warning;
 $label-danger-border-color: $brand-danger;
@@ -489,8 +458,6 @@ $label-danger-border-color: $brand-danger;
 // Text Color
 $label-default-color: $font-color-default;
 $label-primary-color: #fff;
-$label-info-color: #fff;
-$label-inverse-color: #fff;
 $label-success-color: #fff;
 $label-warning-color: #fff;
 $label-danger-color: #fff;
@@ -500,9 +467,7 @@ $label-danger-color: #fff;
 
 // Background Color
 $groupbox-default-bg: $gray-primary;
-$groupbox-inverse-bg: $brand-inverse;
 $groupbox-primary-bg: $brand-primary;
-$groupbox-info-bg: $brand-info;
 $groupbox-success-bg: $brand-success;
 $groupbox-warning-bg: $brand-warning;
 $groupbox-danger-bg: $brand-danger;
@@ -510,9 +475,7 @@ $groupbox-white-bg: #fff;
 
 // Text Color
 $groupbox-default-color: $font-color-default;
-$groupbox-inverse-color: #fff;
 $groupbox-primary-color: #fff;
-$groupbox-info-color: #fff;
 $groupbox-success-color: #fff;
 $groupbox-warning-color: #fff;
 $groupbox-danger-color: #fff;
@@ -523,14 +486,12 @@ $groupbox-white-color: $font-color-default;
 
 // Text and Border Color
 $callout-default-color: $font-color-default;
-$callout-info-color: $brand-info;
 $callout-success-color: $brand-success;
 $callout-warning-color: $brand-warning;
 $callout-danger-color: $brand-danger;
 
 // Background Color
 $callout-default-bg: $color-default-lighter;
-$callout-info-bg: $color-info-lighter;
 $callout-success-bg: $color-success-lighter;
 $callout-warning-bg: $color-warning-lighter;
 $callout-danger-bg: $color-danger-lighter;
@@ -632,3 +593,100 @@ $screen-lg-max: ($screen-xl - 1);
 $important-flex: true; // ./base/flex.scss
 $important-spacing: true; // ./base/spacing.scss
 $important-helpers: true; // ./helpers/helperclasses.scss
+
+//===== Legacy variables =====
+
+//== Step 1: Brand Colors
+$brand-inverse: #24276c;
+$brand-info: #0086d9;
+
+//== Step 2: UI Customization
+
+// Sidebar
+$sidebar-bg: $brand-inverse;
+
+//== Navigation
+//## Used in components/navigation
+
+// Default Navigation styling
+$navigation-bg: $brand-inverse;
+
+//== Buttons
+//## Define background-color, border-color and text. Used in components/buttons
+
+// Button Background Color
+$btn-inverse-bg: $brand-inverse;
+$btn-info-bg: $brand-info;
+
+// Button Border Color
+$btn-inverse-border-color: $brand-inverse;
+$btn-info-border-color: $brand-info;
+
+// Button Text Color
+$btn-inverse-color: #fff;
+$btn-info-color: #fff;
+
+// Button Background Color
+$btn-inverse-bg-hover: mix($btn-inverse-bg, white, 80%);
+$btn-info-bg-hover: mix($btn-info-bg, black, 80%);
+
+//== Color variations
+//## These variations are used to support several other variables and components
+
+// Color variations
+$color-inverse-darker: mix($brand-inverse, black, 60%);
+$color-inverse-dark: mix($brand-inverse, black, 70%);
+$color-inverse-light: mix($brand-inverse, white, 60%);
+$color-inverse-lighter: mix($brand-inverse, white, 20%);
+
+$color-info-darker: mix($brand-info, black, 60%);
+$color-info-dark: mix($brand-info, black, 70%);
+$color-info-light: mix($brand-info, white, 60%);
+$color-info-lighter: mix($brand-info, white, 20%);
+
+//== Alerts
+//## Default Bootstrap alerts, not a widget in the Modeler (used in components/alerts)
+
+// Background Color
+$alert-info-bg: $color-primary-lighter;
+
+// Text Color
+$alert-info-color: $color-primary-darker;
+
+// Border Color
+$alert-info-border-color: $color-primary-dark;
+
+//== Labels
+//## Default Bootstrap Labels, not a widget in the Modeler (used in components/labels)
+
+// Background Color
+$label-info-bg: $brand-info;
+$label-inverse-bg: $brand-inverse;
+
+// Border Color
+$label-info-border-color: $brand-info;
+$label-inverse-border-color: $brand-inverse;
+
+// Text Color
+$label-info-color: #fff;
+$label-inverse-color: #fff;
+
+//== Groupbox
+//## Default variables for Groupbox Widget (used in components/groupbox)
+
+// Background Color
+$groupbox-inverse-bg: $brand-inverse;
+$groupbox-info-bg: $brand-info;
+
+// Text Color
+$groupbox-inverse-color: #fff;
+$groupbox-info-color: #fff;
+
+//== Callout (groupbox) Colors
+//## Extended variables for Groupbox Widget (used in components/groupbox)
+
+// Text and Border Color
+$callout-info-color: $brand-info;
+
+// Background Color
+$callout-info-bg: $color-info-lighter;

--- a/packages/theming/atlas/src/theme/web/custom-variables.scss
+++ b/packages/theming/atlas/src/theme/web/custom-variables.scss
@@ -124,41 +124,26 @@ $navigation-font-size: $font-size-default;
 $navigation-sub-font-size: $font-size-small;
 $navigation-glyph-size: 20px; // For glyphicons that you can select in the Mendix Modeler
 
-$navigation-bg-hover: lighten($navigation-bg, 4);
-$navigation-bg-active: lighten($navigation-bg, 8);
 $navigation-color: #fff;
 $navigation-color-hover: #fff;
 $navigation-color-active: #fff;
 
-$navigation-sub-bg: darken($navigation-bg, 4);
-$navigation-sub-bg-hover: $navigation-sub-bg;
-$navigation-sub-bg-active: $navigation-sub-bg;
 $navigation-sub-color: #aaa;
 $navigation-sub-color-hover: $brand-primary;
 $navigation-sub-color-active: $brand-primary;
-
-$navigation-border-color: $navigation-bg-hover;
 
 // Navigation Sidebar
 $navsidebar-font-size: $font-size-default;
 $navsidebar-sub-font-size: $font-size-small;
 $navsidebar-glyph-size: 20px; // For glyphicons that you can select in the Mendix Modeler
 
-$navsidebar-bg: $sidebar-bg;
-$navsidebar-bg-hover: darken($navsidebar-bg, 4);
-$navsidebar-bg-active: darken($navsidebar-bg, 8);
 $navsidebar-color: #fff;
 $navsidebar-color-hover: #fff;
 $navsidebar-color-active: #fff;
 
-$navsidebar-sub-bg: darken($navsidebar-bg, 4);
-$navsidebar-sub-bg-hover: $navsidebar-sub-bg;
-$navsidebar-sub-bg-active: $navsidebar-sub-bg;
 $navsidebar-sub-color: #aaa;
 $navsidebar-sub-color-hover: $brand-primary;
 $navsidebar-sub-color-active: $brand-primary;
-
-$navsidebar-border-color: $navsidebar-bg-hover;
 
 // Navigation topbar
 $navtopbar-font-size: $font-size-default;
@@ -610,6 +595,25 @@ $sidebar-bg: $brand-inverse;
 
 // Default Navigation styling
 $navigation-bg: $brand-inverse;
+$navigation-bg-hover: lighten($navigation-bg, 4);
+$navigation-bg-active: lighten($navigation-bg, 8);
+
+$navigation-sub-bg: darken($navigation-bg, 4);
+$navigation-sub-bg-hover: $navigation-sub-bg;
+$navigation-sub-bg-active: $navigation-sub-bg;
+
+$navigation-border-color: $navigation-bg-hover;
+
+// Navigation Sidebar
+$navsidebar-bg: $sidebar-bg;
+$navsidebar-bg-hover: darken($navsidebar-bg, 4);
+$navsidebar-bg-active: darken($navsidebar-bg, 8);
+
+$navsidebar-sub-bg: darken($navsidebar-bg, 4);
+$navsidebar-sub-bg-hover: $navsidebar-sub-bg;
+$navsidebar-sub-bg-active: $navsidebar-sub-bg;
+
+$navsidebar-border-color: $navsidebar-bg-hover;
 
 //== Buttons
 //## Define background-color, border-color and text. Used in components/buttons

--- a/packages/theming/atlas/src/themesource/atlas_core/web/_variables.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/_variables.scss
@@ -25,8 +25,6 @@ $gray-lighter: #f8f8f8 !default;
 //== Step 1: Brand Colors
 $brand-default: $gray-primary !default;
 $brand-primary: #264ae5 !default;
-$brand-inverse: #24276c !default;
-$brand-info: #0086d9 !default;
 $brand-success: #3cb33d !default;
 $brand-warning: #eca51c !default;
 $brand-danger: #e33f4e !default;
@@ -55,9 +53,6 @@ $m-header-height: 45px !default;
 $m-header-bg: $topbar-bg !default;
 $m-header-color: #555 !default;
 $m-header-title-size: 17px !default;
-
-// Sidebar
-$sidebar-bg: $brand-inverse !default;
 
 // Navbar Brand Name / For your company, product, or project name (used in layouts/base/)
 $navbar-brand-name: $font-color-default !default;
@@ -135,7 +130,6 @@ $navigation-font-size: $font-size-default !default;
 $navigation-sub-font-size: $font-size-small !default;
 $navigation-glyph-size: 20px !default; // For glyphicons that you can select in the Mendix Modeler
 
-$navigation-bg: $brand-inverse !default;
 $navigation-bg-hover: lighten($navigation-bg, 4) !default;
 $navigation-bg-active: lighten($navigation-bg, 8) !default;
 $navigation-color: #fff !default;
@@ -201,7 +195,6 @@ $navtopbar-border-color: $topbar-border-color !default;
 $form-input-style: default !default;
 
 // Form Label
-$form-label-color: $brand-inverse !default;
 $form-label-size: $font-size-default !default;
 $form-label-weight: $font-weight-semibold !default;
 $form-label-gutter: 8px !default;
@@ -245,27 +238,21 @@ $btn-border-radius: $border-radius-default !default;
 
 // Button Background Color
 $btn-default-bg: #fff !default;
-$btn-inverse-bg: $brand-inverse !default;
 $btn-primary-bg: $brand-primary !default;
-$btn-info-bg: $brand-info !default;
 $btn-success-bg: $brand-success !default;
 $btn-warning-bg: $brand-warning !default;
 $btn-danger-bg: $brand-danger !default;
 
 // Button Border Color
 $btn-default-border-color: $gray-primary !default;
-$btn-inverse-border-color: $brand-inverse !default;
 $btn-primary-border-color: $brand-primary !default;
-$btn-info-border-color: $brand-info !default;
 $btn-success-border-color: $brand-success !default;
 $btn-warning-border-color: $brand-warning !default;
 $btn-danger-border-color: $brand-danger !default;
 
 // Button Text Color
 $btn-default-color: $brand-primary !default;
-$btn-inverse-color: #fff !default;
 $btn-primary-color: #fff !default;
-$btn-info-color: #fff !default;
 $btn-success-color: #fff !default;
 $btn-warning-color: #fff !default;
 $btn-danger-color: #fff !default;
@@ -275,9 +262,7 @@ $btn-default-icon-color: $gray !default;
 
 // Button Background Color
 $btn-default-bg-hover: $btn-default-border-color !default;
-$btn-inverse-bg-hover: mix($btn-inverse-bg, white, 80%) !default;
 $btn-primary-bg-hover: mix($btn-primary-bg, black, 80%) !default;
-$btn-info-bg-hover: mix($btn-info-bg, black, 80%) !default;
 $btn-success-bg-hover: mix($btn-success-bg, black, 80%) !default;
 $btn-warning-bg-hover: mix($btn-warning-bg, black, 80%) !default;
 $btn-danger-bg-hover: mix($btn-danger-bg, black, 80%) !default;
@@ -310,20 +295,10 @@ $color-default-dark: mix($brand-default, black, 70%) !default;
 $color-default-light: mix($brand-default, white, 40%) !default;
 $color-default-lighter: mix($brand-default, white, 20%) !default;
 
-$color-inverse-darker: mix($brand-inverse, black, 60%) !default;
-$color-inverse-dark: mix($brand-inverse, black, 70%) !default;
-$color-inverse-light: mix($brand-inverse, white, 40%) !default;
-$color-inverse-lighter: mix($brand-inverse, white, 20%) !default;
-
 $color-primary-darker: mix($brand-primary, black, 60%) !default;
 $color-primary-dark: mix($brand-primary, black, 70%) !default;
 $color-primary-light: mix($brand-primary, white, 40%) !default;
 $color-primary-lighter: mix($brand-primary, white, 20%) !default;
-
-$color-info-darker: mix($brand-info, black, 60%) !default;
-$color-info-dark: mix($brand-info, black, 70%) !default;
-$color-info-light: mix($brand-info, white, 60%) !default;
-$color-info-lighter: mix($brand-info, white, 20%) !default;
 
 $color-success-darker: mix($brand-success, black, 60%) !default;
 $color-success-dark: mix($brand-success, black, 70%) !default;
@@ -485,8 +460,6 @@ $wizard-visited-border-color: $wizard-visited !default;
 // Background Color
 $label-default-bg: $brand-default !default;
 $label-primary-bg: $brand-primary !default;
-$label-info-bg: $brand-info !default;
-$label-inverse-bg: $brand-inverse !default;
 $label-success-bg: $brand-success !default;
 $label-warning-bg: $brand-warning !default;
 $label-danger-bg: $brand-danger !default;
@@ -494,8 +467,6 @@ $label-danger-bg: $brand-danger !default;
 // Border Color
 $label-default-border-color: $brand-default !default;
 $label-primary-border-color: $brand-primary !default;
-$label-info-border-color: $brand-info !default;
-$label-inverse-border-color: $brand-inverse !default;
 $label-success-border-color: $brand-success !default;
 $label-warning-border-color: $brand-warning !default;
 $label-danger-border-color: $brand-danger !default;
@@ -503,8 +474,6 @@ $label-danger-border-color: $brand-danger !default;
 // Text Color
 $label-default-color: $font-color-default !default;
 $label-primary-color: #fff !default;
-$label-info-color: #fff !default;
-$label-inverse-color: #fff !default;
 $label-success-color: #fff !default;
 $label-warning-color: #fff !default;
 $label-danger-color: #fff !default;
@@ -514,9 +483,7 @@ $label-danger-color: #fff !default;
 
 // Background Color
 $groupbox-default-bg: $gray-primary !default;
-$groupbox-inverse-bg: $brand-inverse !default;
 $groupbox-primary-bg: $brand-primary !default;
-$groupbox-info-bg: $brand-info !default;
 $groupbox-success-bg: $brand-success !default;
 $groupbox-warning-bg: $brand-warning !default;
 $groupbox-danger-bg: $brand-danger !default;
@@ -524,9 +491,7 @@ $groupbox-white-bg: #fff !default;
 
 // Text Color
 $groupbox-default-color: $font-color-default !default;
-$groupbox-inverse-color: #fff !default;
 $groupbox-primary-color: #fff !default;
-$groupbox-info-color: #fff !default;
 $groupbox-success-color: #fff !default;
 $groupbox-warning-color: #fff !default;
 $groupbox-danger-color: #fff !default;
@@ -646,3 +611,84 @@ $screen-lg-max: ($screen-xl - 1) !default;
 $important-flex: true !default; // ./base/flex.scss
 $important-spacing: true !default; // ./base/spacing.scss
 $important-helpers: true !default; // ./helpers/helperclasses.scss
+
+//===== Legacy variables =====
+
+//== Step 1: Brand Colors
+$brand-inverse: #24276c !default;
+$brand-info: #0086d9 !default;
+
+//== Step 2: UI Customization
+// Sidebar
+$sidebar-bg: $brand-inverse !default;
+
+//== Navigation
+//## Used in components/navigation
+
+// Default Navigation styling
+$navigation-bg: $brand-inverse !default;
+
+//== Form
+//## Used in components/inputs
+
+// Form Label
+$form-label-color: $brand-inverse !default;
+
+//== Buttons
+//## Define background-color, border-color and text. Used in components/buttons
+
+// Button Background Color
+$btn-inverse-bg: $brand-inverse !default;
+$btn-info-bg: $brand-info !default;
+
+// Button Border Color
+$btn-inverse-border-color: $brand-inverse !default;
+$btn-info-border-color: $brand-info !default;
+
+// Button Text Color
+$btn-inverse-color: #fff !default;
+$btn-info-color: #fff !default;
+
+// Button Background Color
+$btn-inverse-bg-hover: mix($btn-inverse-bg, white, 80%) !default;
+$btn-info-bg-hover: mix($btn-info-bg, black, 80%) !default;
+
+//== Color variations
+//## These variations are used to support several other variables and components
+
+// Color variations
+$color-inverse-darker: mix($brand-inverse, black, 60%) !default;
+$color-inverse-dark: mix($brand-inverse, black, 70%) !default;
+$color-inverse-light: mix($brand-inverse, white, 40%) !default;
+$color-inverse-lighter: mix($brand-inverse, white, 20%) !default;
+
+$color-info-darker: mix($brand-info, black, 60%) !default;
+$color-info-dark: mix($brand-info, black, 70%) !default;
+$color-info-light: mix($brand-info, white, 60%) !default;
+$color-info-lighter: mix($brand-info, white, 20%) !default;
+
+//== Labels
+//## Default Bootstrap Labels, not a widget in the Modeler (used in components/labels)
+
+// Background Color
+$label-info-bg: $brand-info !default;
+$label-inverse-bg: $brand-inverse !default;
+
+// Border Color
+$label-info-border-color: $brand-info !default;
+$label-inverse-border-color: $brand-inverse !default;
+
+// Text Color
+$label-info-color: #fff !default;
+$label-inverse-color: #fff !default;
+
+//== Groupbox
+//## Default variables for Groupbox Widget (used in components/groupbox)
+
+// Background Color
+$groupbox-inverse-bg: $brand-inverse !default;
+$groupbox-info-bg: $brand-info !default;
+
+// Text Color
+$groupbox-inverse-color: #fff !default;
+$groupbox-info-color: #fff !default;

--- a/packages/theming/atlas/src/themesource/atlas_core/web/_variables.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/_variables.scss
@@ -130,41 +130,26 @@ $navigation-font-size: $font-size-default !default;
 $navigation-sub-font-size: $font-size-small !default;
 $navigation-glyph-size: 20px !default; // For glyphicons that you can select in the Mendix Modeler
 
-$navigation-bg-hover: lighten($navigation-bg, 4) !default;
-$navigation-bg-active: lighten($navigation-bg, 8) !default;
 $navigation-color: #fff !default;
 $navigation-color-hover: #fff !default;
 $navigation-color-active: #fff !default;
 
-$navigation-sub-bg: darken($navigation-bg, 4) !default;
-$navigation-sub-bg-hover: $navigation-sub-bg !default;
-$navigation-sub-bg-active: $navigation-sub-bg !default;
 $navigation-sub-color: #aaa !default;
 $navigation-sub-color-hover: $brand-primary !default;
 $navigation-sub-color-active: $brand-primary !default;
-
-$navigation-border-color: $navigation-bg-hover !default;
 
 // Navigation Sidebar
 $navsidebar-font-size: $font-size-default !default;
 $navsidebar-sub-font-size: $font-size-small !default;
 $navsidebar-glyph-size: 20px !default; // For glyphicons that you can select in the Mendix Modeler
 
-$navsidebar-bg: $sidebar-bg !default;
-$navsidebar-bg-hover: darken($navsidebar-bg, 4) !default;
-$navsidebar-bg-active: darken($navsidebar-bg, 8) !default;
 $navsidebar-color: #fff !default;
 $navsidebar-color-hover: #fff !default;
 $navsidebar-color-active: #fff !default;
 
-$navsidebar-sub-bg: darken($navsidebar-bg, 4) !default;
-$navsidebar-sub-bg-hover: $navsidebar-sub-bg !default;
-$navsidebar-sub-bg-active: $navsidebar-sub-bg !default;
 $navsidebar-sub-color: #aaa !default;
 $navsidebar-sub-color-hover: $brand-primary !default;
 $navsidebar-sub-color-active: $brand-primary !default;
-
-$navsidebar-border-color: $navsidebar-bg-hover !default;
 
 // Navigation topbar
 $navtopbar-font-size: $font-size-default !default;
@@ -627,6 +612,25 @@ $sidebar-bg: $brand-inverse !default;
 
 // Default Navigation styling
 $navigation-bg: $brand-inverse !default;
+$navigation-bg-hover: lighten($navigation-bg, 4) !default;
+$navigation-bg-active: lighten($navigation-bg, 8) !default;
+
+$navigation-sub-bg: darken($navigation-bg, 4) !default;
+$navigation-sub-bg-hover: $navigation-sub-bg !default;
+$navigation-sub-bg-active: $navigation-sub-bg !default;
+
+$navigation-border-color: $navigation-bg-hover !default;
+
+// Navigation Sidebar
+$navsidebar-bg: $sidebar-bg !default;
+$navsidebar-bg-hover: darken($navsidebar-bg, 4) !default;
+$navsidebar-bg-active: darken($navsidebar-bg, 8) !default;
+
+$navsidebar-sub-bg: darken($navsidebar-bg, 4) !default;
+$navsidebar-sub-bg-hover: $navsidebar-sub-bg !default;
+$navsidebar-sub-bg-active: $navsidebar-sub-bg !default;
+
+$navsidebar-border-color: $navsidebar-bg-hover !default;
 
 //== Form
 //## Used in components/inputs

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_groupbox.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_groupbox.scss
@@ -12,6 +12,7 @@
 //## Helper classes to change the look and feel of the component
 ========================================================================== */
 // Color variations
+.groupbox-secondary,
 .groupbox-default {
     @include groupbox-variant($groupbox-default-color, $groupbox-default-bg);
 }

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_labels.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_labels.scss
@@ -13,8 +13,8 @@
 badge widget
 ========================================================================== */
 // Color variations
-.label-default,
-.label-secondary {
+.label-secondary,
+.label-default {
     color: $label-default-color;
     background-color: $label-default-bg;
 }

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_typography.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_typography.scss
@@ -46,6 +46,8 @@
 }
 
 // Color variations
+.text-secondary,
+.text-secondary:hover,
 .text-default,
 .text-default:hover {
     color: $font-color-default !important;

--- a/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
@@ -271,6 +271,10 @@
                     "class": "background-primary"
                 },
                 {
+                    "name": "Brand Secondary",
+                    "class": "background-secondary"
+                },
+                {
                     "name": "Brand Success",
                     "oldNames": ["Success"],
                     "class": "background-success"
@@ -474,14 +478,14 @@
             "description": "Choose one of the following styles to change the appearance of the groupbox.",
             "options": [
                 {
-                    "name": "Brand Default",
-                    "oldNames": ["Default"],
-                    "class": "groupbox-default"
-                },
-                {
                     "name": "Brand Primary",
                     "oldNames": ["Primary"],
                     "class": "groupbox-primary"
+                },
+                {
+                    "name": "Brand Secondary",
+                    "oldNames": ["Default", "Brand Default"],
+                    "class": "groupbox-secondary"
                 },
                 {
                     "name": "Brand Success",
@@ -618,24 +622,14 @@
             "description": "Change the appearance of a label.",
             "options": [
                 {
-                    "name": "Brand Default",
-                    "oldNames": ["Default"],
-                    "class": "label-default"
-                },
-                {
                     "name": "Brand Primary",
                     "oldNames": ["Primary"],
                     "class": "label-primary"
                 },
                 {
-                    "name": "Brand Inverse",
-                    "oldNames": ["Inverse"],
-                    "class": "label-inverse"
-                },
-                {
-                    "name": "Brand Info",
-                    "oldNames": ["Info"],
-                    "class": "label-info"
+                    "name": "Brand Secondary",
+                    "oldNames": ["Default", "Brand Default"],
+                    "class": "label-secondary"
                 },
                 {
                     "name": "Brand Success",
@@ -761,24 +755,14 @@
                     "class": "text-detail"
                 },
                 {
-                    "name": "Brand Default",
-                    "oldNames": ["Default"],
-                    "class": "text-default"
-                },
-                {
                     "name": "Brand Primary",
                     "oldNames": ["Primary"],
                     "class": "text-primary"
                 },
                 {
-                    "name": "Brand Inverse",
-                    "oldNames": ["Inverse"],
-                    "class": "text-inverse"
-                },
-                {
-                    "name": "Brand Info",
-                    "oldNames": ["Info"],
-                    "class": "text-info"
+                    "name": "Brand Secondary",
+                    "oldNames": ["Default", "Brand Default"],
+                    "class": "text-secondary"
                 },
                 {
                     "name": "Brand Success",


### PR DESCRIPTION
### Why?
The info and inverse brand styles are not encourgaed to be used anymore with Atlas 3.

### What?
- The info and inverse brand styles have been removed from design properties. 
- The info and inverse brand style Atlas variables have been moved at the bottom of the variable files under the heading "Legacy".

### How to test?
X