### PR TITLE
[NC-227 + NC-176] Add support for markers from datasource & Fix bugs

### DIFF
--- a/packages/pluggableWidgets/maps-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/maps-native/CHANGELOG.md
@@ -10,10 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added consistency check to throw an error if minimum zoom level is **greater** than the maximum zoom level.
 - Added consistency check to throw an error if default zoom level is **smaller** than the minimum zoom level.
 - Added consistency check to throw an error if default zoom level is **greater** than the maximum zoom level.
+- We added the option to use dynamic markers.
 
 ### Changed
+- We now hide widget properties when they are not needed.
 
 ### Fixed
-
+- We fixed an issue where the default zoom level was not taken into account.
+- We fixed an issue where the maps was invisible when placed inside of another widget without a fixed height.
+- We fixed an issue where the maps showed the wrong location / "Fit to markers" didn't work when the minimum zoom level was not "World".
 
 ## [major.minor.patch] - YYYY-MM-DD

--- a/packages/pluggableWidgets/maps-native/package.json
+++ b/packages/pluggableWidgets/maps-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maps-native",
   "widgetName": "Maps",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
+++ b/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
@@ -1,4 +1,4 @@
-import { hidePropertiesIn, hidePropertyIn, Problem, Properties } from "@mendix/piw-utils-internal";
+import { changePropertyIn, hidePropertiesIn, hidePropertyIn, Problem, Properties } from "@mendix/piw-utils-internal";
 import { MapsPreviewProps } from "../typings/MapsProps";
 
 export function getProperties(values: MapsPreviewProps, defaultProperties: Properties): Properties {
@@ -18,6 +18,30 @@ export function getProperties(values: MapsPreviewProps, defaultProperties: Prope
             hidePropertyIn(defaultProperties, values, "defaultZoomLevel");
         }
     }
+
+    changePropertyIn(defaultProperties, values, prop => {
+        prop.objectHeaders = ["Address", "Latitude", "Longitude"];
+        prop.objects?.forEach((object, index) => {
+            const column = values.markers[index];
+            object.captions = [
+                column.address,
+                column.latitude,
+                column.longitude
+            ];
+        })
+    }, "markers");
+
+    changePropertyIn(defaultProperties, values, prop => {
+        prop.objectHeaders = ["Address", "Latitude", "Longitude"];
+        prop.objects?.forEach((object, index) => {
+            const column = values.markers[index];
+            object.captions = [
+                column.address,
+                column.latitude,
+                column.longitude
+            ];
+        })
+    }, "dynamicMarkers");
 
     return defaultProperties;
 }

--- a/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
+++ b/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
@@ -128,8 +128,7 @@ export function check(values: MapsPreviewProps): Problem[] {
     });
 
     values.dynamicMarkers.forEach((marker, index) => {
-        // @ts-ignore
-        if (!marker.markersDS.type || marker.markersDS.type === "null") {
+        if (marker.markersDS === {} || marker.markersDS === null) {
             errors.push({
                 property: `dynamicMarkers/${index + 1}/markersDS`,
                 message: "A data source should be selected in order to retrieve a list of markers"

--- a/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
+++ b/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
@@ -1,5 +1,22 @@
-import { changePropertyIn, hidePropertiesIn, hidePropertyIn, Problem, Properties } from "@mendix/piw-utils-internal";
+import {
+    changePropertyIn,
+    hidePropertiesIn,
+    hidePropertyIn,
+    Problem,
+    Properties,
+    StructurePreviewProps
+} from "@mendix/piw-utils-internal";
 import { MapsPreviewProps } from "../typings/MapsProps";
+import StructurePreviewMapsSVG from "./assets/StructurePreviewMaps.svg";
+
+export function getPreview(_: MapsPreviewProps): StructurePreviewProps {
+    return {
+        type: "Image",
+        document: decodeURIComponent(StructurePreviewMapsSVG.replace("data:image/svg+xml,", "")),
+        width: 375,
+        height: 375
+    };
+}
 
 export function getProperties(values: MapsPreviewProps, defaultProperties: Properties): Properties {
     values.markers.forEach((f, index) => {

--- a/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
+++ b/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
@@ -1,45 +1,80 @@
-import { Problem, StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { hidePropertyIn, Problem, Properties } from "@mendix/piw-utils-internal";
 import { MapsPreviewProps } from "../typings/MapsProps";
-import StructurePreviewMapsSVG from "./assets/StructurePreviewMaps.svg";
+
+export function getProperties(
+    values: MapsPreviewProps,
+    defaultProperties: Properties,
+): Properties {
+    [...values.markers, ...values.dynamicMarkers].forEach((f, index) => {
+        if (f.locationType === "address") {
+            hidePropertyIn(defaultProperties, values, "markers", index, "latitude");
+            hidePropertyIn(defaultProperties, values, "markers", index, "longitude");
+        } else {
+            hidePropertyIn(defaultProperties, values, "markers", index, "address");
+        }
+    });
+
+    return defaultProperties;
+}
 
 export function check(values: MapsPreviewProps): Problem[] {
     const errors: Problem[] = [];
-    const zoomLevels = ["world", "continent", "country", "city", "town", "streets", "building"];
 
-    const defaultZoomLevelIndex = zoomLevels.indexOf(values.defaultZoomLevel);
-    const minZoomLevelIndex = zoomLevels.indexOf(values.minZoomLevel);
-    const maxZoomLevelIndex = zoomLevels.indexOf(values.maxZoomLevel);
+    values.markers.forEach((marker, index) => {
+        if (marker.locationType === "address") {
+            if (!marker.address) {
+                errors.push({
+                    property: `markers/${index + 1}/address`,
+                    message: "A static marker requires an address"
+                });
+            }
+        } else {
+            if (!marker.latitude) {
+                errors.push({
+                    property: `markers/${index + 1}/latitude`,
+                    message: "A static marker requires latitude"
+                });
+            }
+            if (!marker.longitude) {
+                errors.push({
+                    property: `markers/${index + 1}/longitude`,
+                    message: "A static marker requires longitude"
+                });
+            }
+        }
+    });
 
-    if (minZoomLevelIndex > maxZoomLevelIndex) {
-        errors.push({
-            property: "minZoomLevel",
-            severity: "error",
-            message: "The minimum zoom level can not be greater than the maximum zoom level."
-        });
-    }
-
-    if (defaultZoomLevelIndex < minZoomLevelIndex) {
-        errors.push({
-            property: "defaultZoomLevel",
-            severity: "error",
-            message: "The default zoom level can not be smaller than the minimum zoom level."
-        });
-    } else if (defaultZoomLevelIndex > maxZoomLevelIndex) {
-        errors.push({
-            property: "defaultZoomLevel",
-            severity: "error",
-            message: "The default zoom level can not be greater than the maximum zoom level."
-        });
-    }
+    values.dynamicMarkers.forEach((marker, index) => {
+        // @ts-ignore
+        if (marker.markersDS.type === "null") {
+            errors.push({
+                property: `dynamicMarkers/${index + 1}/markersDS`,
+                message: "A data source should be selected in order to retrieve a list of markers"
+            });
+        } else {
+            if (marker.locationType === "address") {
+                if (!marker.address) {
+                    errors.push({
+                        property: `dynamicMarkers/${index + 1}/address`,
+                        message: "A dynamic marker requires an address"
+                    });
+                }
+            } else {
+                if (!marker.latitude) {
+                    errors.push({
+                        property: `dynamicMarkers/${index + 1}/latitude`,
+                        message: "A dynamic marker requires latitude"
+                    });
+                }
+                if (!marker.longitude) {
+                    errors.push({
+                        property: `dynamicMarkers/${index + 1}/longitude`,
+                        message: "A dynamic marker requires longitude"
+                    });
+                }
+            }
+        }
+    });
 
     return errors;
-}
-
-export function getPreview(_: MapsPreviewProps): StructurePreviewProps {
-    return {
-        type: "Image",
-        document: decodeURIComponent(StructurePreviewMapsSVG.replace("data:image/svg+xml,", "")),
-        width: 375,
-        height: 375
-    };
 }

--- a/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
+++ b/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
@@ -19,29 +19,31 @@ export function getProperties(values: MapsPreviewProps, defaultProperties: Prope
         }
     }
 
-    changePropertyIn(defaultProperties, values, prop => {
-        prop.objectHeaders = ["Address", "Latitude", "Longitude"];
-        prop.objects?.forEach((object, index) => {
-            const column = values.markers[index];
-            object.captions = [
-                column.address,
-                column.latitude,
-                column.longitude
-            ];
-        })
-    }, "markers");
+    changePropertyIn(
+        defaultProperties,
+        values,
+        prop => {
+            prop.objectHeaders = ["Address", "Latitude", "Longitude"];
+            prop.objects?.forEach((object, index) => {
+                const column = values.markers[index];
+                object.captions = [column.address, column.latitude, column.longitude];
+            });
+        },
+        "markers"
+    );
 
-    changePropertyIn(defaultProperties, values, prop => {
-        prop.objectHeaders = ["Address", "Latitude", "Longitude"];
-        prop.objects?.forEach((object, index) => {
-            const column = values.markers[index];
-            object.captions = [
-                column.address,
-                column.latitude,
-                column.longitude
-            ];
-        })
-    }, "dynamicMarkers");
+    changePropertyIn(
+        defaultProperties,
+        values,
+        prop => {
+            prop.objectHeaders = ["Address", "Latitude", "Longitude"];
+            prop.objects?.forEach((object, index) => {
+                const column = values.markers[index];
+                object.captions = [column.address, column.latitude, column.longitude];
+            });
+        },
+        "dynamicMarkers"
+    );
 
     return defaultProperties;
 }

--- a/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
+++ b/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
@@ -129,7 +129,7 @@ export function check(values: MapsPreviewProps): Problem[] {
 
     values.dynamicMarkers.forEach((marker, index) => {
         // @ts-ignore
-        if (marker.markersDS.type === "null") {
+        if (!marker.markersDS.type || marker.markersDS.type === "null") {
             errors.push({
                 property: `dynamicMarkers/${index + 1}/markersDS`,
                 message: "A data source should be selected in order to retrieve a list of markers"

--- a/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
+++ b/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
@@ -2,7 +2,7 @@ import { changePropertyIn, hidePropertiesIn, hidePropertyIn, Problem, Properties
 import { MapsPreviewProps } from "../typings/MapsProps";
 
 export function getProperties(values: MapsPreviewProps, defaultProperties: Properties): Properties {
-    [...values.markers, ...values.dynamicMarkers].forEach((f, index) => {
+    values.markers.forEach((f, index) => {
         if (f.locationType === "address") {
             hidePropertyIn(defaultProperties, values, "markers", index, "latitude");
             hidePropertyIn(defaultProperties, values, "markers", index, "longitude");
@@ -11,10 +11,19 @@ export function getProperties(values: MapsPreviewProps, defaultProperties: Prope
         }
     });
 
+    values.dynamicMarkers.forEach((f, index) => {
+        if (f.locationType === "address") {
+            hidePropertyIn(defaultProperties, values, "dynamicMarkers", index, "latitude");
+            hidePropertyIn(defaultProperties, values, "dynamicMarkers", index, "longitude");
+        } else {
+            hidePropertyIn(defaultProperties, values, "dynamicMarkers", index, "address");
+        }
+    });
+
     if (values.fitToMarkers) {
         hidePropertiesIn(defaultProperties, values, ["centerAddress", "centerLatitude", "centerLongitude"]);
 
-        if (values.markers.length > 1) {
+        if (values.markers.length > 1 || values.dynamicMarkers.length > 1) {
             hidePropertyIn(defaultProperties, values, "defaultZoomLevel");
         }
     }
@@ -38,7 +47,7 @@ export function getProperties(values: MapsPreviewProps, defaultProperties: Prope
         prop => {
             prop.objectHeaders = ["Address", "Latitude", "Longitude"];
             prop.objects?.forEach((object, index) => {
-                const column = values.markers[index];
+                const column = values.dynamicMarkers[index];
                 object.captions = [column.address, column.latitude, column.longitude];
             });
         },

--- a/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
+++ b/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
@@ -24,6 +24,32 @@ export function getProperties(values: MapsPreviewProps, defaultProperties: Prope
 
 export function check(values: MapsPreviewProps): Problem[] {
     const errors: Problem[] = [];
+    const zoomLevels = ["world", "continent", "country", "city", "town", "streets", "building"];
+    const defaultZoomLevelIndex = zoomLevels.indexOf(values.defaultZoomLevel);
+    const minZoomLevelIndex = zoomLevels.indexOf(values.minZoomLevel);
+    const maxZoomLevelIndex = zoomLevels.indexOf(values.maxZoomLevel);
+
+    if (minZoomLevelIndex > maxZoomLevelIndex) {
+        errors.push({
+            property: "minZoomLevel",
+            severity: "error",
+            message: "The minimum zoom level can not be greater than the maximum zoom level."
+        });
+    }
+
+    if (defaultZoomLevelIndex < minZoomLevelIndex) {
+        errors.push({
+            property: "defaultZoomLevel",
+            severity: "error",
+            message: "The default zoom level can not be smaller than the minimum zoom level."
+        });
+    } else if (defaultZoomLevelIndex > maxZoomLevelIndex) {
+        errors.push({
+            property: "defaultZoomLevel",
+            severity: "error",
+            message: "The default zoom level can not be greater than the maximum zoom level."
+        });
+    }
 
     values.markers.forEach((marker, index) => {
         if (marker.locationType === "address") {

--- a/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
+++ b/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
@@ -1,10 +1,7 @@
-import { hidePropertyIn, Problem, Properties } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, hidePropertyIn, Problem, Properties } from "@mendix/piw-utils-internal";
 import { MapsPreviewProps } from "../typings/MapsProps";
 
-export function getProperties(
-    values: MapsPreviewProps,
-    defaultProperties: Properties,
-): Properties {
+export function getProperties(values: MapsPreviewProps, defaultProperties: Properties): Properties {
     [...values.markers, ...values.dynamicMarkers].forEach((f, index) => {
         if (f.locationType === "address") {
             hidePropertyIn(defaultProperties, values, "markers", index, "latitude");
@@ -13,6 +10,14 @@ export function getProperties(
             hidePropertyIn(defaultProperties, values, "markers", index, "address");
         }
     });
+
+    if (values.fitToMarkers) {
+        hidePropertiesIn(defaultProperties, values, ["centerAddress", "centerLatitude", "centerLongitude"]);
+
+        if (values.markers.length > 1) {
+            hidePropertyIn(defaultProperties, values, "defaultZoomLevel");
+        }
+    }
 
     return defaultProperties;
 }

--- a/packages/pluggableWidgets/maps-native/src/Maps.tsx
+++ b/packages/pluggableWidgets/maps-native/src/Maps.tsx
@@ -115,11 +115,9 @@ export class Maps extends Component<Props, State> {
         );
     }
 
-    private onMapReady(): void {
-        // if (Platform.OS === "android") {
-        this.updateCamera(false);
+    private async onMapReady(): Promise<void> {
+        await this.updateCamera(false);
         this.setState({ status: this.props.interactive ? Status.MapReady : Status.CameraReady });
-        // }
         this.onRegionChangeComplete();
     }
 

--- a/packages/pluggableWidgets/maps-native/src/Maps.tsx
+++ b/packages/pluggableWidgets/maps-native/src/Maps.tsx
@@ -199,18 +199,18 @@ export class Maps extends Component<Props, State> {
     private async getCenter(): Promise<LatLng> {
         const center =
             (this.props.centerLatitude && this.props.centerLongitude) || this.props.centerAddress
-            ? await this.parseCoordinate(
-                this.props.centerLatitude,
-                this.props.centerLongitude,
-                this.props.centerAddress
-            )
-            : this.props.markers.length === 1 && this.props.fitToMarkers
-              ? await this.parseCoordinate(
-                    this.props.markers[0].latitude,
-                    this.props.markers[0].longitude,
-                    this.props.markers[0].address
-                )
-              : null;
+                ? await this.parseCoordinate(
+                      this.props.centerLatitude,
+                      this.props.centerLongitude,
+                      this.props.centerAddress
+                  )
+                : this.props.markers.length === 1 && this.props.fitToMarkers
+                ? await this.parseCoordinate(
+                      this.props.markers[0].latitude,
+                      this.props.markers[0].longitude,
+                      this.props.markers[0].address
+                  )
+                : null;
 
         return center || { latitude: 51.9066346, longitude: 4.4861703 };
     }

--- a/packages/pluggableWidgets/maps-native/src/Maps.tsx
+++ b/packages/pluggableWidgets/maps-native/src/Maps.tsx
@@ -117,7 +117,9 @@ export class Maps extends Component<Props, State> {
 
     private async onMapReady(): Promise<void> {
         await this.updateCamera(false);
-        this.setState({ status: this.props.interactive ? Status.MapReady : Status.CameraReady });
+        if (Platform.OS === "android") {
+            this.setState({ status: this.props.interactive ? Status.MapReady : Status.CameraReady });
+        }
         this.onRegionChangeComplete();
     }
 
@@ -195,7 +197,7 @@ export class Maps extends Component<Props, State> {
             if (animated) {
                 this.mapViewRef.current.animateCamera(camera);
             } else {
-                this.mapViewRef.current.setCamera({ ...camera, center: await this.getCenter() });
+                this.mapViewRef.current.setCamera(camera);
             }
         }
     }

--- a/packages/pluggableWidgets/maps-native/src/Maps.tsx
+++ b/packages/pluggableWidgets/maps-native/src/Maps.tsx
@@ -157,9 +157,7 @@ export class Maps extends Component<Props, State> {
     private async parseMarkers(): Promise<void> {
         const markers = [
             ...this.props.markers.map(convertStaticModeledMarker),
-            ...this.props.dynamicMarkers
-                .map(convertDynamicModeledMarker)
-                .reduce((prev, current) => [...prev, ...current], [])
+            ...this.props.dynamicMarkers.flatMap(convertDynamicModeledMarker)
         ];
 
         const parsedMarkers = await Promise.all(

--- a/packages/pluggableWidgets/maps-native/src/Maps.tsx
+++ b/packages/pluggableWidgets/maps-native/src/Maps.tsx
@@ -54,11 +54,16 @@ export class Maps extends Component<Props, State> {
 
     componentDidUpdate(): void {
         if (
-            this.state.status === Status.CameraReady ||
-            (this.state.status === Status.LoadingMarkers &&
-                (!this.props.dynamicMarkers.length ||
-                    this.props.dynamicMarkers.filter(m => m.markersDS?.status !== ValueStatus.Available).length === 0))
+            this.state.status === Status.LoadingMarkers &&
+            (!this.props.dynamicMarkers.length ||
+                this.props.dynamicMarkers.filter(m => m.markersDS?.status !== ValueStatus.Available).length === 0)
         ) {
+            this.parseMarkers();
+        }
+    }
+
+    UNSAFE_componentWillReceiveProps(): void {
+        if (this.state.status === Status.CameraReady) {
             this.parseMarkers();
         }
     }

--- a/packages/pluggableWidgets/maps-native/src/Maps.tsx
+++ b/packages/pluggableWidgets/maps-native/src/Maps.tsx
@@ -56,7 +56,7 @@ export class Maps extends Component<Props, State> {
         if (
             this.state.status === Status.LoadingMarkers &&
             (!this.props.dynamicMarkers.length ||
-                this.props.dynamicMarkers.filter(m => m.markersDS?.status !== ValueStatus.Available).length === 0)
+                this.props.dynamicMarkers.every(m => m.markersDS?.status === ValueStatus.Available))
         ) {
             this.parseMarkers();
         }

--- a/packages/pluggableWidgets/maps-native/src/Maps.tsx
+++ b/packages/pluggableWidgets/maps-native/src/Maps.tsx
@@ -1,5 +1,5 @@
 import { flattenStyles } from "@mendix/piw-native-utils-internal";
-import { ActionValue } from "mendix";
+import { ActionValue, ValueStatus } from "mendix";
 import { Icon } from "mendix/components/native/Icon";
 import { Component, createElement, createRef } from "react";
 import { ActivityIndicator, Platform, View } from "react-native";
@@ -45,11 +45,17 @@ export class Maps extends Component<Props, State> {
     private readonly geocoder = new CachedGeocoder();
 
     componentDidMount(): void {
-        this.parseMarkers();
+        if (!this.props.dynamicMarkers.length) {
+            this.parseMarkers();
+        }
     }
 
     componentDidUpdate(): void {
-        if (this.state.status === Status.LoadingMarkers) {
+        if (
+            this.state.status === Status.LoadingMarkers &&
+            (!this.props.dynamicMarkers.length ||
+                this.props.dynamicMarkers.filter(m => m.markersDS?.status !== ValueStatus.Available).length === 0)
+        ) {
             this.parseMarkers();
         }
     }

--- a/packages/pluggableWidgets/maps-native/src/Maps.tsx
+++ b/packages/pluggableWidgets/maps-native/src/Maps.tsx
@@ -58,9 +58,6 @@ export class Maps extends Component<Props, State> {
         ) {
             this.parseMarkers();
         }
-    }
-
-    UNSAFE_componentWillReceiveProps(): void {
         if (this.state.status === Status.CameraReady) {
             this.parseMarkers();
         }

--- a/packages/pluggableWidgets/maps-native/src/Maps.tsx
+++ b/packages/pluggableWidgets/maps-native/src/Maps.tsx
@@ -201,17 +201,19 @@ export class Maps extends Component<Props, State> {
     }
 
     private async getCenter(): Promise<LatLng> {
-        const { markers, fitToMarkers, centerLatitude, centerLongitude, centerAddress } = this.props;
+        const { fitToMarkers, centerLatitude, centerLongitude, centerAddress } = this.props;
         const center =
-            this.state.markers?.length === 1 && this.props.fitToMarkers
+            (centerLatitude && centerLongitude) || centerAddress
+                ? await this.parseCoordinate(
+                      Number(centerLatitude?.value),
+                      Number(centerLongitude?.value),
+                      centerAddress?.value
+                  )
+                : this.state.markers?.length === 1 && fitToMarkers
                 ? this.state.markers[0]?.coordinate
-                : await this.parseCoordinate(
-                      Number(this.props.centerLatitude?.value),
-                      Number(this.props.centerLongitude?.value),
-                      this.props.centerAddress?.value
-                  );
+                : { latitude: 51.9066346, longitude: 4.4861703 };
 
-        return center || { latitude: 51.9066346, longitude: 4.4861703 };
+        return center as LatLng;
     }
 
     private parseCoordinate(

--- a/packages/pluggableWidgets/maps-native/src/Maps.tsx
+++ b/packages/pluggableWidgets/maps-native/src/Maps.tsx
@@ -119,10 +119,8 @@ export class Maps extends Component<Props, State> {
     }
 
     private onMapReady(): void {
-        if (Platform.OS === "android") {
-            this.updateCamera(false);
-            this.setState({ status: this.props.interactive ? Status.MapReady : Status.CameraReady });
-        }
+        this.updateCamera(false);
+        this.setState({ status: this.props.interactive ? Status.MapReady : Status.CameraReady });
         this.onRegionChangeComplete();
     }
 
@@ -200,17 +198,19 @@ export class Maps extends Component<Props, State> {
 
     private async getCenter(): Promise<LatLng> {
         const center =
-            this.props.markers.length === 1 && this.props.fitToMarkers
-                ? await this.parseCoordinate(
-                      this.props.markers[0].latitude,
-                      this.props.markers[0].longitude,
-                      this.props.markers[0].address
-                  )
-                : await this.parseCoordinate(
-                      this.props.centerLatitude,
-                      this.props.centerLongitude,
-                      this.props.centerAddress
-                  );
+            (this.props.centerLatitude && this.props.centerLongitude) || this.props.centerAddress
+            ? await this.parseCoordinate(
+                this.props.centerLatitude,
+                this.props.centerLongitude,
+                this.props.centerAddress
+            )
+            : this.props.markers.length === 1 && this.props.fitToMarkers
+              ? await this.parseCoordinate(
+                    this.props.markers[0].latitude,
+                    this.props.markers[0].longitude,
+                    this.props.markers[0].address
+                )
+              : null;
 
         return center || { latitude: 51.9066346, longitude: 4.4861703 };
     }

--- a/packages/pluggableWidgets/maps-native/src/Maps.tsx
+++ b/packages/pluggableWidgets/maps-native/src/Maps.tsx
@@ -197,22 +197,15 @@ export class Maps extends Component<Props, State> {
     }
 
     private async getCenter(): Promise<LatLng> {
+        const { markers, fitToMarkers, centerLatitude, centerLongitude, centerAddress } = this.props;
         const center =
-            (this.props.centerLatitude && this.props.centerLongitude) || this.props.centerAddress
-                ? await this.parseCoordinate(
-                      this.props.centerLatitude,
-                      this.props.centerLongitude,
-                      this.props.centerAddress
-                  )
-                : this.props.markers.length === 1 && this.props.fitToMarkers
-                ? await this.parseCoordinate(
-                      this.props.markers[0].latitude,
-                      this.props.markers[0].longitude,
-                      this.props.markers[0].address
-                  )
-                : null;
+            (centerLatitude && centerLongitude) || centerAddress
+                ? await this.parseCoordinate(centerLatitude, centerLongitude, centerAddress)
+                : markers.length === 1 && fitToMarkers
+                ? await this.parseCoordinate(markers[0].latitude, markers[0].longitude, markers[0].address)
+                : { latitude: 51.9066346, longitude: 4.4861703 };
 
-        return center || { latitude: 51.9066346, longitude: 4.4861703 };
+        return center as LatLng;
     }
 
     private parseCoordinate(
@@ -220,7 +213,7 @@ export class Maps extends Component<Props, State> {
         longitudeProp?: DynamicValue<Big>,
         addressProp?: DynamicValue<string>
     ): Promise<LatLng | null> {
-        if (latitudeProp && latitudeProp.value && longitudeProp && longitudeProp.value) {
+        if (latitudeProp?.value && longitudeProp?.value) {
             const latitude = Number(latitudeProp.value);
             const longitude = Number(longitudeProp.value);
 

--- a/packages/pluggableWidgets/maps-native/src/Maps.xml
+++ b/packages/pluggableWidgets/maps-native/src/Maps.xml
@@ -164,24 +164,6 @@
                 </property>
             </propertyGroup>
         </propertyGroup>
-        <propertyGroup caption="Appearance">
-            <propertyGroup caption="Custom icon">
-                <property key="icon" type="icon" required="false">
-                    <caption>Icon</caption>
-                    <description/>
-                </property>
-                <property key="iconSize" type="integer" defaultValue="32">
-                    <caption>Size</caption>
-                    <description/>
-                </property>
-            </propertyGroup>
-            <propertyGroup caption="Color">
-                <property key="color" type="string" required="false">
-                    <caption>Marker</caption>
-                    <description>Overrides the default color provided through design properties. Not supported for custom images.</description>
-                </property>
-            </propertyGroup>
-        </propertyGroup>
         <propertyGroup caption="View">
             <propertyGroup caption="Automatic">
                 <property key="fitToMarkers" type="boolean" defaultValue="true">

--- a/packages/pluggableWidgets/maps-native/src/Maps.xml
+++ b/packages/pluggableWidgets/maps-native/src/Maps.xml
@@ -30,13 +30,15 @@
                                     <caption>Address</caption>
                                     <description>Address containing (a subset of) street, number, zipcode, city and country.</description>
                                 </property>
-                                <property key="latitude" type="textTemplate" required="false">
+                                <property key="latitude" type="expression" required="false">
                                     <caption>Latitude</caption>
                                     <description>Decimal number from -90.0 to 90.0.</description>
+                                    <returnType type="Decimal"/>
                                 </property>
-                                <property key="longitude" type="textTemplate" required="false">
+                                <property key="longitude" type="expression" required="false">
                                     <caption>Longitude</caption>
                                     <description>Decimal number from -180.0 to 180.0.</description>
+                                    <returnType type="Decimal"/>
                                 </property>
                             </propertyGroup>
                             <propertyGroup caption="Callout box">

--- a/packages/pluggableWidgets/maps-native/src/Maps.xml
+++ b/packages/pluggableWidgets/maps-native/src/Maps.xml
@@ -1,69 +1,186 @@
 <?xml version="1.0" encoding="utf-8"?>
-<widget id="com.mendix.widget.native.maps.Maps" supportedPlatform="Native" needsEntityContext="true" offlineCapable="true" pluginWidget="true" xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd">
+<widget id="com.mendix.widget.native.maps.Maps" supportedPlatform="Native" needsEntityContext="true"
+        offlineCapable="true" pluginWidget="true" xmlns="http://www.mendix.com/widget/1.0/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd">
     <name>Maps</name>
     <description>Show locations on an interactive map.</description>
-    <icon>iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAAHdbkFIAAAJL0lEQVR42u1aC2wUVRRFUcRP/ETEvyQaNTF+EgU1GH/4ye62oAiNIhKq4Cf+UFEJEAVFpN3Ctpa2sSIWAX9NC7OzRUHRoqiQCJJYQMVPFKMon0rlM2+30ue9u++1b+7O7MzOzlJRJnnZnTd37jv3vnvvu+++6dEjmyugGVz9NV0lJSV35MYBr7Kysr74W1paOiUjp8rKyiPECxcnO+rr63tZEQKnDvlnE4DkVi0rNfQobua9g3r7tVY6aEDR1GZijzdPv6KPkve1tbVHpREA0B3ybfj/fBqB2gH/49C+Vgn2EQIOuumZxiFrHUhMQY397UpPnPNDkbOc7WCUtSUZRI15gRgLhbS9HULgOZYMJCzVbGQbHON9ZL8tfFW+5Mjv8qTVhKLxiYEo63CUXz6QvyE9PgIZTQXRAPYN0D5yjcCpAbNa08vhcHgcdFZnGoHOdY9/9xXUjOlyCguaEpdlHYACGtul3oM1tji+CIoxVEuUCOR/Rx/AhyHdKA5o8Tp8Aa5DwIDCgagxzdEKqSmHlvBTKAJB01pRUXGyK1+Q19Dl/ESFwTSMGBktcUZJKVeZqPLL8GMZ3TG6SUYgezu0pqQ4UfaqoxVC50rgfD0VxUp5dgwyErhikE2zRQBeeRX8X+0JgfiNQHty/4vw/7gwONNlmDYIGxvzE+CixgqxyG2VfaEl7LyQZtxdtIH3Sl9N4xfkNCB41QQ54c+Uz+Fi8G1ixa3tHChqvNUVefkJKoicDAcAbMaXwC/OCerGIKHeNakB2K5kjIDYKcL/L+q9GgKs0htXF30JpN6DTEcu3DgN7wua4hcq874Xg3dyWrTdrUkwGntUEWYp8oK8cnDWANRWsOgvaWzzLdcySD/w+UOvvG+XDCx1NTiqXbywWY222Des4Y/FSRAwmHxW9Dk/UmrjuVnVC8XUjc2kUSfpIwLABCsGRZz3VIxwtVjFE0Ldd4t353kGAC8zJK6urj4mEwM5eEFT+9WK9s4VAL7PRQM8X41OjSsPqKmpOUH0tXnxIKHVy4Vm1jm9PFAQfqH03Sv6XvMKwPU0AMEbQlXF1I+hL7Q/APycTxv4H6/l/5kLtp7H4rKcloxE2Xt5Hzyks4hTRlTQxM7Oj+R6fIIcBDfeFivhWvm8qJkf4zsApWRwVieoWPz2gqhxvbI2vC7yg305D4gFDem3xa9/KRMPPTUwu5mqngKdHo6ovo/bzUM9ZURyzytLFqbEExJVAPWnWI53pqbCeBHvx9StpsnIBM8pmSrlkCg/LTU4a6NSp1KyxBUC3CqxPI8QvBp8ATC1mR+m3svtcyeAmDFWuGW9XXbleOEmXt1KA8PPklLp7EmRoLZSG4Bd9DjxjKWKBPGLPGfFmL2qSSTm+9TYYO7XddqCzh7BPvCQoyidJwCybqlWI4KL93CRbj9k76psJ9LcP/fjnAEspUvo82WV3Eq6rhjQfpXdjsgLgB1WDIa/84uMB9/aBaqJlQtyB2D1Ao0JYHQBZde0Qe4dbfLBzm1ezgCCeuJKk9vprJCWgywANIr+OzwBkG4JbbuI+Z/KPWGXRhL9MwCQO+2IJwDgltcJr/iEzrkIw82ZtAfvDxL9Kz0BgIEfFHP4cud+cAPvJSJeu9P04Q5LCMDcBKGLBfFGhWmVADAurym5iN1juzUlx4J+dwNYJ6bgci+hVLoc/A73NAV4+kZPoLIEUC7onyAA9gm+vTwHIZfVlccFfQUB9oXoH5hvAMME/SLCo8aVJ+UKYObMmQME/RoCrFj0v9Ft1RFhnJu6FQBu/w9ucA9e3XVhgRW/R4A8piSoGW/Dav4JFuAho4tBSvEyFttxn/OfEjoQTYzGMxansoZFvaUjFDUWFH3AjzswC0lRY6HliRbk7XgUi58oYIUbT9eDMTY4qMUnozXYvLM1b3Uf34tYWuIKLM+Yj/GMn/B4x7WrJJPd1Bk+2X2/+q8WvkBjN6bNYMy4waSgJbwf+PyHFjO9PRCNmzZNyW+YNNZCzkQbulVISCkKrRbYGdCGNLaScmXXIQ6WN8CUt7jxf6C7x+xOqW2vbOOrG50W+4K8KQCYV1oN+vTsN4kgbKkp+nfW8TqfPy6f37KMn0kLz8FofGTXBjQ+VH02auF6p3TrpbwpAJivUgeD5POaVH0Av70xzeR8pbJ+hlk41pq+WqQKm0rcmN5lPe0DiYWsJgnwNUQBq/IiPJ5LA/OEOlgkEjlSVOb6mIIfLGOFMX66UkaYT5c59GdQxmwQ/leioD1Dl/G+SiVQNwdDc5EeMRAFJOQZut/+fykZqIX46nizFezdjAXdLkHiw2X91N7/WWyqUk8HV3iGPN9kY5kt5Fz20nyY/wPE3+ZSmiGLdr6pAr6lYfue+9bww1UaFBDNGoR5GJa2pyD6F93azI+3OJqZpPIqXLxrHx5U2cSmuQTb/fkIgHOJBTxgoaSReEBBZnYHAD8pu2MhNsf0RWnjn/yFcISXl5ef6nVy/LCAFrf7Tvx0JM28dWOQ0xhoLRAf1qvvDav/lc8oDWe77/3KV+Hr6up6Z7v5nlQxDwXoMClCZ7ZLVGEscQmNEaMWrN/idfOPmH1TgNulBvq/Uekmz36rPwj1A1nGfqcuEdJYdVrqq8eHyU94lHHHu12iIRBe7af5jycarqQ0WEuUdUUBtkPWF2k0l+dN+Mkt3S1ipB+1jB8txn3MbZJDk7RMyvKigHdU5mVlZXdZFNYvJEr6mu4D5EGaXaNrPIx7GxFqcYbC/l2E9m0/FfAjYX6+RZ5QRGgarbfKrMYi/9+C1mAxbn/Cc20GjOcT2h/98v8+ZGbbbABMIXTT7HgmM8fk1w2sOaizYIZZ7UuE2uawVLep9FVVVSf6sf4HCYjlbtwE2p0+WR+zSr9taJcTDEE/AEzZD/XqfH2q+KwfFtB0oCoAsfuhgK3EBE+nNLNmzTqPuMn3Pgbg1wjvMXa0iI3Q/pFrAOxHNPqbDchbycAxHxUwlWB4zmHCfiM1i365bIGLyOCaDd0k4nulPm7D7yEY6hwUoJHJGJ6L9sOE2WSbQRcQutF+KQCWwhuJAj50wDyZYAnnooAVhNlNNnRridkN8EsBNL5A+84B802EvjkXBew+gFcAOWm7c/G/gPza6gAVfjPKcPBk9uBlff0D/JLUfaEaS14AAAAASUVORK5CYII=</icon>
+    <icon>
+        iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAAHdbkFIAAAJL0lEQVR42u1aC2wUVRRFUcRP/ETEvyQaNTF+EgU1GH/4ye62oAiNIhKq4Cf+UFEJEAVFpN3Ctpa2sSIWAX9NC7OzRUHRoqiQCJJYQMVPFKMon0rlM2+30ue9u++1b+7O7MzOzlJRJnnZnTd37jv3vnvvu+++6dEjmyugGVz9NV0lJSV35MYBr7Kysr74W1paOiUjp8rKyiPECxcnO+rr63tZEQKnDvlnE4DkVi0rNfQobua9g3r7tVY6aEDR1GZijzdPv6KPkve1tbVHpREA0B3ybfj/fBqB2gH/49C+Vgn2EQIOuumZxiFrHUhMQY397UpPnPNDkbOc7WCUtSUZRI15gRgLhbS9HULgOZYMJCzVbGQbHON9ZL8tfFW+5Mjv8qTVhKLxiYEo63CUXz6QvyE9PgIZTQXRAPYN0D5yjcCpAbNa08vhcHgcdFZnGoHOdY9/9xXUjOlyCguaEpdlHYACGtul3oM1tji+CIoxVEuUCOR/Rx/AhyHdKA5o8Tp8Aa5DwIDCgagxzdEKqSmHlvBTKAJB01pRUXGyK1+Q19Dl/ESFwTSMGBktcUZJKVeZqPLL8GMZ3TG6SUYgezu0pqQ4UfaqoxVC50rgfD0VxUp5dgwyErhikE2zRQBeeRX8X+0JgfiNQHty/4vw/7gwONNlmDYIGxvzE+CixgqxyG2VfaEl7LyQZtxdtIH3Sl9N4xfkNCB41QQ54c+Uz+Fi8G1ixa3tHChqvNUVefkJKoicDAcAbMaXwC/OCerGIKHeNakB2K5kjIDYKcL/L+q9GgKs0htXF30JpN6DTEcu3DgN7wua4hcq874Xg3dyWrTdrUkwGntUEWYp8oK8cnDWANRWsOgvaWzzLdcySD/w+UOvvG+XDCx1NTiqXbywWY222Des4Y/FSRAwmHxW9Dk/UmrjuVnVC8XUjc2kUSfpIwLABCsGRZz3VIxwtVjFE0Ldd4t353kGAC8zJK6urj4mEwM5eEFT+9WK9s4VAL7PRQM8X41OjSsPqKmpOUH0tXnxIKHVy4Vm1jm9PFAQfqH03Sv6XvMKwPU0AMEbQlXF1I+hL7Q/APycTxv4H6/l/5kLtp7H4rKcloxE2Xt5Hzyks4hTRlTQxM7Oj+R6fIIcBDfeFivhWvm8qJkf4zsApWRwVieoWPz2gqhxvbI2vC7yg305D4gFDem3xa9/KRMPPTUwu5mqngKdHo6ovo/bzUM9ZURyzytLFqbEExJVAPWnWI53pqbCeBHvx9StpsnIBM8pmSrlkCg/LTU4a6NSp1KyxBUC3CqxPI8QvBp8ATC1mR+m3svtcyeAmDFWuGW9XXbleOEmXt1KA8PPklLp7EmRoLZSG4Bd9DjxjKWKBPGLPGfFmL2qSSTm+9TYYO7XddqCzh7BPvCQoyidJwCybqlWI4KL93CRbj9k76psJ9LcP/fjnAEspUvo82WV3Eq6rhjQfpXdjsgLgB1WDIa/84uMB9/aBaqJlQtyB2D1Ao0JYHQBZde0Qe4dbfLBzm1ezgCCeuJKk9vprJCWgywANIr+OzwBkG4JbbuI+Z/KPWGXRhL9MwCQO+2IJwDgltcJr/iEzrkIw82ZtAfvDxL9Kz0BgIEfFHP4cud+cAPvJSJeu9P04Q5LCMDcBKGLBfFGhWmVADAurym5iN1juzUlx4J+dwNYJ6bgci+hVLoc/A73NAV4+kZPoLIEUC7onyAA9gm+vTwHIZfVlccFfQUB9oXoH5hvAMME/SLCo8aVJ+UKYObMmQME/RoCrFj0v9Ft1RFhnJu6FQBu/w9ucA9e3XVhgRW/R4A8piSoGW/Dav4JFuAho4tBSvEyFttxn/OfEjoQTYzGMxansoZFvaUjFDUWFH3AjzswC0lRY6HliRbk7XgUi58oYIUbT9eDMTY4qMUnozXYvLM1b3Uf34tYWuIKLM+Yj/GMn/B4x7WrJJPd1Bk+2X2/+q8WvkBjN6bNYMy4waSgJbwf+PyHFjO9PRCNmzZNyW+YNNZCzkQbulVISCkKrRbYGdCGNLaScmXXIQ6WN8CUt7jxf6C7x+xOqW2vbOOrG50W+4K8KQCYV1oN+vTsN4kgbKkp+nfW8TqfPy6f37KMn0kLz8FofGTXBjQ+VH02auF6p3TrpbwpAJivUgeD5POaVH0Av70xzeR8pbJ+hlk41pq+WqQKm0rcmN5lPe0DiYWsJgnwNUQBq/IiPJ5LA/OEOlgkEjlSVOb6mIIfLGOFMX66UkaYT5c59GdQxmwQ/leioD1Dl/G+SiVQNwdDc5EeMRAFJOQZut/+fykZqIX46nizFezdjAXdLkHiw2X91N7/WWyqUk8HV3iGPN9kY5kt5Fz20nyY/wPE3+ZSmiGLdr6pAr6lYfue+9bww1UaFBDNGoR5GJa2pyD6F93azI+3OJqZpPIqXLxrHx5U2cSmuQTb/fkIgHOJBTxgoaSReEBBZnYHAD8pu2MhNsf0RWnjn/yFcISXl5ef6nVy/LCAFrf7Tvx0JM28dWOQ0xhoLRAf1qvvDav/lc8oDWe77/3KV+Hr6up6Z7v5nlQxDwXoMClCZ7ZLVGEscQmNEaMWrN/idfOPmH1TgNulBvq/Uekmz36rPwj1A1nGfqcuEdJYdVrqq8eHyU94lHHHu12iIRBe7af5jycarqQ0WEuUdUUBtkPWF2k0l+dN+Mkt3S1ipB+1jB8txn3MbZJDk7RMyvKigHdU5mVlZXdZFNYvJEr6mu4D5EGaXaNrPIx7GxFqcYbC/l2E9m0/FfAjYX6+RZ5QRGgarbfKrMYi/9+C1mAxbn/Cc20GjOcT2h/98v8+ZGbbbABMIXTT7HgmM8fk1w2sOaizYIZZ7UuE2uawVLep9FVVVSf6sf4HCYjlbtwE2p0+WR+zSr9taJcTDEE/AEzZD/XqfH2q+KwfFtB0oCoAsfuhgK3EBE+nNLNmzTqPuMn3Pgbg1wjvMXa0iI3Q/pFrAOxHNPqbDchbycAxHxUwlWB4zmHCfiM1i365bIGLyOCaDd0k4nulPm7D7yEY6hwUoJHJGJ6L9sOE2WSbQRcQutF+KQCWwhuJAj50wDyZYAnnooAVhNlNNnRridkN8EsBNL5A+84B802EvjkXBew+gFcAOWm7c/G/gPza6gAVfjPKcPBk9uBlff0D/JLUfaEaS14AAAAASUVORK5CYII=
+    </icon>
     <properties>
-        <propertyGroup caption="Markers">
-            <property key="markers" type="object" isList="true" required="false">
-                <caption>List</caption>
-                <description/>
-                <properties>
-                    <propertyGroup caption="General">
-                        <propertyGroup caption="Location">
-                            <property key="address" type="expression" required="false">
-                                <caption>Address</caption>
-                                <description>When latitude and longitude are provided, the address is ignored.</description>
-                                <returnType type="String"/>
-                            </property>
-                            <property key="latitude" type="expression" required="false">
-                                <caption>Latitude</caption>
-                                <description/>
-                                <returnType type="Decimal"/>
-                            </property>
-                            <property key="longitude" type="expression" required="false">
-                                <caption>Longitude</caption>
-                                <description/>
-                                <returnType type="Decimal"/>
-                            </property>
+        <propertyGroup caption="General">
+            <propertyGroup caption="Markers">
+                <property key="markers" type="object" isList="true" required="false">
+                    <caption>Markers</caption>
+                    <description>A list of static locations on the map.</description>
+                    <properties>
+                        <propertyGroup caption="Locations">
+                            <propertyGroup caption="Location">
+                                <property key="locationType" type="enumeration" defaultValue="address">
+                                    <caption>Location</caption>
+                                    <description/>
+                                    <enumerationValues>
+                                        <enumerationValue key="address">Based on address</enumerationValue>
+                                        <enumerationValue key="latlng">Based on latitude and longitude
+                                        </enumerationValue>
+                                    </enumerationValues>
+                                </property>
+                                <property key="address" type="textTemplate" required="false">
+                                    <caption>Address</caption>
+                                    <description>Address containing (a subset of) street, number, zipcode, city and country.</description>
+                                </property>
+                                <property key="latitude" type="textTemplate" required="false">
+                                    <caption>Latitude</caption>
+                                    <description>Decimal number from -90.0 to 90.0.</description>
+                                </property>
+                                <property key="longitude" type="textTemplate" required="false">
+                                    <caption>Longitude</caption>
+                                    <description>Decimal number from -180.0 to 180.0.</description>
+                                </property>
+                            </propertyGroup>
+                            <propertyGroup caption="Callout box">
+                                <property key="title" type="textTemplate" required="false">
+                                    <caption>Title</caption>
+                                    <description>Title displayed when clicking the marker.</description>
+                                </property>
+                                <property key="description" type="textTemplate" required="false">
+                                    <caption>Description</caption>
+                                    <description>Description displayed when clicking the marker.</description>
+                                </property>
+                            </propertyGroup>
+                            <propertyGroup caption="Events">
+                                <property key="onClick" type="action" required="false">
+                                    <caption>On click</caption>
+                                    <description/>
+                                </property>
+                            </propertyGroup>
                         </propertyGroup>
-                        <propertyGroup caption="Callout box">
-                            <property key="title" type="textTemplate" required="false">
-                                <caption>Title</caption>
-                                <description/>
-                            </property>
-                            <property key="description" type="textTemplate" required="false">
-                                <caption>Description</caption>
-                                <description/>
-                            </property>
+                        <propertyGroup caption="Appearance">
+                            <propertyGroup caption="Custom icon">
+                                <property key="icon" type="icon" required="false">
+                                    <caption>Icon</caption>
+                                    <description/>
+                                </property>
+                                <property key="iconSize" type="integer" defaultValue="32">
+                                    <caption>Size</caption>
+                                    <description/>
+                                </property>
+                            </propertyGroup>
+                            <propertyGroup caption="Color">
+                                <property key="iconColor" type="string" required="false">
+                                    <caption>Marker</caption>
+                                    <description>Overrides the default color provided through design properties. Not supported for custom images.</description>
+                                </property>
+                            </propertyGroup>
                         </propertyGroup>
-                        <propertyGroup caption="Events">
-                            <property key="onClick" type="action" required="false">
-                                <caption>On click</caption>
-                                <description>To enable the click event the map 'Interactive' property should be set to 'Yes'.</description>
-                            </property>
+                    </properties>
+                </property>
+                <property key="dynamicMarkers" type="object" isList="true" required="false">
+                    <caption>Marker list</caption>
+                    <description>A list of markers showing dynamic locations on the map.</description>
+                    <properties>
+                        <propertyGroup caption="Locations">
+                            <propertyGroup caption="Location">
+                                <property key="markersDS" type="datasource" isList="true" required="false">
+                                    <caption>Data source</caption>
+                                    <description/>
+                                </property>
+                                <property key="locationType" type="enumeration" defaultValue="address">
+                                    <caption>Location</caption>
+                                    <description/>
+                                    <enumerationValues>
+                                        <enumerationValue key="address">Based on address</enumerationValue>
+                                        <enumerationValue key="latlng">Based on latitude and longitude</enumerationValue>
+                                    </enumerationValues>
+                                </property>
+                                <property key="address" type="attribute" dataSource="markersDS"
+                                          required="false">
+                                    <caption>Address</caption>
+                                    <description>Address containing (a subset of) street, number, zipcode, city and country.</description>
+                                    <attributeTypes>
+                                        <attributeType name="String"/>
+                                    </attributeTypes>
+                                </property>
+                                <property key="latitude" type="attribute" dataSource="markersDS"
+                                          required="false">
+                                    <caption>Latitude</caption>
+                                    <description>Decimal number from -90.0 to 90.0.</description>
+                                    <attributeTypes>
+                                        <attributeType name="Decimal"/>
+                                    </attributeTypes>
+                                </property>
+                                <property key="longitude" type="attribute" dataSource="markersDS"
+                                          required="false">
+                                    <caption>Longitude</caption>
+                                    <description>Decimal number from -180.0 to 180.0.</description>
+                                    <attributeTypes>
+                                        <attributeType name="Decimal"/>
+                                    </attributeTypes>
+                                </property>
+                            </propertyGroup>
+                            <propertyGroup caption="Callout box">
+                                <property key="title" type="attribute" dataSource="markersDS" required="false">
+                                    <caption>Title</caption>
+                                    <description>Title displayed when clicking the marker.</description>
+                                    <attributeTypes>
+                                        <attributeType name="String"/>
+                                    </attributeTypes>
+                                </property>
+                                <property key="description" type="attribute" dataSource="markersDS" required="false">
+                                    <caption>Description</caption>
+                                    <description>Description displayed when clicking the marker.</description>
+                                    <attributeTypes>
+                                        <attributeType name="String"/>
+                                    </attributeTypes>
+                                </property>
+                            </propertyGroup>
+                            <propertyGroup caption="Events">
+                                <property key="onClick" type="action" dataSource="markersDS" required="false">
+                                    <caption>On click</caption>
+                                    <description/>
+                                </property>
+                            </propertyGroup>
                         </propertyGroup>
-                    </propertyGroup>
-                    <propertyGroup caption="Appearance">
-                        <propertyGroup caption="Custom icon">
-                            <property key="icon" type="icon" required="false">
-                                <caption>Icon</caption>
-                                <description/>
-                            </property>
-                            <property key="iconSize" type="integer" defaultValue="32">
-                                <caption>Size</caption>
-                                <description/>
-                            </property>
+                        <propertyGroup caption="Appearance">
+                            <propertyGroup caption="Custom icon">
+                                <property key="icon" type="icon" required="false">
+                                    <caption>Icon</caption>
+                                    <description/>
+                                </property>
+                                <property key="iconSize" type="integer" defaultValue="32">
+                                    <caption>Size</caption>
+                                    <description/>
+                                </property>
+                            </propertyGroup>
+                            <propertyGroup caption="Color">
+                                <property key="iconColor" type="string" required="false">
+                                    <caption>Marker</caption>
+                                    <description>Overrides the default color provided through design properties. Not supported for custom images.</description>
+                                </property>
+                            </propertyGroup>
                         </propertyGroup>
-                        <propertyGroup caption="Color">
-                            <property key="color" type="string" required="false">
-                                <caption>Marker</caption>
-                                <description>Overrides the default color provided through design properties. Not supported for custom images.</description>
-                            </property>
-                        </propertyGroup>
-                    </propertyGroup>
-                </properties>
-            </property>
+                    </properties>
+                </property>
+            </propertyGroup>
+        </propertyGroup>
+        <propertyGroup caption="Appearance">
+            <propertyGroup caption="Custom icon">
+                <property key="icon" type="icon" required="false">
+                    <caption>Icon</caption>
+                    <description/>
+                </property>
+                <property key="iconSize" type="integer" defaultValue="32">
+                    <caption>Size</caption>
+                    <description/>
+                </property>
+            </propertyGroup>
+            <propertyGroup caption="Color">
+                <property key="color" type="string" required="false">
+                    <caption>Marker</caption>
+                    <description>Overrides the default color provided through design properties. Not supported for custom images.</description>
+                </property>
+            </propertyGroup>
         </propertyGroup>
         <propertyGroup caption="View">
             <propertyGroup caption="Automatic">
@@ -74,17 +191,17 @@
             </propertyGroup>
             <propertyGroup caption="Default center">
                 <property key="centerAddress" type="expression" required="false">
-                    <caption>Address </caption>
+                    <caption>Address</caption>
                     <description>When latitude and longitude are provided, the address is ignored.</description>
                     <returnType type="String"/>
                 </property>
                 <property key="centerLatitude" type="expression" required="false">
-                    <caption>Latitude </caption>
+                    <caption>Latitude</caption>
                     <description/>
                     <returnType type="Decimal"/>
                 </property>
                 <property key="centerLongitude" type="expression" required="false">
-                    <caption>Longitude </caption>
+                    <caption>Longitude</caption>
                     <description/>
                     <returnType type="Decimal"/>
                 </property>
@@ -104,7 +221,7 @@
                     </enumerationValues>
                 </property>
                 <property key="minZoomLevel" type="enumeration" defaultValue="world">
-                    <caption>Minimum </caption>
+                    <caption>Minimum</caption>
                     <description/>
                     <enumerationValues>
                         <enumerationValue key="world">World</enumerationValue>
@@ -117,7 +234,7 @@
                     </enumerationValues>
                 </property>
                 <property key="maxZoomLevel" type="enumeration" defaultValue="building">
-                    <caption>Maximum </caption>
+                    <caption>Maximum</caption>
                     <description/>
                     <enumerationValues>
                         <enumerationValue key="world">World</enumerationValue>

--- a/packages/pluggableWidgets/maps-native/src/package.xml
+++ b/packages/pluggableWidgets/maps-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Maps" version="2.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Maps" version="2.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Maps.xml"/>
         </widgetFiles>

--- a/packages/pluggableWidgets/maps-native/src/ui/Styles.ts
+++ b/packages/pluggableWidgets/maps-native/src/ui/Styles.ts
@@ -16,7 +16,9 @@ export interface MapsStyle extends Style {
 }
 
 export const defaultMapsStyle: MapsStyle = {
-    container: {},
+    container: {
+        minHeight: 50
+    },
     loadingOverlay: {
         position: "absolute",
         top: 0,

--- a/packages/pluggableWidgets/maps-native/src/util/data.ts
+++ b/packages/pluggableWidgets/maps-native/src/util/data.ts
@@ -1,0 +1,52 @@
+import { ObjectItem, ValueStatus } from "mendix";
+import { DynamicMarkersType, MarkersType } from "../../typings/MapsProps";
+import { ModeledMarker } from "../../typings/shared";
+
+export declare type Option<T> = T | undefined;
+
+export function convertStaticModeledMarker(marker: MarkersType): ModeledMarker {
+    return {
+        address: marker.address?.value,
+        latitude: Number(marker.latitude?.value),
+        longitude: Number(marker.longitude?.value),
+        title: marker.title?.value,
+        description: marker.description?.value,
+        onClick: marker.onClick?.execute,
+        icon: marker.icon?.value,
+        iconSize: Number(marker.iconSize),
+        iconColor: marker.iconColor
+    };
+}
+
+export function convertDynamicModeledMarker(marker: DynamicMarkersType): ModeledMarker[] {
+    if (marker.markersDS && marker.markersDS.status === ValueStatus.Available) {
+        return marker.markersDS.items?.map(item => fromDatasource(marker, item)) ?? [];
+    }
+    return [];
+}
+
+function fromDatasource(marker: DynamicMarkersType, item: ObjectItem): ModeledMarker {
+    const {
+        locationType,
+        address,
+        latitude,
+        longitude,
+        onClick,
+        title,
+        description,
+        icon,
+        iconSize,
+        iconColor
+    } = marker;
+    return {
+        address: locationType === "address" && address ? address.get(item).value : undefined,
+        latitude: locationType === "latlng" && latitude ? Number(latitude.get(item).value) : undefined,
+        longitude: locationType === "latlng" && longitude ? Number(longitude.get(item).value) : undefined,
+        title: title ? title.get(item).value : "",
+        description: description ? description.get(item).value : "",
+        onClick: onClick ? onClick.get(item).execute : undefined,
+        icon: icon ? icon.value : undefined,
+        iconSize: iconSize ? Number(iconSize) : undefined,
+        iconColor: iconColor ? iconColor : undefined
+    };
+}

--- a/packages/pluggableWidgets/maps-native/typings/MapsProps.d.ts
+++ b/packages/pluggableWidgets/maps-native/typings/MapsProps.d.ts
@@ -3,19 +3,38 @@
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
-import { ActionValue, DynamicValue, NativeIcon } from "mendix";
+import { ActionValue, DynamicValue, ListValue, NativeIcon, ListActionValue, ListAttributeValue } from "mendix";
 import { Big } from "big.js";
 
+export type LocationTypeEnum = "address" | "latlng";
+
 export interface MarkersType {
+    locationType: LocationTypeEnum;
     address?: DynamicValue<string>;
-    latitude?: DynamicValue<Big>;
-    longitude?: DynamicValue<Big>;
+    latitude?: DynamicValue<string>;
+    longitude?: DynamicValue<string>;
     title?: DynamicValue<string>;
     description?: DynamicValue<string>;
     onClick?: ActionValue;
     icon?: DynamicValue<NativeIcon>;
     iconSize: number;
-    color: string;
+    iconColor: string;
+}
+
+export type LocationTypeEnum = "address" | "latlng";
+
+export interface DynamicMarkersType {
+    markersDS?: ListValue;
+    locationType: LocationTypeEnum;
+    address?: ListAttributeValue<string>;
+    latitude?: ListAttributeValue<Big>;
+    longitude?: ListAttributeValue<Big>;
+    title?: ListAttributeValue<string>;
+    description?: ListAttributeValue<string>;
+    onClick?: ListActionValue;
+    icon?: DynamicValue<NativeIcon>;
+    iconSize: number;
+    iconColor: string;
 }
 
 export type DefaultZoomLevelEnum = "world" | "continent" | "country" | "city" | "town" | "streets" | "building";
@@ -29,6 +48,7 @@ export type MapTypeEnum = "standard" | "satellite";
 export type ProviderEnum = "default" | "google";
 
 export interface MarkersPreviewType {
+    locationType: LocationTypeEnum;
     address: string;
     latitude: string;
     longitude: string;
@@ -37,13 +57,31 @@ export interface MarkersPreviewType {
     onClick: {} | null;
     icon: { type: "glyph"; iconClass: string; } | { type: "image"; imageUrl: string; } | null;
     iconSize: number | null;
-    color: string;
+    iconColor: string;
+}
+
+export interface DynamicMarkersPreviewType {
+    markersDS: {} | null;
+    locationType: LocationTypeEnum;
+    address: string;
+    latitude: string;
+    longitude: string;
+    title: string;
+    description: string;
+    onClick: {} | null;
+    icon: { type: "glyph"; iconClass: string; } | { type: "image"; imageUrl: string; } | null;
+    iconSize: number | null;
+    iconColor: string;
 }
 
 export interface MapsProps<Style> {
     name: string;
     style: Style[];
     markers: MarkersType[];
+    dynamicMarkers: DynamicMarkersType[];
+    icon?: DynamicValue<NativeIcon>;
+    iconSize: number;
+    color: string;
     fitToMarkers: boolean;
     centerAddress?: DynamicValue<string>;
     centerLatitude?: DynamicValue<Big>;
@@ -61,6 +99,10 @@ export interface MapsPreviewProps {
     class: string;
     style: string;
     markers: MarkersPreviewType[];
+    dynamicMarkers: DynamicMarkersPreviewType[];
+    icon: { type: "glyph"; iconClass: string; } | { type: "image"; imageUrl: string; } | null;
+    iconSize: number | null;
+    color: string;
     fitToMarkers: boolean;
     centerAddress: string;
     centerLatitude: string;

--- a/packages/pluggableWidgets/maps-native/typings/MapsProps.d.ts
+++ b/packages/pluggableWidgets/maps-native/typings/MapsProps.d.ts
@@ -11,8 +11,8 @@ export type LocationTypeEnum = "address" | "latlng";
 export interface MarkersType {
     locationType: LocationTypeEnum;
     address?: DynamicValue<string>;
-    latitude?: DynamicValue<string>;
-    longitude?: DynamicValue<string>;
+    latitude?: DynamicValue<Big>;
+    longitude?: DynamicValue<Big>;
     title?: DynamicValue<string>;
     description?: DynamicValue<string>;
     onClick?: ActionValue;

--- a/packages/pluggableWidgets/maps-native/typings/MapsProps.d.ts
+++ b/packages/pluggableWidgets/maps-native/typings/MapsProps.d.ts
@@ -79,9 +79,6 @@ export interface MapsProps<Style> {
     style: Style[];
     markers: MarkersType[];
     dynamicMarkers: DynamicMarkersType[];
-    icon?: DynamicValue<NativeIcon>;
-    iconSize: number;
-    color: string;
     fitToMarkers: boolean;
     centerAddress?: DynamicValue<string>;
     centerLatitude?: DynamicValue<Big>;
@@ -100,9 +97,6 @@ export interface MapsPreviewProps {
     style: string;
     markers: MarkersPreviewType[];
     dynamicMarkers: DynamicMarkersPreviewType[];
-    icon: { type: "glyph"; iconClass: string; } | { type: "image"; imageUrl: string; } | null;
-    iconSize: number | null;
-    color: string;
     fitToMarkers: boolean;
     centerAddress: string;
     centerLatitude: string;

--- a/packages/pluggableWidgets/maps-native/typings/shared.d.ts
+++ b/packages/pluggableWidgets/maps-native/typings/shared.d.ts
@@ -1,0 +1,20 @@
+
+export interface ModeledMarker {
+    address?: string;
+    latitude?: number;
+    longitude?: number;
+    title?: string;
+    description?: string;
+    onClick?: ActionValue;
+    icon?: NativeIcon | GlyphIcon;
+    iconSize?: number;
+    iconColor?: string;
+}
+
+export interface Marker {
+    latitude: number;
+    longitude: number;
+    url: string;
+    onClick?: ActionValue;
+    title?: string;
+}

--- a/packages/theming/atlas/src/themesource/atlas_core/native/core/helpers/maps.ts
+++ b/packages/theming/atlas/src/themesource/atlas_core/native/core/helpers/maps.ts
@@ -38,6 +38,7 @@ export const mapsSquare = {
 export const mapsMaxSpace = {
     container: {
         flex: 1,
+        minHeight: 50,
         aspectRatio: undefined
     }
 };

--- a/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
@@ -1,6 +1,6 @@
 import fg from "fast-glob";
 import { readJson, writeJson } from "fs-extra";
-import { existsSync, join } from "fs";
+import { existsSync } from "fs";
 import { dirname, join } from "path";
 import copy from "recursive-copy";
 import { promisify } from "util";

--- a/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
@@ -1,7 +1,7 @@
 import fg from "fast-glob";
 import { readJson, writeJson } from "fs-extra";
 import { existsSync } from "fs";
-import { dirname, join } from "path";
+import { basename, dirname, join } from "path";
 import copy from "recursive-copy";
 import { promisify } from "util";
 import resolve from "resolve";
@@ -69,7 +69,9 @@ async function resolvePackage(target, sourceDir) {
         let targetPackagePath = await promisify(resolve)(join(targetPackage, "package.json"), { basedir: sourceDir });
         return dirname(targetPackagePath);
     } catch (e) {
-        if (e.message.includes("Cannot find module")) throw e;
+        if (e.message.includes("Cannot find module") && !basename(targetPackage).test(/^.+\.{js|jsx|ts|tsx|json}$/)) {
+            throw e;
+        }
         return undefined;
     }
 }

--- a/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
@@ -66,8 +66,10 @@ async function resolvePackage(target, sourceDir) {
     const targetParts = target.split("/");
     const targetPackage = targetParts[0].startsWith("@") ? `${targetParts[0]}/${targetParts[1]}` : targetParts[0];
     try {
-        return dirname(await promisify(resolve)(`${targetPackage}/package.json`, { basedir: sourceDir }));
+        let targetPackagePath = await promisify(resolve)(`${targetPackage}/package.json`, { basedir: sourceDir });
+        return dirname(targetPackagePath);
     } catch (e) {
+        if (e.message.includes("Cannot find module")) throw e;
         return undefined;
     }
 }
@@ -86,7 +88,8 @@ async function getTransitiveDependencies(packagePath, isExternal) {
         }
         result.add(nextPath);
 
-        const packageJson = await readJson(join(nextPath, "package.json"));
+        const packageJsonPath = join(nextPath, "package.json");
+        const packageJson = await readJson(packageJsonPath);
         const dependencies = (packageJson.dependencies ? Object.keys(packageJson.dependencies) : []).concat(
             packageJson.peerDependencies ? Object.keys(packageJson.peerDependencies) : []
         );

--- a/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
@@ -1,6 +1,6 @@
 import fg from "fast-glob";
 import { readJson, writeJson } from "fs-extra";
-import { existsSync } from "fs";
+import { existsSync, join } from "fs";
 import { dirname, join } from "path";
 import copy from "recursive-copy";
 import { promisify } from "util";
@@ -66,7 +66,7 @@ async function resolvePackage(target, sourceDir) {
     const targetParts = target.split("/");
     const targetPackage = targetParts[0].startsWith("@") ? `${targetParts[0]}/${targetParts[1]}` : targetParts[0];
     try {
-        let targetPackagePath = await promisify(resolve)(`${targetPackage}/package.json`, { basedir: sourceDir });
+        let targetPackagePath = await promisify(resolve)(join(targetPackage, "package.json"), { basedir: sourceDir });
         return dirname(targetPackagePath);
     } catch (e) {
         if (e.message.includes("Cannot find module")) throw e;

--- a/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
@@ -69,7 +69,7 @@ async function resolvePackage(target, sourceDir) {
         let targetPackagePath = await promisify(resolve)(join(targetPackage, "package.json"), { basedir: sourceDir });
         return dirname(targetPackagePath);
     } catch (e) {
-        if (e.message.includes("Cannot find module") && !basename(targetPackage).test(/^.+\.{js|jsx|ts|tsx|json}$/)) {
+        if (e.message.includes("Cannot find module") && !basename(targetPackage).test(/\.((j|t)sx?)|json|(pn|jpe?|sv)g|(tif|gi)f$/g)) {
             throw e;
         }
         return undefined;

--- a/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
@@ -68,7 +68,7 @@ async function resolvePackage(target, sourceDir) {
     try {
         return dirname(await promisify(resolve)(join(targetPackage, "package.json"), { basedir: sourceDir }));
     } catch (e) {
-        if (e.message.includes("Cannot find module") && targetPackage.test(/\.((j|t)sx?)|json|(pn|jpe?|sv)g|(tif|gi)f$/g)) {
+        if (e.message.includes("Cannot find module") && /\.((j|t)sx?)|json|(pn|jpe?|sv)g|(tif|gi)f$/g.test(targetPackage)) {
             throw e;
         }
         return undefined;

--- a/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
@@ -68,7 +68,7 @@ async function resolvePackage(target, sourceDir) {
     try {
         return dirname(await promisify(resolve)(join(targetPackage, "package.json"), { basedir: sourceDir }));
     } catch (e) {
-        if (e.message.includes("Cannot find module") && /\.((j|t)sx?)|json|(pn|jpe?|sv)g|(tif|gi)f$/g.test(targetPackage)) {
+        if (e.message.includes("Cannot find module") && !/\.((j|t)sx?)|json|(pn|jpe?|sv)g|(tif|gi)f$/g.test(targetPackage)) {
             throw e;
         }
         return undefined;

--- a/packages/tools/pluggable-widgets-tools/scripts/e2e.js
+++ b/packages/tools/pluggable-widgets-tools/scripts/e2e.js
@@ -87,13 +87,12 @@ async function main() {
         .toString()
         .trim();
 
-    // Spin up the standalone selenium firefox
-    const freePortFirefox = await findFreePort(4444);
-    const firefoxContainerId = execSync(
-        `docker run -d -p ${freePortFirefox}:4444 -v /dev/shm:/dev/shm selenium/standalone-firefox`
+     // Spin up the standalone selenium docker image
+    const freePortBrowser = await findFreePort(4444);
+    const browserDocker = process.env.BROWSER_DOCKER || "selenium/standalone-firefox:88.0";
+    const browserContainerId = execSync(
+        `docker run -d -p ${freePortBrowser}:4444 -v /dev/shm:/dev/shm ${browserDocker}`
     )
-        .toString()
-        .trim();
 
     let attempts = 60;
     for (; attempts > 0; --attempts) {
@@ -118,7 +117,7 @@ async function main() {
                 ...process.env,
                 URL: `http://${ip}:${freePort}`,
                 SERVER_IP: ip,
-                SERVER_PORT: freePortFirefox
+                SERVER_PORT: freePortBrowser
             }
         });
     } catch (e) {
@@ -129,7 +128,7 @@ async function main() {
         throw e;
     } finally {
         execSync(`docker rm -f ${runtimeContainerId}`);
-        execSync(`docker rm -f ${firefoxContainerId}`);
+        execSync(`docker rm -f ${browserContainerId}`);
     }
 }
 

--- a/packages/tools/pluggable-widgets-tools/scripts/e2e.js
+++ b/packages/tools/pluggable-widgets-tools/scripts/e2e.js
@@ -93,6 +93,8 @@ async function main() {
     const browserContainerId = execSync(
         `docker run -d -p ${freePortBrowser}:4444 -v /dev/shm:/dev/shm ${browserDocker}`
     )
+        .toString()
+        .trim();
 
     let attempts = 60;
     for (; attempts > 0; --attempts) {


### PR DESCRIPTION


## Checklist
- Contains unit tests ❌
- Contains breaking changes ✅
- Contains Atlas changes  ✅ 
- Compatible with: MX 9️⃣

#### Native specific
- Works in Android ✅
- Works in iOS ✅
- Works in Tablet ✅

## This PR contains
- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
- Enable the users to add markers from a datasource.
- To fix the following issues:

> - Default zoom level is not considered at all although there is a single marker. Minimum seems to be the toggle that handles zoom level
> - Default center also not seem to work
> - When map size set to max space, it is important to set height of the surrounding container. Otherwise it wont be shown. Document this.


## Relevant changes
New properties have been added.
The coordinates for setting the initial center have been updated.
A minHeight of 50 has been added so the widget will always be visible.

## What should be covered while testing?
Check if all marker properties work on all devices.
Check if the above mentioned issues are fixed
