### PR TITLE
test(progress-bar-web): increase timeout and decrease maxInstances

### DIFF
--- a/packages/pluggableWidgets/badge-button-web/tests/e2e/specs/differentViews.spec.ts
+++ b/packages/pluggableWidgets/badge-button-web/tests/e2e/specs/differentViews.spec.ts
@@ -58,8 +58,10 @@ describe("BadgeButton different views", () => {
         it("displays multiple widgets", () => {
             const badgeButton = new badgeButtonWidget("badgeButtonTemplateGrid");
 
+            badgeButton.element.waitForDisplayed();
+
             expect(badgeButton.getAllBadges().length).toBeGreaterThan(1);
-            expect(templateGrid.rowCount).toEqual(3);
+            expect(templateGrid.rowCount).toEqual(2);
         });
     });
 

--- a/packages/pluggableWidgets/progress-bar-web/tests/e2e/specs/onClick.spec.ts
+++ b/packages/pluggableWidgets/progress-bar-web/tests/e2e/specs/onClick.spec.ts
@@ -49,11 +49,11 @@ describe("Progress Bar on click", () => {
     it("should Open Blocking Popup Page", () => {
         const progressBar = new ProgressBar("onClickOpenBlockingPopupPage");
         const value = progressBar.value;
-        progressBar.element.waitForDisplayed();
+        progressBar.element.waitForDisplayed({ timeout: 3000 });
         progressBar.clickableArea.click();
 
         const progressBarOpened = new ProgressBar("onClickOpened");
-        progressBarOpened.element.waitForDisplayed();
+        progressBarOpened.element.waitForDisplayed({ timeout: 3000 });
         expect(value).toContain(progressBarOpened.value);
     });
 });

--- a/packages/tools/pluggable-widgets-tools/test-config/wdio.conf.js
+++ b/packages/tools/pluggable-widgets-tools/test-config/wdio.conf.js
@@ -22,7 +22,7 @@ exports.config = {
     host: serverIp,
     port: serverPort,
     specs: [join(process.cwd(), "./tests/e2e/**/*.spec.js"), join(process.cwd(), "./tests/e2e/**/*.spec.ts")],
-    maxInstances: 5,
+    maxInstances: 1,
     capabilities: [
         {
             browserName,


### PR DESCRIPTION
## Checklist
- Compatible with: MX  9️⃣

#### Web specific
- Contains e2e tests ✅ 
- Compatible with Studio  ❌
- Cross-browser compatible ❌

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (test)

## What is the purpose of this PR?
Progress bar e2e test keep failing due the loading time of the widget and probably the docker resources used in the GH Actions made the things going too slow when it's running the workflow. I'm going to try increase the timeout and changing the number of browsers instances being used to test.

## Relevant changes
Increase the failing spec timeout and decrease the maxInstances in the wdio config to try improve the stability of these tests.
After changing the maxInstances was necessary fix the badge-button spec as well.
