### PR TITLE
[WC-274] fall back to default structure preview when user opts for custom visualization

### DIFF
--- a/packages/pluggableWidgets/timeline-web/src/Timeline.editorConfig.ts
+++ b/packages/pluggableWidgets/timeline-web/src/Timeline.editorConfig.ts
@@ -75,7 +75,11 @@ export function check(values: TimelinePreviewProps): Problem[] {
     return errors;
 }
 
-export function getPreview(values: TimelinePreviewProps): StructurePreviewProps {
+export function getPreview(values: TimelinePreviewProps): StructurePreviewProps | null {
+    if (values.customVisualization) {
+        return null;
+    }
+
     return {
         type: "Container",
         children: [

--- a/packages/pluggableWidgets/timeline-web/typings/TimelineProps.d.ts
+++ b/packages/pluggableWidgets/timeline-web/typings/TimelineProps.d.ts
@@ -54,10 +54,10 @@ export interface TimelinePreviewProps {
     groupByDayOptions: GroupByDayOptionsEnum;
     groupByMonthOptions: GroupByMonthOptionsEnum;
     ungroupedEventsPosition: UngroupedEventsPositionEnum;
-    customIcon: { widgetCount: number; renderer: ComponentType };
-    customGroupHeader: { widgetCount: number; renderer: ComponentType };
-    customTitle: { widgetCount: number; renderer: ComponentType };
-    customEventDateTime: { widgetCount: number; renderer: ComponentType };
-    customDescription: { widgetCount: number; renderer: ComponentType };
+    customIcon: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
+    customGroupHeader: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
+    customTitle: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
+    customEventDateTime: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
+    customDescription: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     onClick: {} | null;
 }


### PR DESCRIPTION
This addresses the dropzone issues in custom mode in structure preview by just disabling it.

![image](https://user-images.githubusercontent.com/5955441/114008763-d86a6380-9862-11eb-9d4a-af8f4900a504.png)

Version is already 2.0.0