### PR TITLE
feat(maps-web): add small description for google maps api token key

### DIFF
--- a/packages/pluggableWidgets/maps-web/src/Maps.editorConfig.ts
+++ b/packages/pluggableWidgets/maps-web/src/Maps.editorConfig.ts
@@ -75,9 +75,7 @@ export function getProperties(
             "mapTypeControl",
             "fullScreenControl",
             "rotateControl",
-            "mapStyles",
-            "geodecodeApiKey",
-            "geodecodeApiKeyExp"
+            "mapStyles"
         ]);
         if (values.mapProvider === "openStreet") {
             hidePropertiesIn(defaultProperties, values, ["apiKeyExp", "apiKey"]);

--- a/packages/pluggableWidgets/maps-web/src/Maps.editorConfig.ts
+++ b/packages/pluggableWidgets/maps-web/src/Maps.editorConfig.ts
@@ -75,7 +75,9 @@ export function getProperties(
             "mapTypeControl",
             "fullScreenControl",
             "rotateControl",
-            "mapStyles"
+            "mapStyles",
+            "geodecodeApiKey",
+            "geodecodeApiKeyExp"
         ]);
         if (values.mapProvider === "openStreet") {
             hidePropertiesIn(defaultProperties, values, ["apiKeyExp", "apiKey"]);

--- a/packages/pluggableWidgets/maps-web/src/Maps.xml
+++ b/packages/pluggableWidgets/maps-web/src/Maps.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <widget id="com.mendix.widget.custom.Maps.Maps" pluginWidget="true" offlineCapable="true"
-        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd">
+    xmlns="http://www.mendix.com/widget/1.0/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd">
     <name>Maps</name>
     <description>Custom description please</description>
     <helpUrl>https://docs.mendix.com/appstore/widgets/maps</helpUrl>
-    <icon>
-        iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAAHdbkFIAAAJL0lEQVR42u1aC2wUVRRFUcRP/ETEvyQaNTF+EgU1GH/4ye62oAiNIhKq4Cf+UFEJEAVFpN3Ctpa2sSIWAX9NC7OzRUHRoqiQCJJYQMVPFKMon0rlM2+30ue9u++1b+7O7MzOzlJRJnnZnTd37jv3vnvvu+++6dEjmyugGVz9NV0lJSV35MYBr7Kysr74W1paOiUjp8rKyiPECxcnO+rr63tZEQKnDvlnE4DkVi0rNfQobua9g3r7tVY6aEDR1GZijzdPv6KPkve1tbVHpREA0B3ybfj/fBqB2gH/49C+Vgn2EQIOuumZxiFrHUhMQY397UpPnPNDkbOc7WCUtSUZRI15gRgLhbS9HULgOZYMJCzVbGQbHON9ZL8tfFW+5Mjv8qTVhKLxiYEo63CUXz6QvyE9PgIZTQXRAPYN0D5yjcCpAbNa08vhcHgcdFZnGoHOdY9/9xXUjOlyCguaEpdlHYACGtul3oM1tji+CIoxVEuUCOR/Rx/AhyHdKA5o8Tp8Aa5DwIDCgagxzdEKqSmHlvBTKAJB01pRUXGyK1+Q19Dl/ESFwTSMGBktcUZJKVeZqPLL8GMZ3TG6SUYgezu0pqQ4UfaqoxVC50rgfD0VxUp5dgwyErhikE2zRQBeeRX8X+0JgfiNQHty/4vw/7gwONNlmDYIGxvzE+CixgqxyG2VfaEl7LyQZtxdtIH3Sl9N4xfkNCB41QQ54c+Uz+Fi8G1ixa3tHChqvNUVefkJKoicDAcAbMaXwC/OCerGIKHeNakB2K5kjIDYKcL/L+q9GgKs0htXF30JpN6DTEcu3DgN7wua4hcq874Xg3dyWrTdrUkwGntUEWYp8oK8cnDWANRWsOgvaWzzLdcySD/w+UOvvG+XDCx1NTiqXbywWY222Des4Y/FSRAwmHxW9Dk/UmrjuVnVC8XUjc2kUSfpIwLABCsGRZz3VIxwtVjFE0Ldd4t353kGAC8zJK6urj4mEwM5eEFT+9WK9s4VAL7PRQM8X41OjSsPqKmpOUH0tXnxIKHVy4Vm1jm9PFAQfqH03Sv6XvMKwPU0AMEbQlXF1I+hL7Q/APycTxv4H6/l/5kLtp7H4rKcloxE2Xt5Hzyks4hTRlTQxM7Oj+R6fIIcBDfeFivhWvm8qJkf4zsApWRwVieoWPz2gqhxvbI2vC7yg305D4gFDem3xa9/KRMPPTUwu5mqngKdHo6ovo/bzUM9ZURyzytLFqbEExJVAPWnWI53pqbCeBHvx9StpsnIBM8pmSrlkCg/LTU4a6NSp1KyxBUC3CqxPI8QvBp8ATC1mR+m3svtcyeAmDFWuGW9XXbleOEmXt1KA8PPklLp7EmRoLZSG4Bd9DjxjKWKBPGLPGfFmL2qSSTm+9TYYO7XddqCzh7BPvCQoyidJwCybqlWI4KL93CRbj9k76psJ9LcP/fjnAEspUvo82WV3Eq6rhjQfpXdjsgLgB1WDIa/84uMB9/aBaqJlQtyB2D1Ao0JYHQBZde0Qe4dbfLBzm1ezgCCeuJKk9vprJCWgywANIr+OzwBkG4JbbuI+Z/KPWGXRhL9MwCQO+2IJwDgltcJr/iEzrkIw82ZtAfvDxL9Kz0BgIEfFHP4cud+cAPvJSJeu9P04Q5LCMDcBKGLBfFGhWmVADAurym5iN1juzUlx4J+dwNYJ6bgci+hVLoc/A73NAV4+kZPoLIEUC7onyAA9gm+vTwHIZfVlccFfQUB9oXoH5hvAMME/SLCo8aVJ+UKYObMmQME/RoCrFj0v9Ft1RFhnJu6FQBu/w9ucA9e3XVhgRW/R4A8piSoGW/Dav4JFuAho4tBSvEyFttxn/OfEjoQTYzGMxansoZFvaUjFDUWFH3AjzswC0lRY6HliRbk7XgUi58oYIUbT9eDMTY4qMUnozXYvLM1b3Uf34tYWuIKLM+Yj/GMn/B4x7WrJJPd1Bk+2X2/+q8WvkBjN6bNYMy4waSgJbwf+PyHFjO9PRCNmzZNyW+YNNZCzkQbulVISCkKrRbYGdCGNLaScmXXIQ6WN8CUt7jxf6C7x+xOqW2vbOOrG50W+4K8KQCYV1oN+vTsN4kgbKkp+nfW8TqfPy6f37KMn0kLz8FofGTXBjQ+VH02auF6p3TrpbwpAJivUgeD5POaVH0Av70xzeR8pbJ+hlk41pq+WqQKm0rcmN5lPe0DiYWsJgnwNUQBq/IiPJ5LA/OEOlgkEjlSVOb6mIIfLGOFMX66UkaYT5c59GdQxmwQ/leioD1Dl/G+SiVQNwdDc5EeMRAFJOQZut/+fykZqIX46nizFezdjAXdLkHiw2X91N7/WWyqUk8HV3iGPN9kY5kt5Fz20nyY/wPE3+ZSmiGLdr6pAr6lYfue+9bww1UaFBDNGoR5GJa2pyD6F93azI+3OJqZpPIqXLxrHx5U2cSmuQTb/fkIgHOJBTxgoaSReEBBZnYHAD8pu2MhNsf0RWnjn/yFcISXl5ef6nVy/LCAFrf7Tvx0JM28dWOQ0xhoLRAf1qvvDav/lc8oDWe77/3KV+Hr6up6Z7v5nlQxDwXoMClCZ7ZLVGEscQmNEaMWrN/idfOPmH1TgNulBvq/Uekmz36rPwj1A1nGfqcuEdJYdVrqq8eHyU94lHHHu12iIRBe7af5jycarqQ0WEuUdUUBtkPWF2k0l+dN+Mkt3S1ipB+1jB8txn3MbZJDk7RMyvKigHdU5mVlZXdZFNYvJEr6mu4D5EGaXaNrPIx7GxFqcYbC/l2E9m0/FfAjYX6+RZ5QRGgarbfKrMYi/9+C1mAxbn/Cc20GjOcT2h/98v8+ZGbbbABMIXTT7HgmM8fk1w2sOaizYIZZ7UuE2uawVLep9FVVVSf6sf4HCYjlbtwE2p0+WR+zSr9taJcTDEE/AEzZD/XqfH2q+KwfFtB0oCoAsfuhgK3EBE+nNLNmzTqPuMn3Pgbg1wjvMXa0iI3Q/pFrAOxHNPqbDchbycAxHxUwlWB4zmHCfiM1i365bIGLyOCaDd0k4nulPm7D7yEY6hwUoJHJGJ6L9sOE2WSbQRcQutF+KQCWwhuJAj50wDyZYAnnooAVhNlNNnRridkN8EsBNL5A+84B802EvjkXBew+gFcAOWm7c/G/gPza6gAVfjPKcPBk9uBlff0D/JLUfaEaS14AAAAASUVORK5CYII=
+    <icon> iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAAHdbkFIAAAJL0lEQVR42u1aC2wUVRRFUcRP/ETEvyQaNTF+EgU1GH/4ye62oAiNIhKq4Cf+UFEJEAVFpN3Ctpa2sSIWAX9NC7OzRUHRoqiQCJJYQMVPFKMon0rlM2+30ue9u++1b+7O7MzOzlJRJnnZnTd37jv3vnvvu+++6dEjmyugGVz9NV0lJSV35MYBr7Kysr74W1paOiUjp8rKyiPECxcnO+rr63tZEQKnDvlnE4DkVi0rNfQobua9g3r7tVY6aEDR1GZijzdPv6KPkve1tbVHpREA0B3ybfj/fBqB2gH/49C+Vgn2EQIOuumZxiFrHUhMQY397UpPnPNDkbOc7WCUtSUZRI15gRgLhbS9HULgOZYMJCzVbGQbHON9ZL8tfFW+5Mjv8qTVhKLxiYEo63CUXz6QvyE9PgIZTQXRAPYN0D5yjcCpAbNa08vhcHgcdFZnGoHOdY9/9xXUjOlyCguaEpdlHYACGtul3oM1tji+CIoxVEuUCOR/Rx/AhyHdKA5o8Tp8Aa5DwIDCgagxzdEKqSmHlvBTKAJB01pRUXGyK1+Q19Dl/ESFwTSMGBktcUZJKVeZqPLL8GMZ3TG6SUYgezu0pqQ4UfaqoxVC50rgfD0VxUp5dgwyErhikE2zRQBeeRX8X+0JgfiNQHty/4vw/7gwONNlmDYIGxvzE+CixgqxyG2VfaEl7LyQZtxdtIH3Sl9N4xfkNCB41QQ54c+Uz+Fi8G1ixa3tHChqvNUVefkJKoicDAcAbMaXwC/OCerGIKHeNakB2K5kjIDYKcL/L+q9GgKs0htXF30JpN6DTEcu3DgN7wua4hcq874Xg3dyWrTdrUkwGntUEWYp8oK8cnDWANRWsOgvaWzzLdcySD/w+UOvvG+XDCx1NTiqXbywWY222Des4Y/FSRAwmHxW9Dk/UmrjuVnVC8XUjc2kUSfpIwLABCsGRZz3VIxwtVjFE0Ldd4t353kGAC8zJK6urj4mEwM5eEFT+9WK9s4VAL7PRQM8X41OjSsPqKmpOUH0tXnxIKHVy4Vm1jm9PFAQfqH03Sv6XvMKwPU0AMEbQlXF1I+hL7Q/APycTxv4H6/l/5kLtp7H4rKcloxE2Xt5Hzyks4hTRlTQxM7Oj+R6fIIcBDfeFivhWvm8qJkf4zsApWRwVieoWPz2gqhxvbI2vC7yg305D4gFDem3xa9/KRMPPTUwu5mqngKdHo6ovo/bzUM9ZURyzytLFqbEExJVAPWnWI53pqbCeBHvx9StpsnIBM8pmSrlkCg/LTU4a6NSp1KyxBUC3CqxPI8QvBp8ATC1mR+m3svtcyeAmDFWuGW9XXbleOEmXt1KA8PPklLp7EmRoLZSG4Bd9DjxjKWKBPGLPGfFmL2qSSTm+9TYYO7XddqCzh7BPvCQoyidJwCybqlWI4KL93CRbj9k76psJ9LcP/fjnAEspUvo82WV3Eq6rhjQfpXdjsgLgB1WDIa/84uMB9/aBaqJlQtyB2D1Ao0JYHQBZde0Qe4dbfLBzm1ezgCCeuJKk9vprJCWgywANIr+OzwBkG4JbbuI+Z/KPWGXRhL9MwCQO+2IJwDgltcJr/iEzrkIw82ZtAfvDxL9Kz0BgIEfFHP4cud+cAPvJSJeu9P04Q5LCMDcBKGLBfFGhWmVADAurym5iN1juzUlx4J+dwNYJ6bgci+hVLoc/A73NAV4+kZPoLIEUC7onyAA9gm+vTwHIZfVlccFfQUB9oXoH5hvAMME/SLCo8aVJ+UKYObMmQME/RoCrFj0v9Ft1RFhnJu6FQBu/w9ucA9e3XVhgRW/R4A8piSoGW/Dav4JFuAho4tBSvEyFttxn/OfEjoQTYzGMxansoZFvaUjFDUWFH3AjzswC0lRY6HliRbk7XgUi58oYIUbT9eDMTY4qMUnozXYvLM1b3Uf34tYWuIKLM+Yj/GMn/B4x7WrJJPd1Bk+2X2/+q8WvkBjN6bNYMy4waSgJbwf+PyHFjO9PRCNmzZNyW+YNNZCzkQbulVISCkKrRbYGdCGNLaScmXXIQ6WN8CUt7jxf6C7x+xOqW2vbOOrG50W+4K8KQCYV1oN+vTsN4kgbKkp+nfW8TqfPy6f37KMn0kLz8FofGTXBjQ+VH02auF6p3TrpbwpAJivUgeD5POaVH0Av70xzeR8pbJ+hlk41pq+WqQKm0rcmN5lPe0DiYWsJgnwNUQBq/IiPJ5LA/OEOlgkEjlSVOb6mIIfLGOFMX66UkaYT5c59GdQxmwQ/leioD1Dl/G+SiVQNwdDc5EeMRAFJOQZut/+fykZqIX46nizFezdjAXdLkHiw2X91N7/WWyqUk8HV3iGPN9kY5kt5Fz20nyY/wPE3+ZSmiGLdr6pAr6lYfue+9bww1UaFBDNGoR5GJa2pyD6F93azI+3OJqZpPIqXLxrHx5U2cSmuQTb/fkIgHOJBTxgoaSReEBBZnYHAD8pu2MhNsf0RWnjn/yFcISXl5ef6nVy/LCAFrf7Tvx0JM28dWOQ0xhoLRAf1qvvDav/lc8oDWe77/3KV+Hr6up6Z7v5nlQxDwXoMClCZ7ZLVGEscQmNEaMWrN/idfOPmH1TgNulBvq/Uekmz36rPwj1A1nGfqcuEdJYdVrqq8eHyU94lHHHu12iIRBe7af5jycarqQ0WEuUdUUBtkPWF2k0l+dN+Mkt3S1ipB+1jB8txn3MbZJDk7RMyvKigHdU5mVlZXdZFNYvJEr6mu4D5EGaXaNrPIx7GxFqcYbC/l2E9m0/FfAjYX6+RZ5QRGgarbfKrMYi/9+C1mAxbn/Cc20GjOcT2h/98v8+ZGbbbABMIXTT7HgmM8fk1w2sOaizYIZZ7UuE2uawVLep9FVVVSf6sf4HCYjlbtwE2p0+WR+zSr9taJcTDEE/AEzZD/XqfH2q+KwfFtB0oCoAsfuhgK3EBE+nNLNmzTqPuMn3Pgbg1wjvMXa0iI3Q/pFrAOxHNPqbDchbycAxHxUwlWB4zmHCfiM1i365bIGLyOCaDd0k4nulPm7D7yEY6hwUoJHJGJ6L9sOE2WSbQRcQutF+KQCWwhuJAj50wDyZYAnnooAVhNlNNnRridkN8EsBNL5A+84B802EvjkXBew+gFcAOWm7c/G/gPza6gAVfjPKcPBk9uBlff0D/JLUfaEaS14AAAAASUVORK5CYII=
     </icon>
     <properties>
         <!-- Data source -->
@@ -97,16 +96,14 @@
                                         <attributeType name="String"/>
                                     </attributeTypes>
                                 </property>
-                                <property key="latitude" type="attribute" dataSource="markersDS"
-                                          required="false">
+                                <property key="latitude" type="attribute" dataSource="markersDS" required="false">
                                     <caption>Latitude</caption>
                                     <description>Decimal number from -90.0 to 90.0.</description>
                                     <attributeTypes>
                                         <attributeType name="Decimal"/>
                                     </attributeTypes>
                                 </property>
-                                <property key="longitude" type="attribute" dataSource="markersDS"
-                                          required="false">
+                                <property key="longitude" type="attribute" dataSource="markersDS" required="false">
                                     <caption>Longitude</caption>
                                     <description>Decimal number from -180.0 to 180.0.</description>
                                     <attributeTypes>
@@ -157,11 +154,11 @@
                 </property>
                 <property key="geodecodeApiKey" type="string" required="false">
                     <caption>Google maps API Key</caption>
-                    <description/>
+                    <description>If Google Maps is not used as the map provider, this property becomes optional. If you're using markers based on address, then this key is necessary for the markers to work.</description>
                 </property>
                 <property key="geodecodeApiKeyExp" type="expression" required="false">
                     <caption>Google maps API Key</caption>
-                    <description/>
+                    <description>If Google Maps is not used as the map provider, this property becomes optional. If you're using markers based on address, then this key is necessary for the markers to work.</description>
                     <returnType type="String"/>
                 </property>
                 <property key="showCurrentLocation" type="boolean" defaultValue="false">

--- a/packages/pluggableWidgets/maps-web/src/Maps.xml
+++ b/packages/pluggableWidgets/maps-web/src/Maps.xml
@@ -154,11 +154,11 @@
                 </property>
                 <property key="geodecodeApiKey" type="string" required="false">
                     <caption>Google maps API Key</caption>
-                    <description>If Google Maps is not used as the map provider, this property becomes optional. If you're using markers based on address, then this key is necessary for the markers to work.</description>
+                    <description>If you are not using Google Maps as your map provider, this property becomes optional. If you are using markers based on address, this key is required for those markers to work.</description>
                 </property>
                 <property key="geodecodeApiKeyExp" type="expression" required="false">
                     <caption>Google maps API Key</caption>
-                    <description>If Google Maps is not used as the map provider, this property becomes optional. If you're using markers based on address, then this key is necessary for the markers to work.</description>
+                    <description>If you are not using Google Maps as your map provider, this property becomes optional. If you are using markers based on address, this key is required for those markers to work.</description>
                     <returnType type="String"/>
                 </property>
                 <property key="showCurrentLocation" type="boolean" defaultValue="false">


### PR DESCRIPTION
Right now the general property tab always contains the following block at the end:

![image](https://user-images.githubusercontent.com/5955441/112001248-148d8c80-8b1f-11eb-8a3e-3e8872e6b61e.png)

But even if you change the map provider and thus need another api token, it will stay:
![image](https://user-images.githubusercontent.com/5955441/112001353-2e2ed400-8b1f-11eb-8c46-fa23216c9439.png)

Open street maps doesn't require an api token, but still shows it. This can be quite confusing for the user since it's not required and not used anyways. So I think removing it should be fine.

## Testing Tips

Just make sure that every other provider works as expected and there's no regression
