### PR TITLE
[WC-272] Fix custom widgets attribute value retrieval

### DIFF
--- a/packages/customWidgets/carousel-web/package.json
+++ b/packages/customWidgets/carousel-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carousel-web",
   "widgetName": "Carousel",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Displays images in a carousel",
   "copyright": "Mendix BV",
   "repository": {

--- a/packages/customWidgets/carousel-web/src/components/CarouselContainer.ts
+++ b/packages/customWidgets/carousel-web/src/components/CarouselContainer.ts
@@ -179,7 +179,7 @@ export default class CarouselContainer extends Component<CarouselContainerProps,
         }
     }
 
-    private extractAttributeValue = <WidgetPropertyTypes>(
+    private extractAttributeValue = async <WidgetPropertyTypes>(
         mxObject: mendix.lib.MxObject,
         attributePath: string
     ): Promise<WidgetPropertyTypes | "" | null | undefined> => {

--- a/packages/customWidgets/carousel-web/src/package.xml
+++ b/packages/customWidgets/carousel-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Carousel" version="1.4.3" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Carousel" version="1.4.4" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Carousel.xml"/>
         </widgetFiles>

--- a/packages/customWidgets/color-picker-web/package.json
+++ b/packages/customWidgets/color-picker-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "color-picker-web",
   "widgetName": "ColorPicker",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Change a color using a color input",
   "copyright": "Mendix BV",
   "repository": {

--- a/packages/customWidgets/color-picker-web/src/package.xml
+++ b/packages/customWidgets/color-picker-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="ColorPicker" version="1.1.4" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="ColorPicker" version="1.1.5" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="ColorPicker.xml"/>
         </widgetFiles>

--- a/packages/customWidgets/range-slider-web/package.json
+++ b/packages/customWidgets/range-slider-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "range-slider-web",
   "widgetName": "RangeSlider",
-  "version": "1.3.3",
+  "version": "1.3.2",
   "description": "Change a range of values on a slider",
   "copyright": "Mendix BV",
   "repository": {

--- a/packages/customWidgets/range-slider-web/src/package.xml
+++ b/packages/customWidgets/range-slider-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="RangeSlider" version="1.3.3" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="RangeSlider" version="1.3.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="RangeSlider.xml"/>
         </widgetFiles>


### PR DESCRIPTION
## Why?
Many custom widgets use the `get` API endpoint to retrieve the value of an attribute from an mx object. This call doesn't work when an attribute over association is selected in the widget configuration.

## What?
TODO

## How to test?
TODO