### PR TITLE
Badge button design properties

### DIFF
--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_badgebutton.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_badgebutton.scss
@@ -14,80 +14,84 @@
 //Badge button color variation
 .btn-secondary,
 .btn-default {
-  .badge {
-    color: $btn-default-bg;
-    background-color: $btn-primary-bg;
-  }
+    .badge {
+        color: $btn-default-bg;
+        background-color: $btn-primary-bg;
+    }
 }
 
 .btn-success {
-  .badge {
-    color: $btn-success-bg;
-  }
+    .badge {
+        color: $btn-success-bg;
+    }
 }
 
 .btn-warning {
-  .badge {
-    color: $btn-warning-bg;
-  }
+    .badge {
+        color: $btn-warning-bg;
+    }
 }
 
 .btn-danger {
-  .badge {
-    color: $btn-danger-bg;
-  }
+    .badge {
+        color: $btn-danger-bg;
+    }
 }
 
 //Badge button bordered variation
 
-.btn-bordered.btn-primary{
-  .badge{
-    background: $btn-primary-bg;
-    color: $btn-primary-color;
-  }
-  &:hover, &:focus{
-    .badge{
-      background-color: $btn-primary-color;
-      color: $btn-primary-bg;
+.btn-bordered.btn-primary {
+    .badge {
+        background: $btn-primary-bg;
+        color: $btn-primary-color;
     }
-  }
+    &:hover,
+    &:focus {
+        .badge {
+            background-color: $btn-primary-color;
+            color: $btn-primary-bg;
+        }
+    }
 }
 
-.btn-bordered.btn-success{
-  .badge{ 
-    background: $btn-success-bg;
-    color: $btn-success-color;
-  }
-  &:hover, &:focus{
-    .badge{
-      background-color: $btn-success-color;
-      color: $btn-success-bg;
+.btn-bordered.btn-success {
+    .badge {
+        background: $btn-success-bg;
+        color: $btn-success-color;
     }
-  }
+    &:hover,
+    &:focus {
+        .badge {
+            background-color: $btn-success-color;
+            color: $btn-success-bg;
+        }
+    }
 }
 
-.btn-bordered.btn-warning{
-  .badge{ 
-    background: $btn-warning-bg;
-    color: $btn-warning-color;
-  }
-  &:hover, &:focus{
-    .badge{
-      background-color: $btn-warning-color;
-      color: $btn-warning-bg;
+.btn-bordered.btn-warning {
+    .badge {
+        background: $btn-warning-bg;
+        color: $btn-warning-color;
     }
-  }
+    &:hover,
+    &:focus {
+        .badge {
+            background-color: $btn-warning-color;
+            color: $btn-warning-bg;
+        }
+    }
 }
 
-.btn-bordered.btn-danger{
-  .badge{ 
-    background: $btn-danger-bg;
-    color: $btn-danger-color;
-  }
-  &:hover, &:focus{
-    .badge{
-      background-color: $btn-danger-color;
-      color: $btn-danger-bg;
+.btn-bordered.btn-danger {
+    .badge {
+        background: $btn-danger-bg;
+        color: $btn-danger-color;
     }
-  }
+    &:hover,
+    &:focus {
+        .badge {
+            background-color: $btn-danger-color;
+            color: $btn-danger-bg;
+        }
+    }
 }

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_badgebutton.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_badgebutton.scss
@@ -11,6 +11,7 @@
    Different background components, all managed by variables
 ========================================================================== */
 
+//Badge button color variation
 .btn-secondary,
 .btn-default {
   .badge {
@@ -34,5 +35,59 @@
 .btn-danger {
   .badge {
     color: $btn-danger-bg;
+  }
+}
+
+//Badge button bordered variation
+
+.btn-bordered.btn-primary{
+  .badge{
+    background: $btn-primary-bg;
+    color: $btn-primary-color;
+  }
+  &:hover, &:focus{
+    .badge{
+      background-color: $btn-primary-color;
+      color: $btn-primary-bg;
+    }
+  }
+}
+
+.btn-bordered.btn-success{
+  .badge{ 
+    background: $btn-success-bg;
+    color: $btn-success-color;
+  }
+  &:hover, &:focus{
+    .badge{
+      background-color: $btn-success-color;
+      color: $btn-success-bg;
+    }
+  }
+}
+
+.btn-bordered.btn-warning{
+  .badge{ 
+    background: $btn-warning-bg;
+    color: $btn-warning-color;
+  }
+  &:hover, &:focus{
+    .badge{
+      background-color: $btn-warning-color;
+      color: $btn-warning-bg;
+    }
+  }
+}
+
+.btn-bordered.btn-danger{
+  .badge{ 
+    background: $btn-danger-bg;
+    color: $btn-danger-color;
+  }
+  &:hover, &:focus{
+    .badge{
+      background-color: $btn-danger-color;
+      color: $btn-danger-bg;
+    }
   }
 }

--- a/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
@@ -869,6 +869,10 @@
             "description": "The brand style affecting this element's appearance.",
             "options": [
                 {
+                    "name": "Brand Primary",
+                    "class": "label-primary"
+                },
+                {
                     "name": "Brand Secondary",
                     "class": "label-secondary"
                 },
@@ -944,6 +948,10 @@
             "description": "The brand style affecting this element's appearance.",
             "options": [
                 {
+                    "name": "Brand Primary",
+                    "class": "btn-primary"
+                },
+                {
                     "name": "Brand Secondary",
                     "class": "btn-secondary"
                 },
@@ -960,6 +968,34 @@
                     "class": "btn-danger"
                 }
             ]
+        },
+        {
+            "name": "Size",
+            "type": "Dropdown",
+            "description": "Size of the buttons",
+            "options": [
+                {
+                    "name": "Small",
+                    "class": "btn-sm"
+                },
+                {
+                    "name": "Large",
+                    "class": "btn-lg"
+                }
+            ]
+        },
+        {
+            "name": "Full width",
+            "type": "Toggle",
+            "description": "Extend the button to the full width of the container it is placed in.",
+            "class": "btn-block"
+        },
+        {
+            "name": "Border",
+            "oldNames": ["Bordered"],
+            "type": "Toggle",
+            "description": "Style the button with a transparent background, a colored border, and colored text.",
+            "class": "btn-bordered"
         }
     ],
     "com.mendix.widget.custom.progresscircle.ProgressCircle": [


### PR DESCRIPTION
### Changes
Added design properties to badge button to align with that of button.
Added styles to Atlas_Core (we might want to consider adding badge to button mixin in Atlas_Core)
Added the "brand primary" option to design property option, as we need an intuitive way to reset button style back to button primary as set to blank is not intuitive.