### PR TITLE
fix(datagrid-web): fixing consistency check & warning

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -59,6 +59,9 @@ export function getProperties(
     if (values.pagination !== "buttons") {
         hidePropertyIn(defaultProperties, values, "pagingPosition");
     }
+    if (values.showEmptyPlaceholder === "none") {
+        hidePropertyIn(defaultProperties, values, "emptyPlaceholder");
+    }
     if (!values.advanced) {
         hidePropertiesIn(defaultProperties, values, [
             "pagination",

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -270,7 +270,7 @@ export function check(values: DatagridPreviewProps): Problem[] {
                 property: `columns/${index + 1}/attribute`,
                 message: `An attribute is required when 'Show' is set to 'Attribute'. Select the 'Attribute' property for column ${column.header}`
             });
-        } else if (!column.attribute && (column.sortable || values.columnsFilterable)) {
+        } else if (!column.attribute && ((values.columnsSortable && column.sortable) || values.columnsFilterable)) {
             errors.push({
                 property: `columns/${index + 1}/attribute`,
                 message: `An attribute is required when filtering or sorting is enabled. Select the 'Attribute' property for column ${column.header}`

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
@@ -61,13 +61,10 @@ export function preview(props: DatagridPreviewProps): ReactElement {
             columnsSortable={props.columnsSortable}
             data={data}
             emptyPlaceholderRenderer={useCallback(
-                renderWrapper =>
-                    props.showEmptyPlaceholder === "custom" ? (
-                        <props.emptyPlaceholder.renderer>{renderWrapper(null)}</props.emptyPlaceholder.renderer>
-                    ) : (
-                        <div />
-                    ),
-                [props.emptyPlaceholder, props.showEmptyPlaceholder]
+                renderWrapper => (
+                    <props.emptyPlaceholder.renderer>{renderWrapper(null)}</props.emptyPlaceholder.renderer>
+                ),
+                [props.emptyPlaceholder]
             )}
             filterRenderer={useCallback(
                 (renderWrapper, columnIndex) => {


### PR DESCRIPTION
Extra: It fixes a warning being thrown in Studio and Design mode:
`[Data grid 2] Preview error: widget container property 'Empty placeholder' has not been rendered, all widget container properties must be rendered.`