### PR TITLE
[WC-255] use useLoadScript instead of LoadScript component to avoid duplicate api load

### DIFF
--- a/packages/pluggableWidgets/maps-web/src/components/GoogleMap.tsx
+++ b/packages/pluggableWidgets/maps-web/src/components/GoogleMap.tsx
@@ -4,7 +4,7 @@ import {
     GoogleMap as GoogleMapComponent,
     Marker as MarkerComponent,
     InfoWindow,
-    LoadScript
+    useLoadScript
 } from "@react-google-maps/api";
 import { Marker, SharedProps } from "../../typings/shared";
 import { getGoogleMapsStyles } from "../utils/google";
@@ -70,16 +70,20 @@ export function GoogleMap(props: GoogleMapsProps): ReactElement {
         }
     }, [map.current, locations, currentLocation, autoZoom]);
 
+    const { isLoaded, loadError } = useLoadScript({
+        googleMapsApiKey: mapsToken ?? "",
+        id: "_com.mendix.widget.custom.Maps.Maps"
+    });
+
+    if (loadError) {
+        setError(loadError.message);
+    }
+
     return (
         <div className={classNames("widget-maps", className)} style={{ ...style, ...getDimensions(props) }}>
             {error && <Alert bootstrapStyle="danger">{error}</Alert>}
             <div className="widget-google-maps-wrapper">
-                <LoadScript
-                    googleMapsApiKey={mapsToken ?? ""}
-                    id="_com.mendix.widget.custom.Maps.Maps"
-                    loadingElement={<div className="spinner" />}
-                    onError={error => setError(error.message)}
-                >
+                {isLoaded ? (
                     <GoogleMapComponent
                         mapContainerClassName="widget-google-maps"
                         options={{
@@ -117,7 +121,9 @@ export function GoogleMap(props: GoogleMapsProps): ReactElement {
                                 />
                             ))}
                     </GoogleMapComponent>
-                </LoadScript>
+                ) : (
+                    <div className="spinner" />
+                )}
             </div>
         </div>
     );

--- a/packages/pluggableWidgets/maps-web/src/components/__tests__/GoogleMap.spec.ts
+++ b/packages/pluggableWidgets/maps-web/src/components/__tests__/GoogleMap.spec.ts
@@ -43,6 +43,7 @@ describe("Google maps", () => {
 
     beforeEach(() => {
         initialize();
+        mockUseLoadScriptHookWithReturn({ isLoaded: true, loadError: undefined });
     });
 
     afterEach(() => {
@@ -53,7 +54,6 @@ describe("Google maps", () => {
         shallow(createElement(GoogleMap, props));
 
     it("renders a map with right structure", () => {
-        mockUseLoadScriptHookWithReturn({ isLoaded: true, loadError: undefined });
         const googleMaps = renderGoogleMap(defaultProps);
         googleMaps.setProps({
             heightUnit: "percentageOfWidth",
@@ -64,7 +64,6 @@ describe("Google maps", () => {
     });
 
     it("renders a map with pixels renders structure correctly", () => {
-        mockUseLoadScriptHookWithReturn({ isLoaded: true, loadError: undefined });
         const googleMaps = renderGoogleMap(defaultProps);
         googleMaps.setProps({
             heightUnit: "pixels",
@@ -75,7 +74,6 @@ describe("Google maps", () => {
     });
 
     it("renders a map with percentage of width and height units renders the structure correctly", () => {
-        mockUseLoadScriptHookWithReturn({ isLoaded: true, loadError: undefined });
         const googleMaps = renderGoogleMap(defaultProps);
         googleMaps.setProps({
             heightUnit: "percentageOfWidth",
@@ -86,7 +84,6 @@ describe("Google maps", () => {
     });
 
     it("renders a map with percentage of parent units renders the structure correctly", () => {
-        mockUseLoadScriptHookWithReturn({ isLoaded: true, loadError: undefined });
         const googleMaps = renderGoogleMap(defaultProps);
         googleMaps.setProps({
             heightUnit: "percentageOfParent",
@@ -97,7 +94,6 @@ describe("Google maps", () => {
     });
 
     it("renders a map with markers", () => {
-        mockUseLoadScriptHookWithReturn({ isLoaded: true, loadError: undefined });
         const googleMaps = renderGoogleMap(defaultProps);
         googleMaps.setProps({
             locations: [
@@ -120,7 +116,6 @@ describe("Google maps", () => {
     });
 
     it("renders a map with current location", () => {
-        mockUseLoadScriptHookWithReturn({ isLoaded: true, loadError: undefined });
         const googleMaps = renderGoogleMap(defaultProps);
         googleMaps.setProps({
             showCurrentLocation: true,

--- a/packages/pluggableWidgets/maps-web/src/components/__tests__/GoogleMap.spec.ts
+++ b/packages/pluggableWidgets/maps-web/src/components/__tests__/GoogleMap.spec.ts
@@ -2,6 +2,20 @@ import { shallow, ShallowWrapper } from "enzyme";
 import { createElement } from "react";
 import { GoogleMap, GoogleMapsProps } from "../GoogleMap";
 import { initialize } from "@googlemaps/jest-mocks";
+import { useLoadScript } from "@react-google-maps/api";
+
+jest.mock("@react-google-maps/api", () => {
+    const original = jest.requireActual("@react-google-maps/api");
+    return {
+        ...original,
+        useLoadScript: jest.fn()
+    };
+});
+
+function mockUseLoadScriptHookWithReturn(returnValue: Partial<ReturnType<typeof useLoadScript>>): void {
+    // @ts-expect-error `mockImplementation` is present cuz of the mock, but TS doesn't know.
+    useLoadScript.mockImplementation(() => returnValue);
+}
 
 describe("Google maps", () => {
     const defaultProps: GoogleMapsProps = {
@@ -31,10 +45,15 @@ describe("Google maps", () => {
         initialize();
     });
 
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
     const renderGoogleMap = (props: GoogleMapsProps): ShallowWrapper<GoogleMapsProps, any> =>
         shallow(createElement(GoogleMap, props));
 
     it("renders a map with right structure", () => {
+        mockUseLoadScriptHookWithReturn({ isLoaded: true, loadError: undefined });
         const googleMaps = renderGoogleMap(defaultProps);
         googleMaps.setProps({
             heightUnit: "percentageOfWidth",
@@ -45,6 +64,7 @@ describe("Google maps", () => {
     });
 
     it("renders a map with pixels renders structure correctly", () => {
+        mockUseLoadScriptHookWithReturn({ isLoaded: true, loadError: undefined });
         const googleMaps = renderGoogleMap(defaultProps);
         googleMaps.setProps({
             heightUnit: "pixels",
@@ -55,6 +75,7 @@ describe("Google maps", () => {
     });
 
     it("renders a map with percentage of width and height units renders the structure correctly", () => {
+        mockUseLoadScriptHookWithReturn({ isLoaded: true, loadError: undefined });
         const googleMaps = renderGoogleMap(defaultProps);
         googleMaps.setProps({
             heightUnit: "percentageOfWidth",
@@ -65,6 +86,7 @@ describe("Google maps", () => {
     });
 
     it("renders a map with percentage of parent units renders the structure correctly", () => {
+        mockUseLoadScriptHookWithReturn({ isLoaded: true, loadError: undefined });
         const googleMaps = renderGoogleMap(defaultProps);
         googleMaps.setProps({
             heightUnit: "percentageOfParent",
@@ -75,6 +97,7 @@ describe("Google maps", () => {
     });
 
     it("renders a map with markers", () => {
+        mockUseLoadScriptHookWithReturn({ isLoaded: true, loadError: undefined });
         const googleMaps = renderGoogleMap(defaultProps);
         googleMaps.setProps({
             locations: [
@@ -97,6 +120,7 @@ describe("Google maps", () => {
     });
 
     it("renders a map with current location", () => {
+        mockUseLoadScriptHookWithReturn({ isLoaded: true, loadError: undefined });
         const googleMaps = renderGoogleMap(defaultProps);
         googleMaps.setProps({
             showCurrentLocation: true,

--- a/packages/pluggableWidgets/maps-web/src/components/__tests__/__snapshots__/GoogleMap.spec.ts.snap
+++ b/packages/pluggableWidgets/maps-web/src/components/__tests__/__snapshots__/GoogleMap.spec.ts.snap
@@ -13,66 +13,54 @@ exports[`Google maps renders a map with current location 1`] = `
   <div
     className="widget-google-maps-wrapper"
   >
-    <LoadScript
-      googleMapsApiKey=""
-      id="_com.mendix.widget.custom.Maps.Maps"
-      loadingElement={
-        <div
-          className="spinner"
-        />
+    <GoogleMap
+      center={
+        Object {
+          "lat": 51.906688,
+          "lng": 4.48837,
+        }
       }
-      onError={[Function]}
-      version="weekly"
-    >
-      <GoogleMap
-        center={
-          Object {
-            "lat": 51.906688,
-            "lng": 4.48837,
-          }
-        }
-        mapContainerClassName="widget-google-maps"
-        onCenterChanged={[Function]}
-        onLoad={[Function]}
-        options={
-          Object {
-            "draggable": true,
-            "fullscreenControl": false,
-            "mapTypeControl": false,
-            "maxZoom": 20,
-            "minZoom": 1,
-            "rotateControl": false,
-            "scrollwheel": true,
-            "streetViewControl": false,
-            "styles": Array [
-              Object {
-                "elementType": "labels",
-                "featureType": "poi",
-                "stylers": Array [
-                  Object {
-                    "visibility": "off",
-                  },
-                ],
-              },
-            ],
-            "zoomControl": true,
-          }
-        }
-        zoom={10}
-      >
-        <GoogleMapsMarker
-          key="marker_0"
-          marker={
+      mapContainerClassName="widget-google-maps"
+      onCenterChanged={[Function]}
+      onLoad={[Function]}
+      options={
+        Object {
+          "draggable": true,
+          "fullscreenControl": false,
+          "mapTypeControl": false,
+          "maxZoom": 20,
+          "minZoom": 1,
+          "rotateControl": false,
+          "scrollwheel": true,
+          "streetViewControl": false,
+          "styles": Array [
             Object {
-              "latitude": 51.906688,
-              "longitude": 4.48837,
-              "url": "image:url",
-            }
+              "elementType": "labels",
+              "featureType": "poi",
+              "stylers": Array [
+                Object {
+                  "visibility": "off",
+                },
+              ],
+            },
+          ],
+          "zoomControl": true,
+        }
+      }
+      zoom={10}
+    >
+      <GoogleMapsMarker
+        key="marker_0"
+        marker={
+          Object {
+            "latitude": 51.906688,
+            "longitude": 4.48837,
+            "url": "image:url",
           }
-          setSelectedMarker={[Function]}
-        />
-      </GoogleMap>
-    </LoadScript>
+        }
+        setSelectedMarker={[Function]}
+      />
+    </GoogleMap>
   </div>
 </div>
 `;
@@ -90,79 +78,67 @@ exports[`Google maps renders a map with markers 1`] = `
   <div
     className="widget-google-maps-wrapper"
   >
-    <LoadScript
-      googleMapsApiKey=""
-      id="_com.mendix.widget.custom.Maps.Maps"
-      loadingElement={
-        <div
-          className="spinner"
-        />
+    <GoogleMap
+      center={
+        Object {
+          "lat": 51.906688,
+          "lng": 4.48837,
+        }
       }
-      onError={[Function]}
-      version="weekly"
+      mapContainerClassName="widget-google-maps"
+      onCenterChanged={[Function]}
+      onLoad={[Function]}
+      options={
+        Object {
+          "draggable": true,
+          "fullscreenControl": false,
+          "mapTypeControl": false,
+          "maxZoom": 20,
+          "minZoom": 1,
+          "rotateControl": false,
+          "scrollwheel": true,
+          "streetViewControl": false,
+          "styles": Array [
+            Object {
+              "elementType": "labels",
+              "featureType": "poi",
+              "stylers": Array [
+                Object {
+                  "visibility": "off",
+                },
+              ],
+            },
+          ],
+          "zoomControl": true,
+        }
+      }
+      zoom={10}
     >
-      <GoogleMap
-        center={
+      <GoogleMapsMarker
+        key="marker_0"
+        marker={
           Object {
-            "lat": 51.906688,
-            "lng": 4.48837,
+            "latitude": 51.906688,
+            "longitude": 4.48837,
+            "title": "Mendix HQ",
+            "url": "image:url",
           }
         }
-        mapContainerClassName="widget-google-maps"
-        onCenterChanged={[Function]}
-        onLoad={[Function]}
-        options={
+        setSelectedMarker={[Function]}
+      />
+      <GoogleMapsMarker
+        key="marker_1"
+        marker={
           Object {
-            "draggable": true,
-            "fullscreenControl": false,
-            "mapTypeControl": false,
-            "maxZoom": 20,
-            "minZoom": 1,
-            "rotateControl": false,
-            "scrollwheel": true,
-            "streetViewControl": false,
-            "styles": Array [
-              Object {
-                "elementType": "labels",
-                "featureType": "poi",
-                "stylers": Array [
-                  Object {
-                    "visibility": "off",
-                  },
-                ],
-              },
-            ],
-            "zoomControl": true,
+            "latitude": 51.922823,
+            "longitude": 4.479632,
+            "title": "Gementee Rotterdam",
+            "url": "image:url",
           }
         }
-        zoom={10}
-      >
-        <GoogleMapsMarker
-          key="marker_0"
-          marker={
-            Object {
-              "latitude": 51.906688,
-              "longitude": 4.48837,
-              "title": "Mendix HQ",
-              "url": "image:url",
-            }
-          }
-          setSelectedMarker={[Function]}
-        />
-        <GoogleMapsMarker
-          key="marker_1"
-          marker={
-            Object {
-              "latitude": 51.922823,
-              "longitude": 4.479632,
-              "title": "Gementee Rotterdam",
-              "url": "image:url",
-            }
-          }
-          setSelectedMarker={[Function]}
-        />
-      </GoogleMap>
-    </LoadScript>
+        setSelectedMarker={[Function]}
+      />
+    </GoogleMap>
   </div>
 </div>
 `;
@@ -180,54 +156,42 @@ exports[`Google maps renders a map with percentage of parent units renders the s
   <div
     className="widget-google-maps-wrapper"
   >
-    <LoadScript
-      googleMapsApiKey=""
-      id="_com.mendix.widget.custom.Maps.Maps"
-      loadingElement={
-        <div
-          className="spinner"
-        />
+    <GoogleMap
+      center={
+        Object {
+          "lat": 51.906688,
+          "lng": 4.48837,
+        }
       }
-      onError={[Function]}
-      version="weekly"
-    >
-      <GoogleMap
-        center={
-          Object {
-            "lat": 51.906688,
-            "lng": 4.48837,
-          }
+      mapContainerClassName="widget-google-maps"
+      onCenterChanged={[Function]}
+      onLoad={[Function]}
+      options={
+        Object {
+          "draggable": true,
+          "fullscreenControl": false,
+          "mapTypeControl": false,
+          "maxZoom": 20,
+          "minZoom": 1,
+          "rotateControl": false,
+          "scrollwheel": true,
+          "streetViewControl": false,
+          "styles": Array [
+            Object {
+              "elementType": "labels",
+              "featureType": "poi",
+              "stylers": Array [
+                Object {
+                  "visibility": "off",
+                },
+              ],
+            },
+          ],
+          "zoomControl": true,
         }
-        mapContainerClassName="widget-google-maps"
-        onCenterChanged={[Function]}
-        onLoad={[Function]}
-        options={
-          Object {
-            "draggable": true,
-            "fullscreenControl": false,
-            "mapTypeControl": false,
-            "maxZoom": 20,
-            "minZoom": 1,
-            "rotateControl": false,
-            "scrollwheel": true,
-            "streetViewControl": false,
-            "styles": Array [
-              Object {
-                "elementType": "labels",
-                "featureType": "poi",
-                "stylers": Array [
-                  Object {
-                    "visibility": "off",
-                  },
-                ],
-              },
-            ],
-            "zoomControl": true,
-          }
-        }
-        zoom={10}
-      />
-    </LoadScript>
+      }
+      zoom={10}
+    />
   </div>
 </div>
 `;
@@ -246,54 +210,42 @@ exports[`Google maps renders a map with percentage of width and height units ren
   <div
     className="widget-google-maps-wrapper"
   >
-    <LoadScript
-      googleMapsApiKey=""
-      id="_com.mendix.widget.custom.Maps.Maps"
-      loadingElement={
-        <div
-          className="spinner"
-        />
+    <GoogleMap
+      center={
+        Object {
+          "lat": 51.906688,
+          "lng": 4.48837,
+        }
       }
-      onError={[Function]}
-      version="weekly"
-    >
-      <GoogleMap
-        center={
-          Object {
-            "lat": 51.906688,
-            "lng": 4.48837,
-          }
+      mapContainerClassName="widget-google-maps"
+      onCenterChanged={[Function]}
+      onLoad={[Function]}
+      options={
+        Object {
+          "draggable": true,
+          "fullscreenControl": false,
+          "mapTypeControl": false,
+          "maxZoom": 20,
+          "minZoom": 1,
+          "rotateControl": false,
+          "scrollwheel": true,
+          "streetViewControl": false,
+          "styles": Array [
+            Object {
+              "elementType": "labels",
+              "featureType": "poi",
+              "stylers": Array [
+                Object {
+                  "visibility": "off",
+                },
+              ],
+            },
+          ],
+          "zoomControl": true,
         }
-        mapContainerClassName="widget-google-maps"
-        onCenterChanged={[Function]}
-        onLoad={[Function]}
-        options={
-          Object {
-            "draggable": true,
-            "fullscreenControl": false,
-            "mapTypeControl": false,
-            "maxZoom": 20,
-            "minZoom": 1,
-            "rotateControl": false,
-            "scrollwheel": true,
-            "streetViewControl": false,
-            "styles": Array [
-              Object {
-                "elementType": "labels",
-                "featureType": "poi",
-                "stylers": Array [
-                  Object {
-                    "visibility": "off",
-                  },
-                ],
-              },
-            ],
-            "zoomControl": true,
-          }
-        }
-        zoom={10}
-      />
-    </LoadScript>
+      }
+      zoom={10}
+    />
   </div>
 </div>
 `;
@@ -311,54 +263,42 @@ exports[`Google maps renders a map with pixels renders structure correctly 1`] =
   <div
     className="widget-google-maps-wrapper"
   >
-    <LoadScript
-      googleMapsApiKey=""
-      id="_com.mendix.widget.custom.Maps.Maps"
-      loadingElement={
-        <div
-          className="spinner"
-        />
+    <GoogleMap
+      center={
+        Object {
+          "lat": 51.906688,
+          "lng": 4.48837,
+        }
       }
-      onError={[Function]}
-      version="weekly"
-    >
-      <GoogleMap
-        center={
-          Object {
-            "lat": 51.906688,
-            "lng": 4.48837,
-          }
+      mapContainerClassName="widget-google-maps"
+      onCenterChanged={[Function]}
+      onLoad={[Function]}
+      options={
+        Object {
+          "draggable": true,
+          "fullscreenControl": false,
+          "mapTypeControl": false,
+          "maxZoom": 20,
+          "minZoom": 1,
+          "rotateControl": false,
+          "scrollwheel": true,
+          "streetViewControl": false,
+          "styles": Array [
+            Object {
+              "elementType": "labels",
+              "featureType": "poi",
+              "stylers": Array [
+                Object {
+                  "visibility": "off",
+                },
+              ],
+            },
+          ],
+          "zoomControl": true,
         }
-        mapContainerClassName="widget-google-maps"
-        onCenterChanged={[Function]}
-        onLoad={[Function]}
-        options={
-          Object {
-            "draggable": true,
-            "fullscreenControl": false,
-            "mapTypeControl": false,
-            "maxZoom": 20,
-            "minZoom": 1,
-            "rotateControl": false,
-            "scrollwheel": true,
-            "streetViewControl": false,
-            "styles": Array [
-              Object {
-                "elementType": "labels",
-                "featureType": "poi",
-                "stylers": Array [
-                  Object {
-                    "visibility": "off",
-                  },
-                ],
-              },
-            ],
-            "zoomControl": true,
-          }
-        }
-        zoom={10}
-      />
-    </LoadScript>
+      }
+      zoom={10}
+    />
   </div>
 </div>
 `;
@@ -376,54 +316,42 @@ exports[`Google maps renders a map with right structure 1`] = `
   <div
     className="widget-google-maps-wrapper"
   >
-    <LoadScript
-      googleMapsApiKey=""
-      id="_com.mendix.widget.custom.Maps.Maps"
-      loadingElement={
-        <div
-          className="spinner"
-        />
+    <GoogleMap
+      center={
+        Object {
+          "lat": 51.906688,
+          "lng": 4.48837,
+        }
       }
-      onError={[Function]}
-      version="weekly"
-    >
-      <GoogleMap
-        center={
-          Object {
-            "lat": 51.906688,
-            "lng": 4.48837,
-          }
+      mapContainerClassName="widget-google-maps"
+      onCenterChanged={[Function]}
+      onLoad={[Function]}
+      options={
+        Object {
+          "draggable": true,
+          "fullscreenControl": false,
+          "mapTypeControl": false,
+          "maxZoom": 20,
+          "minZoom": 1,
+          "rotateControl": false,
+          "scrollwheel": true,
+          "streetViewControl": false,
+          "styles": Array [
+            Object {
+              "elementType": "labels",
+              "featureType": "poi",
+              "stylers": Array [
+                Object {
+                  "visibility": "off",
+                },
+              ],
+            },
+          ],
+          "zoomControl": true,
         }
-        mapContainerClassName="widget-google-maps"
-        onCenterChanged={[Function]}
-        onLoad={[Function]}
-        options={
-          Object {
-            "draggable": true,
-            "fullscreenControl": false,
-            "mapTypeControl": false,
-            "maxZoom": 20,
-            "minZoom": 1,
-            "rotateControl": false,
-            "scrollwheel": true,
-            "streetViewControl": false,
-            "styles": Array [
-              Object {
-                "elementType": "labels",
-                "featureType": "poi",
-                "stylers": Array [
-                  Object {
-                    "visibility": "off",
-                  },
-                ],
-              },
-            ],
-            "zoomControl": true,
-          }
-        }
-        zoom={10}
-      />
-    </LoadScript>
+      }
+      zoom={10}
+    />
   </div>
 </div>
 `;


### PR DESCRIPTION
## Issue

1. Put a map on the home page
2. Go to the home page, see that Google maps works
3. Click on the home icon to refresh the page
4. See that the map is broken
5. Console logs "google api is already presented"

Note:
- This only happened for me on the home page and when refreshing through the icon. If it's a subpage or a browser refresh is performed, everything went fine.

## What was going wrong

So the setup is as follows. We use a `LoadScript` component to load in the google api script. That components is part of the google map api library that we use and handles a lot of the logic for us. What it's supposed to do is set the google api up when loaded, clean it up on unmount, and render the actual map that we provide. After some pairing with @jordanch we found out that some of the lifecycle methods weren't quite handled properly. In the background the `LoadScript` component was just a class component which might be the reason it couldn't quite handle loading 2 versions **sequentially** properly. 

After some debugging we found out that the following happened
1. First map with LoadScript is loaded properly. 
2. Click on home icon
3. New map with LoadScript tries to load in, but crashes because the old LoadScript is still present
4. Old LoadScript is cleaned up

Step 4 is an async step based on the library's code, but for some reason step 3 is already happening before step 4. This causes the issue that we got reported.

## Fix

On top of `LoadScript` component, there's also a `useLoadScript` hook which seems like a more up to date utility to do the same. It uses hooks on the background and the logic seems a little more updated to conform to the new hooks lifecycles. Using this hook, the issue that we had was immediately resolved.

There was however one issue. The hook accepts a `onError` callback, but also uses an `invariant` that does not trigger this callback but just throws an error :expressionless: :expressionless: In particular it's the following code:
https://github.com/JustFly1984/react-google-maps-api/blob/7e807a6b9115766609c667bef783eb01f706f4c7/packages/react-google-maps-api/src/useLoadScript.tsx#L57-L67
```
  React.useEffect(
    function validateLoadedState() {
      if (isLoaded) {
        invariant(
          !!window.google,
          'useLoadScript was marked as loaded, but window.google is not present. Something went wrong.'
        )
      }
    },
    [isLoaded]
  )
```
But basically this code should be unreachable (hence the invariant usage) as it can only be triggered in two ways. After the hooks mounts, at some point either 1) the script is injected which means the google api is done and then `isLoaded` is set to true or 2) the google api is already present and then everything is fine anyways. 

So in theory this code should never be reached and we don't have to do more stuff on our side to potentially catch this error (because doing so is also not trivial after a day of research and trial and error).