### PR TITLE
Adding Rollup plugin for JSActions

### DIFF
--- a/configs/jsactions/rollup-plugin-bigjs-import-replacer.js
+++ b/configs/jsactions/rollup-plugin-bigjs-import-replacer.js
@@ -1,0 +1,11 @@
+export function bigJsImportReplacer() {
+    return {
+        name: "bigjs-import-replacer",
+        async generateBundle(options, bundle) {
+            const [filename] = Object.keys(bundle);
+            const fileInfo = bundle[filename];
+
+            fileInfo.code = fileInfo.code.replace("import { Big } from 'big.js';", `import { Big } from "big.js";`);
+        }
+    };
+}

--- a/configs/jsactions/rollup.config.js
+++ b/configs/jsactions/rollup.config.js
@@ -9,6 +9,7 @@ import { promisify } from "util";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import typescript from "@rollup/plugin-typescript";
 import { collectDependencies } from "../../packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies";
+import { bigJsImportReplacer } from "./rollup-plugin-bigjs-import-replacer";
 
 const cwd = process.cwd();
 
@@ -24,7 +25,7 @@ export default async args => {
         sourceMap: false,
         inlineSources: false,
         target: "es2019",
-        types: ["mendix-client", "big.js", "react-native"],
+        types: ["mendix-client", "react-native"],
         allowSyntheticDefaultImports: true
     });
 
@@ -48,6 +49,7 @@ export default async args => {
                 }),
                 nodeResolvePlugin,
                 typescriptPlugin,
+                bigJsImportReplacer(),
                 i === files.length - 1
                     ? command([
                           async () => {


### PR DESCRIPTION
Why?
Because by default rollup output import codes with single quotes. This is causing in SP the `import { Big } from "big.js";` to be duplicated in any JS Action using it.
This plugin just guarantees the output of `from "big.js";` is double quoted.

How to test?
Compile Nanoflow Commons or Native Mobile Resources jsactions and run SP to check if compilation will fail. Also check in SP if the JS action contains more than 1 import for big.js

JS Actions using it:
- Show progress
- Get current location
- Sign In
- Get device info

Fixes ticket: 119390