### PR TITLE
feat(maps-web): new major release version

### DIFF
--- a/packages/pluggableWidgets/maps-web/src/package.xml
+++ b/packages/pluggableWidgets/maps-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Maps" version="1.0.9" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Maps" version="2.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Maps.xml"/>
         </widgetFiles>


### PR DESCRIPTION
The `package.json` was already 2.0.0 since a long time (a year), but this was still outdated. With the new changes, everything is umbrella'd under 2.0.0