### PR TITLE
[WC-272] Fix custom widgets attribute over association support

### DIFF
--- a/packages/customWidgets/calendar-web/src/Calendar.xml
+++ b/packages/customWidgets/calendar-web/src/Calendar.xml
@@ -83,7 +83,7 @@
             <category>Data source</category>
             <description>For data source microflow, enable to retrieve a sub set of large data set based on view start and end attribute</description>
         </property>
-        <property key="viewStartAttribute" type="attribute" isPath="optional" pathType="reference" required="false" allowNonPersistableEntities="true">
+        <property key="viewStartAttribute" type="attribute" required="false" allowNonPersistableEntities="true">
             <caption>View start attribute</caption>
             <category>Data source</category>
             <description>The date on which the calendar view starts, will be updated with `Refresh data source` before the view changes</description>
@@ -91,7 +91,7 @@
                 <attributeType name="DateTime"/>
             </attributeTypes>
         </property>
-        <property key="viewEndAttribute" type="attribute" isPath="optional" pathType="reference" required="false" allowNonPersistableEntities="true">
+        <property key="viewEndAttribute" type="attribute" required="false" allowNonPersistableEntities="true">
             <caption>View end attribute</caption>
             <category>Data source</category>
             <description>The date on which the calendar view ends, will be updated with `Refresh data source` before the view changes</description>

--- a/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
+++ b/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
@@ -116,8 +116,19 @@ export default class CalendarContainer extends Component<Container.CalendarConta
             return Promise.resolve(undefined);
         }
 
-        return new Promise(resolve => {
-            mxObject.fetch(attributePath, (attributeValue: any): void => resolve(attributeValue));
+        return new Promise((resolve, reject) => {
+            mxObject.fetch(
+                attributePath,
+                (attributeValue: any): void => {
+                    if (attributeValue instanceof Error) {
+                        reject(attributeValue);
+                    } else {
+                        resolve(attributeValue);
+                    }
+                },
+                // @ts-ignore
+                (error: Error): void => reject(error)
+            );
         });
     };
 
@@ -129,8 +140,8 @@ export default class CalendarContainer extends Component<Container.CalendarConta
                     mxObject,
                     this.props.startDateAttribute
                 );
-            } catch (e) {
-                window.mx.ui.error("Unable to fetch start date attribute value");
+            } catch (error) {
+                window.mx.ui.error(`Unable to fetch start date attribute value: ${error.message}`);
             }
             return startDateAttributeValue ? new Date(startDateAttributeValue) : new Date();
         }

--- a/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
+++ b/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
@@ -8,10 +8,14 @@ import moment from "moment";
 import { validateCustomFormats, validateProps } from "../utils/validation";
 import { parseStyle } from "../utils/style";
 
+type MxObject = Omit<mendix.lib.MxObject, "fetch"> & {
+    fetch: (path: string, callback: (requested: any) => void, error: (error: Error) => void) => void;
+};
+
 export interface CalendarContainerState {
     alertMessage: ReactChild;
     events: CalendarEvent[];
-    eventCache: mendix.lib.MxObject[];
+    eventCache: MxObject[];
     eventColor: string;
     loading: boolean;
     startPosition: Date;
@@ -109,7 +113,7 @@ export default class CalendarContainer extends Component<Container.CalendarConta
     }
 
     private extractAttributeValue = async <WidgetPropertyTypes>(
-        mxObject: mendix.lib.MxObject,
+        mxObject: MxObject,
         attributePath: string
     ): Promise<WidgetPropertyTypes | "" | null | undefined> => {
         if (!attributePath) {
@@ -126,13 +130,12 @@ export default class CalendarContainer extends Component<Container.CalendarConta
                         resolve(attributeValue);
                     }
                 },
-                // @ts-ignore
                 (error: Error): void => reject(error)
             );
         });
     };
 
-    private getStartPosition = async (mxObject: mendix.lib.MxObject): Promise<Date> => {
+    private getStartPosition = async (mxObject: MxObject): Promise<Date> => {
         if (mxObject) {
             let startDateAttributeValue;
             try {
@@ -149,7 +152,7 @@ export default class CalendarContainer extends Component<Container.CalendarConta
         return new Date();
     };
 
-    private loadEvents = async (mxObject: mendix.lib.MxObject): Promise<void> => {
+    private loadEvents = async (mxObject: MxObject): Promise<void> => {
         this.subscriptionEventHandles.forEach(window.mx.data.unsubscribe);
         this.subscriptionEventHandles = [];
         if (!mxObject) {
@@ -195,7 +198,7 @@ export default class CalendarContainer extends Component<Container.CalendarConta
         }
     };
 
-    private async setViewDates(mxObject: mendix.lib.MxObject): Promise<void> {
+    private async setViewDates(mxObject: MxObject): Promise<void> {
         const startPosition = await this.getStartPosition(mxObject);
         if (
             this.props.executeOnViewChange &&
@@ -230,7 +233,7 @@ export default class CalendarContainer extends Component<Container.CalendarConta
         this.setState({ startPosition });
     }
 
-    private setCalendarEvents = (mxObjects: mendix.lib.MxObject[]): void => {
+    private setCalendarEvents = (mxObjects: MxObject[]): void => {
         if (mxObjects) {
             const events = mxObjects.map(mxObject => ({
                 title: (mxObject.get(this.props.titleAttribute) as string) || " ",
@@ -244,7 +247,7 @@ export default class CalendarContainer extends Component<Container.CalendarConta
         }
     };
 
-    private subscribeToEventAttributes(mxEventObject: mendix.lib.MxObject): number[] {
+    private subscribeToEventAttributes(mxEventObject: MxObject): number[] {
         return [
             this.props.allDayAttribute,
             this.props.titleAttribute,
@@ -260,7 +263,7 @@ export default class CalendarContainer extends Component<Container.CalendarConta
         );
     }
 
-    private resetSubscriptions = (mxObject: mendix.lib.MxObject): void => {
+    private resetSubscriptions = (mxObject: MxObject): void => {
         this.subscriptionContextHandles.forEach(window.mx.data.unsubscribe);
         this.subscriptionContextHandles = [];
 
@@ -435,7 +438,7 @@ export default class CalendarContainer extends Component<Container.CalendarConta
         });
     };
 
-    private executeEventAction = (mxObject: mendix.lib.MxObject) => {
+    private executeEventAction = (mxObject: MxObject) => {
         const { onClickEvent, onClickMicroflow, mxform, onClickNanoflow } = this.props;
         if (mxObject) {
             this.executeAction(mxObject, onClickEvent, onClickMicroflow, mxform, onClickNanoflow);
@@ -470,7 +473,7 @@ export default class CalendarContainer extends Component<Container.CalendarConta
         });
     };
 
-    private executeSlotAction(mxObject: mendix.lib.MxObject): void {
+    private executeSlotAction(mxObject: MxObject): void {
         const { onCreate, onCreateMicroflow, mxform, onCreateNanoflow } = this.props;
         this.executeAction(mxObject, onCreate, onCreateMicroflow, mxform, onCreateNanoflow);
     }
@@ -501,7 +504,7 @@ export default class CalendarContainer extends Component<Container.CalendarConta
         }
     };
 
-    private executeOnDropAction = (mxObject: mendix.lib.MxObject) => {
+    private executeOnDropAction = (mxObject: MxObject) => {
         const { onChangeEvent, onChangeMicroflow, mxform, onChangeNanoflow } = this.props;
         if (mxObject && mxObject.getGuid()) {
             this.executeAction(mxObject, onChangeEvent, onChangeMicroflow, mxform, onChangeNanoflow);
@@ -509,7 +512,7 @@ export default class CalendarContainer extends Component<Container.CalendarConta
     };
 
     private executeAction(
-        mxObject: mendix.lib.MxObject,
+        mxObject: MxObject,
         action: Container.OnClickEventOptions,
         microflow: string,
         mxform: mxui.lib.form._FormBase,

--- a/packages/customWidgets/calendar-web/src/utils/data.ts
+++ b/packages/customWidgets/calendar-web/src/utils/data.ts
@@ -14,15 +14,15 @@ export const fetchData = (options: Data.FetchDataOptions): Promise<MxObject[]> =
                     constraint: options.constraint || ""
                 })
                     .then(resolve)
-                    .catch(message => reject({ message }));
+                    .catch(message => reject(message));
             } else if (options.type === "microflow" && options.microflow) {
                 fetchByMicroflow(options.microflow, guid)
                     .then(resolve)
-                    .catch(message => reject({ message }));
+                    .catch(message => reject(message));
             } else if (options.type === "nanoflow" && options.nanoflow.nanoflow && options.mxform) {
                 fetchByNanoflow(options.nanoflow, options.mxform)
                     .then(resolve)
-                    .catch(message => reject({ message }));
+                    .catch(message => reject(message));
             }
         } else {
             reject("entity & guid are required");

--- a/packages/customWidgets/calendar-web/src/utils/validation.ts
+++ b/packages/customWidgets/calendar-web/src/utils/validation.ts
@@ -33,12 +33,20 @@ export function validateProps(props: Container.CalendarContainerProps): ReactChi
     if (props.view === "standard" && (props.defaultView === "work_week" || props.defaultView === "agenda")) {
         errorMessages.push(`${props.friendlyId}: ${props.defaultView} is only available in custom view`);
     }
+    if (props.startDateAttribute.split("/").length > 3) {
+        errorMessages.push(`Start date attribute can only go over one association`);
+    }
+
     if (errorMessages.length) {
         return createElement(
             "div",
             {},
-            "Error in calendar configuration:",
-            errorMessages.map((message, key) => createElement("p", { key }, message))
+            createElement("p", {}, "Error in calendar configuration:"),
+            createElement(
+                "ul",
+                {},
+                errorMessages.map((message, key) => createElement("li", { key }, message))
+            )
         );
     }
 

--- a/packages/customWidgets/calendar-web/tests/e2e/specs/renderDifferentViews.spec.ts
+++ b/packages/customWidgets/calendar-web/tests/e2e/specs/renderDifferentViews.spec.ts
@@ -30,4 +30,11 @@ describe("Calendar", () => {
         calendar.element.waitForExist();
         expect(calendar.label.getText()).toBe("Tuesday 02/02/2021");
     });
+    it("renders correct start date after switching the object", () => {
+        page.open("p/startPosition");
+        page.getWidget("switchObjectButton").click();
+        const calendar = new Calendar("calendar2");
+        calendar.element.waitForExist();
+        expect(calendar.label.getText()).toBe("Saturday 01/05/2021");
+    });
 });

--- a/packages/customWidgets/image-viewer-web/package.json
+++ b/packages/customWidgets/image-viewer-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "image-viewer-web",
   "widgetName": "ImageViewer",
-  "version": "1.3.3",
+  "version": "1.3.2",
   "description": "Display an image and enlarge it on click",
   "copyright": "Mendix BV",
   "repository": {

--- a/packages/customWidgets/image-viewer-web/src/ImageViewer.webmodeler.ts
+++ b/packages/customWidgets/image-viewer-web/src/ImageViewer.webmodeler.ts
@@ -20,7 +20,7 @@ export class preview extends Component<ImageViewerContainerProps, {}> {
             return createElement(
                 "div",
                 {},
-                createElement(Alert, { className: "widget-image-viewer-alert-danger", message }),
+                createElement(Alert, { className: "widget-image-viewer-alert-danger" }, message),
                 createElement(ImageViewer, this.transformProps(this.props))
             );
         }

--- a/packages/customWidgets/image-viewer-web/src/components/Alert.ts
+++ b/packages/customWidgets/image-viewer-web/src/components/Alert.ts
@@ -10,11 +10,11 @@ export interface AlertProps {
 }
 
 export const Alert: FunctionComponent<AlertProps> = props =>
-    props.message
+    props.children
         ? createElement(
               "div",
               { className: classNames(`alert alert-${props.bootstrapStyle}`, props.className) },
-              props.message
+              props.children
           )
         : null;
 

--- a/packages/customWidgets/image-viewer-web/src/components/ImageViewerContainer.ts
+++ b/packages/customWidgets/image-viewer-web/src/components/ImageViewerContainer.ts
@@ -1,4 +1,4 @@
-import { Component, createElement, ReactNode } from "react";
+import { Component, createElement, ReactChild, ReactNode } from "react";
 
 import { Alert } from "./Alert";
 import { ImageViewer } from "./ImageViewer";
@@ -30,7 +30,7 @@ interface ImageViewerContainerProps extends WrapperProps {
 }
 
 interface ImageViewerContainerState {
-    alertMessage?: string;
+    alertMessage?: ReactChild;
     imageUrl: string;
 }
 
@@ -67,7 +67,7 @@ class ImageViewerContainer extends Component<ImageViewerContainerProps, ImageVie
         const { height, heightUnit, width, widthUnit, onClickOption, responsive } = this.props;
         const { imageUrl } = this.state;
         if (this.state.alertMessage) {
-            return createElement(Alert, { message: this.state.alertMessage });
+            return createElement(Alert, {}, this.state.alertMessage);
         }
 
         return createElement(ImageViewer, {
@@ -227,31 +227,50 @@ class ImageViewerContainer extends Component<ImageViewerContainerProps, ImageVie
         return {};
     }
 
-    static validateProps(props: ImageViewerContainerProps): string {
-        let message = "";
+    static validateProps(props: ImageViewerContainerProps): ReactChild {
+        const errorMessages: string[] = [];
+
         if (props.source === "systemImage" && props.mxObject && !props.mxObject.isA("System.Image")) {
-            message = "for data source option 'System image' the context object should inherit system.image";
+            errorMessages.push("for data source option 'System image' the context object should inherit system.image");
         }
         if (props.source === "urlAttribute" && !props.dynamicUrlAttribute) {
-            message = "for data source option 'Dynamic URL' the Dynamic image URL attribute should be configured";
+            errorMessages.push(
+                "for data source option 'Dynamic URL' the Dynamic image URL attribute should be configured"
+            );
         }
         if (props.source === "staticUrl" && !props.urlStatic) {
-            message = "for data source option 'Static URL' a static image url should be configured";
+            errorMessages.push("for data source option 'Static URL' a static image url should be configured");
         }
         if (props.source === "staticImage" && !props.imageStatic) {
-            message = "for data source option 'Static Image' a static image should be configured";
+            errorMessages.push("for data source option 'Static Image' a static image should be configured");
         }
         if (props.onClickOption === "callMicroflow" && !props.onClickMicroflow) {
-            message = "on click microflow is required";
+            errorMessages.push("on click microflow is required");
         }
         if (props.onClickOption === "callNanoflow" && !props.onClickNanoflow.nanoflow) {
-            message = "on click nanoflow is required";
+            errorMessages.push("on click nanoflow is required");
         }
         if (props.onClickOption === "showPage" && !props.onClickForm) {
-            message = "on click page is required";
+            errorMessages.push("on click page is required");
+        }
+        if (props.dynamicUrlAttribute.split("/").length > 3) {
+            errorMessages.push(`start date attribute can only go over one association`);
         }
 
-        return message && `Error in imageviewer configuration: ${message}`;
+        if (errorMessages.length) {
+            return createElement(
+                "div",
+                {},
+                createElement("p", {}, "Error in image viewer configuration:"),
+                createElement(
+                    "ul",
+                    {},
+                    errorMessages.map((message, key) => createElement("li", { key }, message))
+                )
+            );
+        }
+
+        return "";
     }
 }
 

--- a/packages/customWidgets/image-viewer-web/src/components/ImageViewerContainer.ts
+++ b/packages/customWidgets/image-viewer-web/src/components/ImageViewerContainer.ts
@@ -114,6 +114,7 @@ class ImageViewerContainer extends Component<ImageViewerContainerProps, ImageVie
                     })
                 );
             }
+
             this.subscriptionHandles.push(
                 window.mx.data.subscribe({
                     guid: mxObject.getGuid(),
@@ -128,13 +129,6 @@ class ImageViewerContainer extends Component<ImageViewerContainerProps, ImageVie
                 })
             );
 
-            this.subscriptionHandles.push(
-                window.mx.data.subscribe({
-                    attr: this.props.dynamicUrlAttribute,
-                    callback: this.attributeCallback(mxObject),
-                    guid: mxObject.getGuid()
-                })
-            );
             this.subscriptionHandles.push(
                 window.mx.data.subscribe({
                     callback: this.attributeCallback(mxObject),

--- a/packages/customWidgets/image-viewer-web/src/components/ImageViewerContainer.ts
+++ b/packages/customWidgets/image-viewer-web/src/components/ImageViewerContainer.ts
@@ -101,6 +101,33 @@ class ImageViewerContainer extends Component<ImageViewerContainerProps, ImageVie
         this.subscriptionHandles = [];
 
         if (mxObject) {
+            const attributePathValues = this.props.dynamicUrlAttribute.split("/");
+
+            if (attributePathValues.length > 2) {
+                const [referenceAttribute, , attr] = attributePathValues;
+
+                this.subscriptionHandles.push(
+                    window.mx.data.subscribe({
+                        guid: mxObject.get(referenceAttribute) as string,
+                        attr,
+                        callback: this.attributeCallback(mxObject)
+                    })
+                );
+            }
+            this.subscriptionHandles.push(
+                window.mx.data.subscribe({
+                    guid: mxObject.getGuid(),
+                    attr: attributePathValues[0],
+                    callback: () => {
+                        this.attributeCallback(mxObject)();
+
+                        if (attributePathValues.length > 2) {
+                            this.resetSubscriptions(mxObject);
+                        }
+                    }
+                })
+            );
+
             this.subscriptionHandles.push(
                 window.mx.data.subscribe({
                     attr: this.props.dynamicUrlAttribute,

--- a/packages/customWidgets/image-viewer-web/src/components/__tests__/Alert.spec.ts
+++ b/packages/customWidgets/image-viewer-web/src/components/__tests__/Alert.spec.ts
@@ -6,7 +6,7 @@ import { Alert } from "../Alert";
 describe("Alert", () => {
     it("renders the structure correctly", () => {
         const message = "This is an error";
-        const alert = shallow(createElement(Alert, { bootstrapStyle: "danger", message }));
+        const alert = shallow(createElement(Alert, { bootstrapStyle: "danger" }, message));
 
         expect(alert.getElement()).toEqual(createElement("div", { className: "alert alert-danger" }, message));
     });
@@ -20,7 +20,7 @@ describe("Alert", () => {
     it("contains additional class name", () => {
         const message = "This is an error";
         const className = "widget-imageviewer";
-        const alert = shallow(createElement(Alert, { bootstrapStyle: "danger", message, className }));
+        const alert = shallow(createElement(Alert, { bootstrapStyle: "danger", className }, message));
 
         expect(alert.getElement()).toEqual(
             createElement("div", { className: "alert alert-danger widget-imageviewer" }, message)
@@ -30,35 +30,35 @@ describe("Alert", () => {
     describe("with bootstrap style", () => {
         it("success", () => {
             const message = "This is an alert";
-            const alert = shallow(createElement(Alert, { bootstrapStyle: "success", message }));
+            const alert = shallow(createElement(Alert, { bootstrapStyle: "success" }, message));
 
             expect(alert.getElement()).toEqual(createElement("div", { className: "alert alert-success" }, message));
         });
 
         it("alert", () => {
             const message = "This is an alert";
-            const alert = shallow(createElement(Alert, { bootstrapStyle: "danger", message }));
+            const alert = shallow(createElement(Alert, { bootstrapStyle: "danger" }, message));
 
             expect(alert.getElement()).toEqual(createElement("div", { className: "alert alert-danger" }, message));
         });
 
         it("info", () => {
             const message = "This is an alert";
-            const alert = shallow(createElement(Alert, { bootstrapStyle: "info", message }));
+            const alert = shallow(createElement(Alert, { bootstrapStyle: "info" }, message));
 
             expect(alert.getElement()).toEqual(createElement("div", { className: "alert alert-info" }, message));
         });
 
         it("warning", () => {
             const message = "This is an alert";
-            const alert = shallow(createElement(Alert, { bootstrapStyle: "warning", message }));
+            const alert = shallow(createElement(Alert, { bootstrapStyle: "warning" }, message));
 
             expect(alert.getElement()).toEqual(createElement("div", { className: "alert alert-warning" }, message));
         });
 
         it("inverse", () => {
             const message = "This is an alert";
-            const alert = shallow(createElement(Alert, { bootstrapStyle: "inverse", message }));
+            const alert = shallow(createElement(Alert, { bootstrapStyle: "inverse" }, message));
 
             expect(alert.getElement()).toEqual(createElement("div", { className: "alert alert-inverse" }, message));
         });

--- a/packages/customWidgets/image-viewer-web/src/package.xml
+++ b/packages/customWidgets/image-viewer-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="ImageViewer" version="1.3.3" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="ImageViewer" version="1.3.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="ImageViewer.xml"/>
         </widgetFiles>


### PR DESCRIPTION
## Why?

The custom widgets calendar-web & image-viewer-web have attributes that support selecting an attribute over association, but didn't properly subscribe to data changes.

## What?

calendar-web:
- Remove ability to configure attribute over association attributes for `viewStartAttribute` and `viewEndAttribute`, because this was never implemented.
- Subscribe properly to configured `startDateAttribute` 1-deep association attribute value changes including context object reference changes.
- Improve fetch code for `startDateAttribute`.
- Show an error message when the attribute over association for `startDateAttribute` is more than one level deep.

image-viewer-web:
- Subscribe properly to configured `dynamicUrlAttribute`  1-deep association attribute value changes including context object reference changes.
- Show an error message when the attribute over association for `dynamicUrlAttribute` is more than one level deep.
- Show all error messages at once.

## How to test?
- Test the three attributes described above.
- Verify that value changes of these attributes are picked up by the widget when configured with an attribute belonging directly to the context object.
- Verify that value changes of these attributes are picked up by the widget when configured with an attribute belonging to a directly to the context object connected (1 deep association attribute) object.
- Verify that value changes due to a reference change (context object is connected with a new object that contains the attribute value) of these attributes are picked up by the widget when configured with an attribute belonging to a directly to the context object connected (1 deep association attribute) object.
- Verify that errors are thrown when the attributes over association are more than one level deep.