### PR TITLE
feat(popup-menu-web): make consistency checks compatible with Mendix 9

### DIFF
--- a/packages/pluggableWidgets/popup-menu-web/package.json
+++ b/packages/pluggableWidgets/popup-menu-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "popup-menu-web",
   "widgetName": "PopupMenu",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "copyright": "Mendix Technology B.V.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.editorConfig.ts
+++ b/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.editorConfig.ts
@@ -87,14 +87,6 @@ export function check(values: PopupMenuPreviewProps): Problem[] {
                 message: "For the popup menu to be visible, you need to add at least one item to it."
             });
         }
-        values.customItems.forEach((item, index) => {
-            if (!item.content) {
-                errors.push({
-                    property: `customItems/${index + 1}/content`,
-                    message: "The content of a menu item cannot be empty."
-                });
-            }
-        });
     }
     return errors;
 }

--- a/packages/pluggableWidgets/popup-menu-web/src/package.xml
+++ b/packages/pluggableWidgets/popup-menu-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="PopupMenu" version="1.0.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="PopupMenu" version="1.0.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="PopupMenu.xml"/>
         </widgetFiles>


### PR DESCRIPTION
Similar to https://github.com/mendix/widgets-resources/pull/536, but then for popup menu web widget

## Testing tips
Same thing: use the widget, create an error and see whether it's thrown in Mendix 9 version