### PR TITLE
RFC: Validate widgets' versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "release": "lerna run release --ignore @mendix/custom-widgets-utils-internal",
     "release:native": "npm run release -- --scope '*-native'",
     "release:web": "npm run release -- --scope '*-web'",
-    "version": "ts-node --project ./scripts/tsconfig.json ./scripts/release/BumpVersion.ts"
+    "version": "ts-node --project ./scripts/tsconfig.json ./scripts/release/BumpVersion.ts",
+    "validate-staged-widget-versions": "node scripts/validation/validate-versions-staged-files.js"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
@@ -80,7 +81,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged --config \"./prettier.config.js\" --pattern \"**/{src,script,test}/**/*.{js,jsx,ts,tsx,scss,html}\"",
+      "pre-commit": "pretty-quick --staged --config \"./prettier.config.js\" --pattern \"**/{src,script,test}/**/*.{js,jsx,ts,tsx,scss,html}\" && npm run validate-staged-widget-versions",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/index.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/index.ts
@@ -1,16 +1,14 @@
 import { promises } from "fs";
 import { join } from "path";
-import { promisify } from "util";
-import { parseString } from "xml2js";
+import { parseStringPromise } from "xml2js";
 import { PackageXml } from "./PackageXml";
 import { WidgetXml } from "./WidgetXml";
 import { generateForWidget } from "./generate";
 
 const { mkdir, readFile, stat, writeFile } = promises;
-const parseStringAsync = promisify(parseString);
 
 export async function transformPackage(content: string, basePath: string) {
-    const contentXml = (await parseStringAsync(content)) as PackageXml;
+    const contentXml = (await parseStringPromise(content)) as PackageXml;
     if (!contentXml) {
         throw new Error("Empty XML, please check your src folder for file package.xml");
     }
@@ -33,7 +31,7 @@ export async function transformPackage(content: string, basePath: string) {
 
         let generatedContent;
         try {
-            const sourceXml = (await parseStringAsync(source)) as WidgetXml;
+            const sourceXml = (await parseStringPromise(source)) as WidgetXml;
             generatedContent = generateForWidget(sourceXml, toWidgetName(sourcePath));
         } catch (err) {
             throw new Error(

--- a/scripts/validation/validate-versions-staged-files.js
+++ b/scripts/validation/validate-versions-staged-files.js
@@ -1,0 +1,76 @@
+const { readFile } = require("fs").promises;
+const { promisify } = require("util");
+const { join, dirname } = require("path");
+const { exec } = require("child_process");
+const { parseStringPromise } = require("xml2js");
+
+const execAsync = promisify(exec);
+
+preCommit().catch(error => {
+    console.error(error);
+    process.exit(1);
+});
+
+async function preCommit() {
+    const [{ stdout: lernaPackages }, { stdout: stagedFiles }] = await Promise.all([
+        execAsync("npx lerna ls --json --all"),
+        execAsync("git diff --staged --name-only")
+    ]);
+    const packages = JSON.parse(lernaPackages.trim());
+    const staged = stagedFiles.trim().split("\n");
+    const changedWidgetPackages = packages
+        .filter(({ location }) => location.match(/(pluggable|custom)Widgets/))
+        .filter(({ location }) =>
+            staged.some(
+                changedFilePath =>
+                    dirname(join(process.cwd(), changedFilePath)).includes(location) &&
+                    changedFilePath
+                        .split("/")
+                        .pop()
+                        .match(/package\.(json|xml)$/)
+            )
+        );
+
+    if (changedWidgetPackages.length) {
+        const validationPromises = [];
+
+        for (const changedWidgetPackage of changedWidgetPackages) {
+            validationPromises.push(
+                new Promise(async (resolve, reject) => {
+                    const packageXmlAsJson = await parseStringPromise(
+                        (await readFile(join(changedWidgetPackage.location, "src", "package.xml"))).toString(),
+                        { ignoreAttrs: false }
+                    );
+                    const packageXmlVersion = packageXmlAsJson.package.clientModule[0].$.version;
+                    const packageJson = JSON.parse(
+                        (await readFile(join(changedWidgetPackage.location, "package.json"))).toString()
+                    );
+                    const packageJsonVersion = packageJson.version;
+                    const filesMissingVersion = [];
+
+                    if (!packageXmlVersion) filesMissingVersion.push("package.xml");
+                    if (!packageJsonVersion) filesMissingVersion.push("package.json");
+
+                    if (filesMissingVersion.length)
+                        reject(`[${packageJson.name}] ${filesMissingVersion.join(" and ")} missing version.`);
+
+                    if (packageJsonVersion === packageXmlVersion) resolve();
+
+                    reject(`[${packageJson.name}] package.json and package.xml versions do not match.`);
+                })
+            );
+        }
+
+        const failedResults = await Promise.allSettled(validationPromises).then(results =>
+            results.filter(result => result.status === "rejected").map(result => result.reason)
+        );
+
+        if (failedResults.length) {
+            for (const error of failedResults) {
+                console.error(error);
+            }
+
+            throw new Error("Widget version validation failed. See above for details.");
+        }
+    }
+}


### PR DESCRIPTION
Validate that a widget's `package.json` `version` matches its `package.xml` `version`. 

 ## Why?

When updating a widget I have forgotten to update both version string literals in unison. This will prevent version mismatches. 

## What?

- add a npm script which can be triggered manually
- add a pre-commit command that executes the script which checks for changed `package.json`s & `package.xml`s for pluggableWidgets and customWidgets, filtered by staged files.

## Assumptions
- each widget has a `package.json` in the root of its directory, and a `package.xml` in `<root>/src/`