### PR TITLE
feat(accessibility-helper-web): make consistency checks compatible with Mendix 9

### DIFF
--- a/packages/pluggableWidgets/accessibility-helper-web/package.json
+++ b/packages/pluggableWidgets/accessibility-helper-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "accessibility-helper-web",
   "widgetName": "AccessibilityHelper",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Set an attribute to a DOM element",
   "copyright": "Mendix 2020",
   "author": "Widget Team",

--- a/packages/pluggableWidgets/accessibility-helper-web/src/AccessibilityHelper.editorConfig.ts
+++ b/packages/pluggableWidgets/accessibility-helper-web/src/AccessibilityHelper.editorConfig.ts
@@ -17,10 +17,10 @@ export function getProperties(values: AccessibilityHelperPreviewProps, defaultPr
 
 export function check(values: AccessibilityHelperPreviewProps): Problem[] {
     const errors: Problem[] = [];
-    values.attributesList.forEach((item: AttributesListPreviewType) => {
+    values.attributesList.forEach((item: AttributesListPreviewType, index) => {
         if (PROHIBITED_ATTRIBUTES.some(value => value === item.attribute)) {
             errors.push({
-                property: "attributesList.attribute",
+                property: `attributesList/${index + 1}/attribute`,
                 message: `Widget tries to change ${item.attribute} attribute, this is prohibited`,
                 url: "https://docs.mendix.com/appstore/widgets/accessibility-helper"
             });

--- a/packages/pluggableWidgets/accessibility-helper-web/src/package.xml
+++ b/packages/pluggableWidgets/accessibility-helper-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="AccessibilityHelper" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="AccessibilityHelper" version="1.0.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="AccessibilityHelper.xml"/>
         </widgetFiles>


### PR DESCRIPTION
Similar to #536 and #537, but then for the accessibility helper web widget

Testing tips
Same thing: use the widget, create an error and see whether it's thrown in Mendix 9 version