### PR TITLE
[Atlas] Allow targeting login header

### DIFF
--- a/packages/theming/atlas/src/theme/web/login-with-sso.html
+++ b/packages/theming/atlas/src/theme/web/login-with-sso.html
@@ -16,7 +16,7 @@
             </div>
             <div class="loginpage-right">
                 <div class="loginpage-formwrapper">
-                    <h2>Sign in</h2>
+                    <h2 id="loginHeader">Sign in</h2>
                     <form id="loginForm" class="loginpage-form" autocomplete="off">
                         <div>
                             <div id="loginMessage" class="alert alert-danger"></div>

--- a/packages/theming/atlas/src/theme/web/login.html
+++ b/packages/theming/atlas/src/theme/web/login.html
@@ -16,7 +16,7 @@
             </div>
             <div class="loginpage-right">
                 <div class="loginpage-formwrapper">
-                    <h2>Sign in</h2>
+                    <h2 id="loginHeader">Sign in</h2>
                     <form id="loginForm" class="loginpage-form" autocomplete="off">
                         <div>
                             <div id="loginMessage" class="alert alert-danger"></div>


### PR DESCRIPTION
## Why?

The login pages have a header "Sign in" which now has an ID that the login.js script can target for translations.