### PR TITLE
CHANGELOG template & Switch-web CHANGELOG

### DIFF
--- a/CHANGELOG-template.md
+++ b/CHANGELOG-template.md
@@ -1,0 +1,31 @@
+# Changelog
+All notable changes to this widget will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### <heading>
+
+## [major.minor.patch] - YYYY-MM-DD
+### <heading>
+- description
+
+### <heading>
+- description
+
+------------------- delete me and below -------------------
+
+`<heading>` should be one of:
+
+- `Added` for new features.
+- `Changed` for changes in existing functionality.
+- `Deprecated` for soon-to-be removed features.
+- `Removed` for now removed features.
+- `Fixed` for any bug fixes.
+- `Security` in case of vulnerabilities.
+
+Add [YANKED] after the release date if the release was unpublished.
+
+Remove "-template" from file name.
+
+------------------- delete me and above -------------------

--- a/packages/pluggableWidgets/switch-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/switch-web/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+All notable changes to this widget will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Add `Brand Secondary` `Style` design-property option.
+- Add `aria-readonly` for improved accessibility.
+
+### Changed
+- Use `div` instead of `small` for improved semantics.
+- Convert `Style` and `Device style` properties to design-properties.
+- Label property converted to system property and moved to common tab.
+- Editability property converted to system property and moved to common tab.
+
+### Removed
+- Removed `input` element.
+- Removed `info` and `inverse` `Style` property options.
+- Removed label width property.
+
+## 3.0.0 DD-MM-YYY
+
+## Older releases
+See [marketplace](https://marketplace.mendix.com/link/component/50324) for previous releases.


### PR DESCRIPTION
## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [x] Other - introduce a CHANGELOG template. 

## What is the purpose of this PR?
- Add a CHANGELOG for switch-web. 
- Introduce a CHANGELOG-template. Use this as a base for widget changelogs.

## What should be covered while testing?
n/a
