### PR TITLE
[WC-171] Calendar-web: fix start date attribute inside the view tab

### DIFF
--- a/packages/customWidgets/calendar-web/package.json
+++ b/packages/customWidgets/calendar-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar-web",
   "widgetName": "Calendar",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Display and manage calendar events",
   "copyright": "Mendix BV",
   "repository": {

--- a/packages/customWidgets/calendar-web/src/package.xml
+++ b/packages/customWidgets/calendar-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Calendar2" version="1.0.9" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Calendar2" version="1.0.10" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Calendar.xml"/>
         </widgetFiles>


### PR DESCRIPTION
## Why?
The start date attribute inside the view tab doesn't work with attributes over association.

## What?
- The start date attribute property inside the view tab works now with attributes over association by using the `fetch` API endpoint.
- Bump patch version.

## How to test?
- Test start date attribute inside the view tab with no attribute, direct (context) object attribute and attribute from an associated object.