### PR TITLE
Correct pretty-quick config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,32 @@
+{
+    "trailingComma": "none",
+    "useTabs": false,
+    "tabWidth": 4,
+    "semi": true,
+    "singleQuote": false,
+    "printWidth": 120,
+    "bracketSpacing": true,
+    "jsxBracketSameLine": false,
+    "arrowParens": "avoid",
+    "proseWrap": "always",
+    "overrides": [
+        {
+            "files": ["CHANGELOG.md", ".travis.yml"],
+            "options": {
+                "proseWrap": "preserve"
+            }
+        },
+        {
+            "files": ["package.json", "package.json"],
+            "options": {
+                "tabWidth": 2
+            }
+        },
+        {
+            "files": "*.md",
+            "options": {
+                "proseWrap": "preserve"
+            }
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   },
   "scripts": {
     "postinstall": "lerna bootstrap --hoist --strict",
-    "prettier": "prettier --config \"./prettier.config.js\" --write \"./**/{src,test}/**/*.{js,jsx,ts,tsx,scss}\"",
-    "format": "pretty-quick --staged",
+    "prettier": "prettier --config \"./prettier.config.js\" --write \"**/{src,script,test}/**/*.{js,jsx,ts,tsx,scss}\"",
+    "format": "pretty-quick --staged --pattern \"**/{src,script,test}/**/*.{js,jsx,ts,tsx,scss}\"",
     "clean-all-screenshots-mac": "find . -name 'screenshot-baseline' -type d -prune -exec rm -rf '{}' +",
     "lint": "npm run lint:src && lerna run lint --stream",
     "lint:src": "eslint --config .eslintrc.js --ext .jsx,.js,.ts,.tsx packages/*/*/src",
@@ -74,7 +74,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged",
+      "pre-commit": "pretty-quick --staged --pattern \"**/{src,script,test}/**/*.{js,jsx,ts,tsx,scss}\"",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -22,5 +22,4 @@ module.exports = {
             }
         }
     ],
-    filepath: "**/{src,test}/**/*.{js,jsx,ts,tsx,scss}"
 };


### PR DESCRIPTION
The goal here is to format consistenty in scripts, on-commit hook and on-save actions.

- temporarily introduce a `.rc` file matching `.js` configuration as pretty-quick doesn't read in `.js` files. I don't see this as an issue as our config doesn't change often. Until pretty-quick reads `.js` we need to maintain both files.
- remove filepath configuration prop as [this is not recommend in configuration](https://prettier.io/docs/en/options.html#file-path)
- update patterns to remove relative start, and include scripts. Apply this across the board.

I think it is a good idea to make a PR to pretty-quick to include reading `.js` files as we depend on this for dynamic base extension.

Webstorm glob suggestion for prettier plugin: `{**/*,*}.{js,jsx,ts,tsx,spec.ts,spec.tsx,css,scss}`

### todo

- [ ] Add a JIRA if this gets merged and include details on landing pretty-quick `.js` feature.