### PR TITLE
[WC-26] Implement popup menu web structure preview

### DIFF
--- a/packages/pluggableWidgets/popup-menu-web/package.json
+++ b/packages/pluggableWidgets/popup-menu-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "popup-menu-web",
   "widgetName": "PopupMenu",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "copyright": "Mendix Technology B.V.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.editorConfig.ts
+++ b/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.editorConfig.ts
@@ -109,10 +109,10 @@ export function getPreview(values: PopupMenuPreviewProps): StructurePreviewProps
 
     return {
         type: "Container",
-        padding: 8,
         children: [
             {
                 type: "Container",
+                backgroundColor: values.menuTrigger.widgetCount === 0 ? "#F5F5F5" : undefined,
                 children: [
                     {
                         type: "DropZone",
@@ -120,6 +120,11 @@ export function getPreview(values: PopupMenuPreviewProps): StructurePreviewProps
                         placeholder: "Place menu trigger widget here"
                     } as DropZoneProps
                 ]
+            } as ContainerProps,
+            {
+                type: "Container",
+                padding: 1,
+                children: []
             } as ContainerProps,
             {
                 type: "RowLayout",

--- a/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.editorConfig.ts
+++ b/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.editorConfig.ts
@@ -110,7 +110,6 @@ export function getPreview(values: PopupMenuPreviewProps): StructurePreviewProps
     return {
         type: "Container",
         padding: 8,
-        // columnSize: "grow",
         children: [
             {
                 type: "Container",
@@ -134,13 +133,14 @@ export function getPreview(values: PopupMenuPreviewProps): StructurePreviewProps
                         children: [...buildMenuItems(values)]
                     } as ContainerProps,
                     {
+                        // To create some space on the right so the menu items don't take full width.
                         type: "Container",
                         children: []
                     } as ContainerProps
                 ]
             } as RowLayoutProps
         ]
-    } as ContainerProps | RowLayoutProps;
+    } as ContainerProps;
 
     function buildMenuItems(values: PopupMenuPreviewProps): StructurePreviewProps[] {
         return values.basicItems.map(

--- a/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.editorConfig.ts
+++ b/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.editorConfig.ts
@@ -1,4 +1,15 @@
-import { changePropertyIn, hidePropertyIn, Problem, Properties } from "@mendix/piw-utils-internal";
+import {
+    changePropertyIn,
+    ContainerProps,
+    DropZoneProps,
+    hidePropertyIn,
+    Problem,
+    Properties,
+    RowLayoutProps,
+    SelectableProps,
+    StructurePreviewProps,
+    TextProps
+} from "@mendix/piw-utils-internal";
 import { BasicItemsPreviewType, PopupMenuPreviewProps } from "../typings/PopupMenuProps";
 
 export function getProperties(
@@ -89,4 +100,72 @@ export function check(values: PopupMenuPreviewProps): Problem[] {
         }
     }
     return errors;
+}
+
+export function getPreview(values: PopupMenuPreviewProps): StructurePreviewProps | null {
+    if (values.advancedMode) {
+        return null;
+    }
+
+    return {
+        type: "Container",
+        padding: 8,
+        // columnSize: "grow",
+        children: [
+            {
+                type: "Container",
+                children: [
+                    {
+                        type: "DropZone",
+                        property: values.menuTrigger,
+                        placeholder: "Place menu trigger widget here"
+                    } as DropZoneProps
+                ]
+            } as ContainerProps,
+            {
+                type: "RowLayout",
+                columnSize: "grow",
+                children: [
+                    {
+                        type: "Container",
+                        borders: true,
+                        borderRadius: 8,
+                        grow: 0,
+                        children: [...buildMenuItems(values)]
+                    } as ContainerProps,
+                    {
+                        type: "Container",
+                        children: []
+                    } as ContainerProps
+                ]
+            } as RowLayoutProps
+        ]
+    } as ContainerProps | RowLayoutProps;
+
+    function buildMenuItems(values: PopupMenuPreviewProps): StructurePreviewProps[] {
+        return values.basicItems.map(
+            item =>
+                ({
+                    type: "Container",
+                    backgroundColor: item.itemType === "divider" ? "#ced0d3" : "#fff",
+                    children: [
+                        {
+                            type: "Selectable",
+                            object: item,
+                            child: {
+                                type: "Container",
+                                padding: item.itemType === "divider" ? 1 : 12,
+                                children: [
+                                    {
+                                        type: "Text",
+                                        fontColor: "#555555",
+                                        content: item.caption
+                                    } as TextProps
+                                ]
+                            } as ContainerProps
+                        } as SelectableProps
+                    ]
+                } as ContainerProps)
+        );
+    }
 }

--- a/packages/pluggableWidgets/popup-menu-web/src/package.xml
+++ b/packages/pluggableWidgets/popup-menu-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="PopupMenu" version="1.0.2" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="PopupMenu" version="2.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="PopupMenu.xml"/>
         </widgetFiles>

--- a/packages/pluggableWidgets/popup-menu-web/typings/PopupMenuProps.d.ts
+++ b/packages/pluggableWidgets/popup-menu-web/typings/PopupMenuProps.d.ts
@@ -34,7 +34,7 @@ export interface BasicItemsPreviewType {
 }
 
 export interface CustomItemsPreviewType {
-    content: { widgetCount: number; renderer: ComponentType };
+    content: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     action: {} | null;
 }
 
@@ -42,7 +42,7 @@ export interface PopupMenuContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
-    tabIndex: number;
+    tabIndex?: number;
     menuTrigger?: ReactNode;
     basicItems: BasicItemsType[];
     customItems: CustomItemsType[];
@@ -55,7 +55,7 @@ export interface PopupMenuContainerProps {
 export interface PopupMenuPreviewProps {
     class: string;
     style: string;
-    menuTrigger: { widgetCount: number; renderer: ComponentType };
+    menuTrigger: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     basicItems: BasicItemsPreviewType[];
     customItems: CustomItemsPreviewType[];
     trigger: TriggerEnum;


### PR DESCRIPTION
This adds structure preview for popup menu. Designs and scope was verified with Chris already.  There is something weird going on with the gray top border for the dropzone that I can't get rid of. Already reported this to @takumagott and they will look into it when they can. But for the scope of contents team it's not a blocker.

## Filled menu with trigger
![image](https://user-images.githubusercontent.com/5955441/113992095-663e5280-9853-11eb-9aeb-1e7f40be5b45.png)

## Filled menu without trigger
![image](https://user-images.githubusercontent.com/5955441/113992128-6e968d80-9853-11eb-8304-8cde071d52b6.png)

## With dividers
![image](https://user-images.githubusercontent.com/5955441/113992164-75250500-9853-11eb-88cb-bb07cda86180.png)

## Nothing (error expected)
![image](https://user-images.githubusercontent.com/5955441/113992251-8cfc8900-9853-11eb-83b2-1da1b997ebd3.png)
