### PR TITLE
RFC: Automate validation and bump of piw copyright

### DIFF
--- a/.github/workflows/BumpPIWCopyright.yml
+++ b/.github/workflows/BumpPIWCopyright.yml
@@ -1,0 +1,42 @@
+name: Bump widgets' copyright
+
+on:
+    schedule:
+        - cron: "0 0 31 12 *"
+jobs:
+    bump_copyright:
+        name: "Bump widgets' copyright"
+        runs-on: ubuntu-latest
+        steps:
+            - name: "Checking-out code"
+              uses: actions/checkout@v2
+              with:
+                  ref: "master"
+            - name: "Defining cache"
+              uses: actions/cache@v2
+              env:
+                  cache-name: cache-node-modules
+              with:
+                  path: ~/.npm
+                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+            - name: "Installing dependencies"
+              run: npm install
+            - name: "Bumping widgets' copyright"
+              run: npm run bump:copyright
+            - name: "Create pull request"
+              id: cpr
+              uses: peter-evans/create-pull-request@v3
+              with:
+                  commit-message: Bump widgets copyright
+                  committer: GitHub <noreply@github.com>
+                  author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+                  branch: automated/bump-piws-copyright-year
+                  delete-branch: true
+                  title: "[Automated] Bump pluggable widgets' copyright year"
+                  body: |
+                      Bump pluggable widgets' copyright year
+                      - Updated to new year's year value
+                      - Auto-generated
+                  labels: |
+                      automated
+                  draft: false

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -29,6 +29,8 @@ jobs:
               run: |
                   export CHANGED_GLOBAL_FILES=$(echo "${{ steps.files.outputs.all }}" | grep -v "^packages")
                   echo "::set-output name=arg::$(if [ "${CHANGED_GLOBAL_FILES}" = "" ] && ${{ github.event_name == 'pull_request' }}; then echo '--since origin/${{ github.base_ref }}'; else echo ''; fi)"
+            - name: "Validating widgets' copyright"
+              run: npm run validate:copyright -- ${{ steps.variables.outputs.arg }}
             - name: "Defining cache"
               uses: actions/cache@v2
               env:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "build": "lerna run build --ignore @widgets-resources/utils-react-widgets",
     "publish": "ts-node --project ./scripts/tsconfig.json ./scripts/release/Release.ts",
     "release": "lerna run release --ignore @widgets-resources/utils-react-widgets",
-    "version": "ts-node --project ./scripts/tsconfig.json ./scripts/release/BumpVersion.ts"
+    "version": "ts-node --project ./scripts/tsconfig.json ./scripts/release/BumpVersion.ts",
+    "validate:copyright": "lerna run validate:copyright --ignore @widgets-resources/utils-react-widgets --stream",
+    "bump:copyright": "lerna run bump:copyright --ignore @widgets-resources/utils-react-widgets --stream"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/packages/pluggableWidgets/timeline-web/package.json
+++ b/packages/pluggableWidgets/timeline-web/package.json
@@ -3,7 +3,7 @@
   "widgetName": "Timeline",
   "version": "2.0.0",
   "description": "Shows timeline",
-  "copyright": "Mendix BV",
+  "copyright": "Copyright © 2005-2020 Mendix Technology B.V. All rights reserved.",
   "author": "Mendix",
   "config": {
     "mendixHost": "http://localhost:8080",
@@ -20,7 +20,9 @@
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
     "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
-    "release": "pluggable-widgets-tools release:web"
+    "release": "pluggable-widgets-tools release:web",
+    "validate:copyright": "pluggable-widgets-tools validate:copyright",
+    "bump:copyright": "pluggable-widgets-tools bump:copyright"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/tools/pluggable-widgets-tools/bin/mx-scripts.js
+++ b/packages/tools/pluggable-widgets-tools/bin/mx-scripts.js
@@ -81,6 +81,10 @@ function getRealCommand(cmd, toolsRoot) {
         case "start:js":
         case "start:ts":
             return "echo This command has no effect, use pluggable-widgets-tools start:web instead!";
+        case "validate:copyright":
+            return `node ${join(toolsRoot, "scripts/validate-copyright.js")}`;
+        case "bump:copyright":
+            return `node ${join(toolsRoot, "scripts/bump-copyright-year.js")}`;
         default:
             console.error(`Unknown command passed to MX Widgets Tools script: '${cmd}'`);
             process.exit(1);

--- a/packages/tools/pluggable-widgets-tools/scripts/bump-copyright-year.js
+++ b/packages/tools/pluggable-widgets-tools/scripts/bump-copyright-year.js
@@ -1,0 +1,17 @@
+const { readFile, writeFile } = require("fs").promises;
+const { join } = require("path");
+const { extractParts } = require("./copyright-utils");
+
+main().catch(e => {
+    console.error(e);
+    process.exit(1);
+});
+
+async function main() {
+    const packageJsonPath = join(process.cwd(), "package.json");
+    const packageJson = JSON.parse((await readFile(packageJsonPath)).toString());
+    const copyright = packageJson.copyright;
+    const [firstTextPart, endYear, secondTextPart] = extractParts(copyright);
+    packageJson.copyright = `${firstTextPart}${endYear + 1}${secondTextPart}`;
+    await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
+}

--- a/packages/tools/pluggable-widgets-tools/scripts/copyright-utils.js
+++ b/packages/tools/pluggable-widgets-tools/scripts/copyright-utils.js
@@ -1,0 +1,12 @@
+function extractParts(copyright) {
+    const startYearIndex = copyright.indexOf("2005-");
+    const [firstPart, secondPart] = [copyright.slice(0, startYearIndex + 5), copyright.slice(startYearIndex + 5)];
+    const textPartStartIndex = secondPart.indexOf(" ");
+    const endYear = parseInt(secondPart.slice(0, textPartStartIndex), 10);
+
+    return [firstPart, endYear, secondPart.slice(textPartStartIndex)];
+}
+
+module.exports = {
+    extractParts
+};

--- a/packages/tools/pluggable-widgets-tools/scripts/validate-copyright.js
+++ b/packages/tools/pluggable-widgets-tools/scripts/validate-copyright.js
@@ -1,0 +1,24 @@
+const { readFile } = require("fs").promises;
+const { join } = require("path");
+const { extractParts } = require("./copyright-utils");
+
+main().catch(e => {
+    console.error(e);
+    process.exit(1);
+});
+
+async function main() {
+    const packageJsonPath = join(process.cwd(), "package.json");
+    const packageJson = JSON.parse((await readFile(packageJsonPath)).toString());
+    const copyright = packageJson.copyright;
+
+    const [firstTextPart, endYear, secondTextPart] = extractParts(copyright);
+
+    if (
+        firstTextPart !== "Copyright © 2005-" ||
+        endYear !== new Date().getFullYear() ||
+        secondTextPart !== " Mendix Technology B.V. All rights reserved."
+    ) {
+        throw new Error(`[${packageJson.name}] Widget's copyright is not valid.`);
+    }
+}


### PR DESCRIPTION
## What?

This introduces a github action to:

. validate PiW copyrights - using gh action triggered on pr->master for changes widgets
. automate the bumping of PiW copyright string literals. The end year gets incremented. The action should run at midnight on the 31st December each year. The action will commit and push the changes to a pull request.

## Why?

The need to maintain copyrights is important from a legal perspective and tedious from a development perspective. Validation assists in maintaining consistent copyrights.

### Todo

- [ ] If this is approved, add the command + uniform copyright to each PIW