### PR TITLE
fix(calendar-web): fixing drop and resize events

### DIFF
--- a/packages/customWidgets/calendar-web/package.json
+++ b/packages/customWidgets/calendar-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar-web",
   "widgetName": "Calendar",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Display and manage calendar events",
   "copyright": "Mendix BV",
   "repository": {

--- a/packages/customWidgets/calendar-web/src/components/Calendar.ts
+++ b/packages/customWidgets/calendar-web/src/components/Calendar.ts
@@ -208,7 +208,7 @@ class Calendar extends Component<CalendarProps, State> {
 
     private onEventDrop = (eventInfo: Container.EventInfo) => {
         if (
-            eventInfo.start.getDate() !== eventInfo.event.start.getDate() &&
+            eventInfo.start.getTime() !== eventInfo.event.start.getTime() &&
             this.props.editable === "default" &&
             this.props.onEventDropAction
         ) {
@@ -218,9 +218,9 @@ class Calendar extends Component<CalendarProps, State> {
 
     private onEventResize = (_resizeType: string, eventInfo: Container.EventInfo) => {
         if (
-            (eventInfo.start.getDate() !== eventInfo.event.start.getDate() ||
-                eventInfo.end.getDate() !== eventInfo.event.end.getDate()) &&
-            eventInfo.start.getDate() < eventInfo.end.getDate() &&
+            (eventInfo.start.getTime() !== eventInfo.event.start.getTime() ||
+                eventInfo.end.getTime() !== eventInfo.event.end.getTime()) &&
+            eventInfo.start.getTime() < eventInfo.end.getTime() &&
             this.props.editable &&
             this.props.onEventResizeAction
         ) {

--- a/packages/customWidgets/calendar-web/src/components/__tests__/Calendar.spec.ts
+++ b/packages/customWidgets/calendar-web/src/components/__tests__/Calendar.spec.ts
@@ -115,6 +115,36 @@ describe("Calendar", () => {
             expect(calendarProps.onEventDropAction).toHaveBeenCalled();
         });
 
+        it("calls onEventDrop when moving the event within same day", () => {
+            const eventInfo = {
+                start: new Date(2021, 4, 27, 0, 0, 0),
+                event: {
+                    start: new Date(2021, 4, 27, 18, 0, 0)
+                }
+            };
+            calendarProps.onEventDropAction = jest.fn();
+            const calendar = renderCalendar(calendarProps);
+            (calendar.instance() as any).onEventDrop(eventInfo);
+
+            expect(calendarProps.onEventDropAction).toHaveBeenCalled();
+        });
+
+        it("calls onEventResize when resizing the event within same day", () => {
+            const eventInfo = {
+                start: new Date(2021, 4, 27, 0, 0, 1),
+                end: new Date(2021, 4, 27, 12, 0, 0),
+                event: {
+                    start: new Date(2021, 4, 27, 18, 0, 0),
+                    end: new Date(2021, 4, 27, 23, 59, 59)
+                }
+            };
+            calendarProps.onEventResizeAction = jest.fn();
+            const calendar = renderCalendar(calendarProps);
+            (calendar.instance() as any).onEventResize(undefined, eventInfo);
+
+            expect(calendarProps.onEventResizeAction).toHaveBeenCalled();
+        });
+
         // it("#onEventResize() calls the parent onEventResize handler when the start date, end date or both dates have changed", () => {
         //     const resizeType = "drop";
         //     const startDate = new Date();

--- a/packages/customWidgets/calendar-web/src/package.xml
+++ b/packages/customWidgets/calendar-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Calendar2" version="1.0.10" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Calendar2" version="1.0.11" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Calendar.xml"/>
         </widgetFiles>


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 7️⃣, 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ❌
- Compatible with Studio ✅
- Cross-browser compatible ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
This PR fixed moving events of calendar within same day, even while dragging & dropping or while resizing one event. This also fixed moving events between months in the same day ranges.

## Relevant changes
This PR introduces the usage of timestamp instead of just comparing the day.

## What should be covered while testing?
Test click, moving events and resizing them using the Test project in the ticket
