### PR TITLE
[WC-109] Update progress bar according to design feedback

### DIFF
--- a/packages/pluggableWidgets/progress-bar-web/src/components/ProgressBar.tsx
+++ b/packages/pluggableWidgets/progress-bar-web/src/components/ProgressBar.tsx
@@ -39,7 +39,7 @@ export function ProgressBar({
     const percentage = calculatePercentage(currentValue, minValue, maxValue);
     return (
         <div
-            className={classNames("widget-progress-bar", "progress-bar-medium", "progress-bar-default", className)}
+            className={classNames("widget-progress-bar", "progress-bar-medium", "progress-bar-primary", className)}
             style={style}
         >
             <div

--- a/packages/pluggableWidgets/progress-bar-web/src/components/__tests__/__snapshots__/ProgressBar.spec.tsx.snap
+++ b/packages/pluggableWidgets/progress-bar-web/src/components/__tests__/__snapshots__/ProgressBar.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Progress bar has progress bar structure 1`] = `
 <div
-  className="widget-progress-bar progress-bar-medium progress-bar-default"
+  className="widget-progress-bar progress-bar-medium progress-bar-primary"
 >
   <div
     className="progress widget-progress-bar-clickable"

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_progressbar.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_progressbar.scss
@@ -50,10 +50,6 @@
     cursor: pointer;
 }
 
-.widget-progress-bar.progress-bar-default .progress-bar {
-    background-color: $brand-default;
-}
-
 .widget-progress-bar.progress-bar-primary .progress-bar {
     background-color: $brand-primary;
 }
@@ -62,20 +58,12 @@
     background-color: $brand-success;
 }
 
-.widget-progress-bar.progress-bar-info .progress-bar {
-    background-color: $brand-info;
-}
-
 .widget-progress-bar.progress-bar-warning .progress-bar {
     background-color: $brand-warning;
 }
 
 .widget-progress-bar.progress-bar-danger .progress-bar {
     background-color: $brand-danger;
-}
-
-.widget-progress-bar.progress-bar-inverse .progress-bar {
-    background-color: $brand-inverse;
 }
 
 .widget-progress-bar-alert.widget-progress-bar-text-contrast .progress-bar {

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_progressbar.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_progressbar.scss
@@ -16,6 +16,7 @@
     width: 100%;
     .progress {
         border-radius: $border-radius-default;
+        background-color: $bg-color;
     }
 }
 
@@ -88,38 +89,6 @@
 .widget-progress-bar-negative {
     float: right;
     display: block;
-}
-
-.widget-progress-bar.progress-bar-background-default > .progress {
-    background-color: $bg-color;
-}
-
-.widget-progress-bar.progress-bar-background-dashboard > .progress {
-    background-color: $bg-color-secondary;
-}
-
-.widget-progress-bar.progress-bar-background-brand-default > .progress {
-    background-color: $brand-default;
-}
-
-.widget-progress-bar.progress-bar-background-primary > .progress {
-    background-color: $brand-primary;
-}
-
-.widget-progress-bar.progress-bar-background-success > .progress {
-    background-color: $brand-success;
-}
-
-.widget-progress-bar.progress-bar-background-info > .progress {
-    background-color: $brand-info;
-}
-
-.widget-progress-bar.progress-bar-background-warning > .progress {
-    background-color: $brand-warning;
-}
-
-.widget-progress-bar.progress-bar-background-danger > .progress {
-    background-color: $brand-danger;
 }
 
 .widget-progress-bar > .alert {

--- a/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
@@ -889,23 +889,10 @@
     ],
     "com.mendix.widget.custom.progressbar.ProgressBar": [
         {
-            "name": "Bar type",
-            "type": "Dropdown",
-            "description": "Type of the progress bar",
-            "options": [
-                {
-                    "name": "Plain",
-                    "class": "progress-bar-default"
-                },
-                {
-                    "name": "Striped",
-                    "class": "progress-striped"
-                },
-                {
-                    "name": "Animated",
-                    "class": "progress-striped active"
-                }
-            ]
+            "name": "Striped bar",
+            "type": "Toggle",
+            "description": "Striped progress bar",
+            "class": "progress-striped"
         },
         {
             "name": "Bar color",

--- a/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
@@ -913,16 +913,8 @@
             "description": "Color of the progress bar",
             "options": [
                 {
-                    "name": "Default",
-                    "class": "progress-bar-default"
-                },
-                {
                     "name": "Primary",
                     "class": "progress-bar-primary"
-                },
-                {
-                    "name": "Info",
-                    "class": "progress-bar-info"
                 },
                 {
                     "name": "Success",

--- a/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
@@ -939,45 +939,6 @@
             ]
         },
         {
-            "name": "Background color",
-            "type": "Dropdown",
-            "description": "Background color of the progress bar",
-            "options": [
-                {
-                    "name": "Background Default",
-                    "class": "progress-bar-background-default"
-                },
-                {
-                    "name": "Background Dashboard",
-                    "class": "progress-bar-background-dashboard"
-                },
-                {
-                    "name": "Brand Default",
-                    "class": "progress-bar-background-brand-default"
-                },
-                {
-                    "name": "Brand Primary",
-                    "class": "progress-bar-background-primary"
-                },
-                {
-                    "name": "Brand Info",
-                    "class": "progress-bar-background-info"
-                },
-                {
-                    "name": "Brand Success",
-                    "class": "progress-bar-background-success"
-                },
-                {
-                    "name": "Brand Warning",
-                    "class": "progress-bar-background-warning"
-                },
-                {
-                    "name": "Brand Danger",
-                    "class": "progress-bar-background-danger"
-                }
-            ]
-        },
-        {
             "name": "Size",
             "type": "Dropdown",
             "description": "Size of the progress bar",


### PR DESCRIPTION
## What

Follow up to #455.

There were a few things that had to be updated based on testing feedback and then design feedback that resulted out of it.

Based on input from @cjfhodges:

- We won't provide the user options for the background color anymore, rather we just stick to `#f8f8f8`
- Narrow the bar color options down to Primary, Success, Warning, and Danger. Default is Primary
- Remove option for an animated progress bar and only allow striped or not-striped -> instead of Dropdown we use a toggle design property.

This also holds for progress circle, so I will update #495 accordingly.