### PR TITLE
[PAG-1449] Add prop for the widgets type

### DIFF
--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
@@ -19,7 +19,7 @@ export interface MyWidgetContainerProps {
 export interface MyWidgetPreviewProps {
     class: string;
     style: string;
-    content: { widgetCount: number; renderer: ComponentType };
+    content: { widgetCount: number; renderer: ComponentType<{repeat?: boolean, caption?: string}> };
     description: string;
     action: {} | null;
 }

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
@@ -19,7 +19,7 @@ export interface MyWidgetContainerProps {
 export interface MyWidgetPreviewProps {
     class: string;
     style: string;
-    content: { widgetCount: number; renderer: ComponentType<{repeat?: boolean, caption?: string}> };
+    content: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     description: string;
     action: {} | null;
 }

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
@@ -13,7 +13,7 @@ export interface DatasourcePropertiesType {
 }
 
 export interface DatasourcePropertiesPreviewType {
-    contentAttribute: { widgetCount: number; renderer: ComponentType };
+    contentAttribute: { widgetCount: number; renderer: ComponentType<{repeat?: boolean, caption?: string}> };
     markerAttribute: string;
     actionAttribute: {} | null;
 }
@@ -39,7 +39,7 @@ export interface MyWidgetPreviewProps {
     class: string;
     style: string;
     contentSource: {} | null;
-    content: { widgetCount: number; renderer: ComponentType };
+    content: { widgetCount: number; renderer: ComponentType<{repeat?: boolean, caption?: string}> };
     markerDataAttribute: string;
     actionAttribute: {} | null;
     textTemplateAttribute: string;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
@@ -13,7 +13,7 @@ export interface DatasourcePropertiesType {
 }
 
 export interface DatasourcePropertiesPreviewType {
-    contentAttribute: { widgetCount: number; renderer: ComponentType<{repeat?: boolean, caption?: string}> };
+    contentAttribute: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     markerAttribute: string;
     actionAttribute: {} | null;
 }
@@ -39,7 +39,7 @@ export interface MyWidgetPreviewProps {
     class: string;
     style: string;
     contentSource: {} | null;
-    content: { widgetCount: number; renderer: ComponentType<{repeat?: boolean, caption?: string}> };
+    content: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     markerDataAttribute: string;
     actionAttribute: {} | null;
     textTemplateAttribute: string;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
@@ -53,7 +53,7 @@ ${generatePreviewTypeBody(extractProperties(prop.properties[0]), generatedTypes)
             );
             return prop.$.isList === "true" ? `${childType}[]` : childType;
         case "widgets":
-            return "{ widgetCount: number; renderer: ComponentType }";
+            return "{ widgetCount: number; renderer: ComponentType<{repeat?: boolean, caption?: string}> }";
         default:
             return "any";
     }

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
@@ -53,7 +53,7 @@ ${generatePreviewTypeBody(extractProperties(prop.properties[0]), generatedTypes)
             );
             return prop.$.isList === "true" ? `${childType}[]` : childType;
         case "widgets":
-            return "{ widgetCount: number; renderer: ComponentType<{repeat?: boolean, caption?: string}> }";
+            return "{ widgetCount: number; renderer: ComponentType<{caption?: string}> }";
         default:
             return "any";
     }


### PR DESCRIPTION
Added a new property for the Widgets Type (dropzones)
	
- caption
	- this will override the default caption that is shown when the dropzone is empty
	