### PR TITLE
[WC-43] Correct atlas font import

### DIFF
--- a/packages/theming/atlas/src/theme/web/custom-variables.scss
+++ b/packages/theming/atlas/src/theme/web/custom-variables.scss
@@ -77,11 +77,10 @@ $link-hover-color: darken($link-color, 15%);
 //== Typography
 //## Change your font family, weight, line-height, headings and more (used in components/typography)
 
-// Font Family Import (Used for google font plugin in theme creater https://ux.mendix.com/theme-creator.html)
+// Font Family Import (Used for google font plugin in theme creater)
 $font-family-import: "https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700";
 @if $font-family-import != false {
-    // Only import, if the import is set
-    @import url($font-family-import);
+    @import url("\"#{$font-family-import}\""); // the `url` function removes the outer quotes, escape inner quotes so that compiled value is a string literal.
 }
 
 // Font Family / False = fallback from Bootstrap (Helvetica Neue)

--- a/packages/theming/atlas/src/theme/web/custom-variables.scss
+++ b/packages/theming/atlas/src/theme/web/custom-variables.scss
@@ -79,9 +79,6 @@ $link-hover-color: darken($link-color, 15%);
 
 // Font Family Import (Used for google font plugin in theme creater)
 $font-family-import: "https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700";
-@if $font-family-import != false {
-    @import url("\"#{$font-family-import}\""); // the `url` function removes the outer quotes, escape inner quotes so that compiled value is a string literal.
-}
 
 // Font Family / False = fallback from Bootstrap (Helvetica Neue)
 $font-family-base: "SFProDisplay", "Open Sans", sans-serif;

--- a/packages/theming/atlas/src/themesource/atlas_core/web/_variables.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/_variables.scss
@@ -83,11 +83,10 @@ $link-hover-color: darken($link-color, 15%) !default;
 //== Typography
 //## Change your font family, weight, line-height, headings and more (used in components/typography)
 
-// Font Family Import (Used for google font plugin in theme creater https://ux.mendix.com/theme-creator.html)
+// Font Family Import (Used for google font plugin in theme creater)
 $font-family-import: "https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" !default;
 @if $font-family-import != false {
-    // Only import, if the import is set
-    @import url($font-family-import);
+    @import url("\"#{$font-family-import}\""); // the `url` function removes the outer quotes, escape inner quotes so that compiled value is a string literal.
 }
 
 // Font Family / False = fallback from Bootstrap (Helvetica Neue)

--- a/packages/theming/atlas/src/themesource/atlas_core/web/_variables.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/_variables.scss
@@ -85,9 +85,6 @@ $link-hover-color: darken($link-color, 15%) !default;
 
 // Font Family Import (Used for google font plugin in theme creater)
 $font-family-import: "https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" !default;
-@if $font-family-import != false {
-    @import url("\"#{$font-family-import}\""); // the `url` function removes the outer quotes, escape inner quotes so that compiled value is a string literal.
-}
 
 // Font Family / False = fallback from Bootstrap (Helvetica Neue)
 $font-family-base: "SFProDisplay", "Open Sans", sans-serif !default;

--- a/packages/theming/atlas/src/themesource/atlas_core/web/main.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/main.scss
@@ -9,6 +9,11 @@
 @import "variables";
 @import "../../../theme/web/custom-variables";
 
+// Font Family Import
+@if $font-family-import != false {
+  @import url("\"#{$font-family-import}\""); // the `url` function removes the outer quotes, escape inner quotes so that compiled value is a string literal.
+}
+
 // Base
 @import "core/base/mixins/animations";
 @import "core/base/mixins/spacing";

--- a/packages/theming/atlas/src/themesource/atlas_core/web/main.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/main.scss
@@ -11,7 +11,7 @@
 
 // Font Family Import
 @if $font-family-import != false {
-  @import url("\"#{$font-family-import}\""); // the `url` function removes the outer quotes, escape inner quotes so that compiled value is a string literal.
+  @import url($font-family-import);
 }
 
 // Base


### PR DESCRIPTION
## What?

Move the import of custom fonts to `main.scss` to avoid duplicate imports in CSS output.

## Why?

Both `variables.scss` and `custom-variables.scss` were importing the custom font, which resulted in potentially duplicate import statements in CSS (if the condition was met).

### Testing suggestion

This depends on page editor team fixing an issue in Studio Pro around overriding SCSS's `url` functionality: https://mendix.atlassian.net/browse/PAG-1498

- set a custom font in `custom-variables` and ensure MX app renders this user-defined custom font. There should only be one import statement in CSS.
- remove the custom font from `custom-variables` and ensure MX app renders atlas-defined custom font. There should only be one import statement in CSS.