### PR TITLE
[WC-241] update mapbox to new API

### DIFF
--- a/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
+++ b/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
@@ -22,7 +22,7 @@ export interface LeafletProps extends SharedProps {
  * If not, we reuse a leaflet icon that's the same as the default implementation should be.
  */
 const defaultMarkerIcon = new LeafletIcon({
-    iconRetinaUrl: require("leaflet/dist/images/marker-icon-2x.png"),
+    iconRetinaUrl: require("leaflet/dist/images/marker-icon.png"),
     iconUrl: require("leaflet/dist/images/marker-icon.png"),
     shadowUrl: require("leaflet/dist/images/marker-shadow.png")
 });
@@ -83,10 +83,7 @@ export function LeafletMap(props: LeafletProps): ReactElement {
                     zoom={autoZoom ? translateZoom("city") : zoom}
                     zoomControl={zoomControl}
                 >
-                    <TileLayer
-                        {...baseMapLayer(mapProvider, mapsToken)}
-                        id={mapProvider === "mapBox" ? "mapbox/streets-v11" : undefined}
-                    />
+                    <TileLayer {...baseMapLayer(mapProvider, mapsToken)} />
                     {locations
                         .concat(currentLocation ? [currentLocation] : [])
                         .filter(m => !!m)

--- a/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
+++ b/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
@@ -24,7 +24,8 @@ export interface LeafletProps extends SharedProps {
 const defaultMarkerIcon = new LeafletIcon({
     iconRetinaUrl: require("leaflet/dist/images/marker-icon.png"),
     iconUrl: require("leaflet/dist/images/marker-icon.png"),
-    shadowUrl: require("leaflet/dist/images/marker-shadow.png")
+    shadowUrl: require("leaflet/dist/images/marker-shadow.png"),
+    iconAnchor: [12, 41]
 });
 
 export function LeafletMap(props: LeafletProps): ReactElement {

--- a/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
+++ b/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
@@ -25,6 +25,7 @@ const defaultMarkerIcon = new LeafletIcon({
     iconRetinaUrl: require("leaflet/dist/images/marker-icon.png"),
     iconUrl: require("leaflet/dist/images/marker-icon.png"),
     shadowUrl: require("leaflet/dist/images/marker-shadow.png"),
+    iconSize: [25, 41],
     iconAnchor: [12, 41]
 });
 

--- a/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
+++ b/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
@@ -85,7 +85,7 @@ export function LeafletMap(props: LeafletProps): ReactElement {
                 >
                     <TileLayer
                         {...baseMapLayer(mapProvider, mapsToken)}
-                        id={mapProvider === "mapBox" ? "mapbox.streets" : undefined}
+                        id={mapProvider === "mapBox" ? "mapbox/streets-v11" : undefined}
                     />
                     {locations
                         .concat(currentLocation ? [currentLocation] : [])

--- a/packages/pluggableWidgets/maps-web/src/components/__tests__/__snapshots__/LeafletMap.spec.ts.snap
+++ b/packages/pluggableWidgets/maps-web/src/components/__tests__/__snapshots__/LeafletMap.spec.ts.snap
@@ -70,7 +70,9 @@ exports[`Leaflet maps renders a map with MapBox maps as provider 1`] = `
       <ForwardRef(Leaflet(TileLayer))
         attribution="Map data &copy; <a href='https://www.openstreetmap.org/'>OpenStreetMap</a> contributors, <a href='https://creativecommons.org/licenses/by-sa/2.0/'>CC-BY-SA</a>, Imagery © <a href='https://www.mapbox.com/'>Mapbox</a>"
         id="mapbox/streets-v11"
+        tileSize={512}
         url="https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}"
+        zoomOffset={-1}
       />
     </Map>
   </div>

--- a/packages/pluggableWidgets/maps-web/src/components/__tests__/__snapshots__/LeafletMap.spec.ts.snap
+++ b/packages/pluggableWidgets/maps-web/src/components/__tests__/__snapshots__/LeafletMap.spec.ts.snap
@@ -69,8 +69,8 @@ exports[`Leaflet maps renders a map with MapBox maps as provider 1`] = `
     >
       <ForwardRef(Leaflet(TileLayer))
         attribution="Map data &copy; <a href='https://www.openstreetmap.org/'>OpenStreetMap</a> contributors, <a href='https://creativecommons.org/licenses/by-sa/2.0/'>CC-BY-SA</a>, Imagery © <a href='https://www.mapbox.com/'>Mapbox</a>"
-        id="mapbox.streets"
-        url="https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png"
+        id="mapbox/streets-v11"
+        url="https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}"
       />
     </Map>
   </div>

--- a/packages/pluggableWidgets/maps-web/src/utils/leaflet.ts
+++ b/packages/pluggableWidgets/maps-web/src/utils/leaflet.ts
@@ -1,3 +1,4 @@
+import { TileLayerProps } from "react-leaflet";
 import { MapProviderEnum } from "../../typings/MapsProps";
 
 const customUrls = {
@@ -13,7 +14,7 @@ const mapAttr = {
     hereMapsAttr: "Map &copy; 1987-2020 <a href='https://developer.here.com'>HERE</a>"
 };
 
-export function baseMapLayer(mapProvider: MapProviderEnum, mapsToken?: string): { attribution: string; url: string } {
+export function baseMapLayer(mapProvider: MapProviderEnum, mapsToken?: string): TileLayerProps {
     let url;
     let attribution;
     let apiKey = "";
@@ -23,6 +24,13 @@ export function baseMapLayer(mapProvider: MapProviderEnum, mapsToken?: string): 
         }
         url = customUrls.mapbox + apiKey;
         attribution = mapAttr.mapboxAttr;
+        return {
+            url,
+            attribution,
+            id: "mapbox/streets-v11",
+            tileSize: 512,
+            zoomOffset: -1
+        };
     } else if (mapProvider === "hereMaps") {
         if (mapsToken && mapsToken.indexOf(",") > 0) {
             const splitToken = mapsToken.split(",");

--- a/packages/pluggableWidgets/maps-web/src/utils/leaflet.ts
+++ b/packages/pluggableWidgets/maps-web/src/utils/leaflet.ts
@@ -2,7 +2,7 @@ import { MapProviderEnum } from "../../typings/MapsProps";
 
 const customUrls = {
     openStreetMap: "https://{s}.tile.osm.org/{z}/{x}/{y}.png",
-    mapbox: "https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png",
+    mapbox: "https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}",
     hereMaps: "https://2.base.maps.cit.api.here.com/maptile/2.1/maptile/newest/normal.day/{z}/{x}/{y}/256/png8"
 };
 


### PR DESCRIPTION
Update mapbox styles according to https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/

Relevant for us:
![image](https://user-images.githubusercontent.com/5955441/111766185-88bcfb80-88a5-11eb-9acb-05e1272c32d2.png)

## Testing Comments

Just check whether mapbox map render normally instead of just grey tiles:
![image](https://user-images.githubusercontent.com/5955441/111766246-996d7180-88a5-11eb-981e-8e8b42dfa768.png)
