### PR TITLE
[WC-381] Widget generator:  fix NPM v7.x.x peer dependency install issue

### DIFF
--- a/packages/tools/generator-widget/CHANGELOG.md
+++ b/packages/tools/generator-widget/CHANGELOG.md
@@ -4,11 +4,9 @@ All notable changes to this widget will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## Changed
-- Set required node version to v12 or higher.
-
 ### Fixed
 - Fixes failing `npm install` executions when scaffolding a widget project with the widget generator with NPM v7.x.x.
 - Explains users in the readme of generated widget project how to install dependencies with NPM v7.x.x.
+- Set required Node.js version to v12 or higher for the generator itself and the generated widget projects, since Node.js v10 is EOL at the end of April 2021 and pluggable widgets tools requires Node.js v12.
 
 ## [major.minor.patch] - YYYY-MM-DD

--- a/packages/tools/generator-widget/CHANGELOG.md
+++ b/packages/tools/generator-widget/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Fixed
 - Fixes failing `npm install` executions when scaffolding a widget project with the widget generator with NPM v7.x.x.
-- Explains users in the readme of generated widget project how to install dependencies with NPM v7.x.x.
+- Explains users in the README of generated widget project how to install dependencies with NPM v7.x.x.
 - Set required Node.js version to v12 or higher for the generator itself and the generated widget projects, since Node.js v10 is EOL at the end of April 2021 and pluggable widgets tools requires Node.js v12.
 
 ## [major.minor.patch] - YYYY-MM-DD

--- a/packages/tools/generator-widget/CHANGELOG.md
+++ b/packages/tools/generator-widget/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this widget will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## Changed
+- Set required node version to v12 or higher.
+
+### Fixed
+- Fixes failing `npm install` executions when scaffolding a widget project with the widget generator with NPM v7.x.x.
+- Explains users in the readme of generated widget project how to install dependencies with NPM v7.x.x.
+
+## [major.minor.patch] - YYYY-MM-DD

--- a/packages/tools/generator-widget/README.md
+++ b/packages/tools/generator-widget/README.md
@@ -15,7 +15,7 @@ This generator uses the Yeoman scaffolding tool to let you quickly create a [Men
 
 ## Installation
 
-1. Install [node.js](https://nodejs.org/) (version >= 10.15).
+1. Install [node.js](https://nodejs.org/) (version >= 12).
 1. Install [Yeoman](http://yeoman.io):
 
     ```bash

--- a/packages/tools/generator-widget/generators/app/index.js
+++ b/packages/tools/generator-widget/generators/app/index.js
@@ -61,7 +61,7 @@ class MxGenerator extends Generator {
 
     install() {
         this.log(text.INSTALL_FINISH_MSG);
-        this.npmInstall();
+        this.npmInstall(undefined, { legacyPeerDeps: true });
     }
 
     async end() {

--- a/packages/tools/generator-widget/generators/app/templates/commons/README.md.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/commons/README.md.ejs
@@ -14,4 +14,11 @@
 [link to GitHub issues]
 
 ## Development and contribution
-[specify contribute]
+
+1. Install NPM package dependencies by using: `npm install`. If you use NPM v7.x.x, which can be checked by executing `npm -v`, execute: `npm install --legacy-peer-deps`.
+1. Run `npm start` to watch for code changes. On every change:
+    - the widget will be bundled;
+    - the bundle will be included in a `dist` folder in the root directory of the project;
+    - the bundle will be included in the `deployment` and `widgets` folder of the Mendix test project.
+
+[specify contribution]

--- a/packages/tools/generator-widget/generators/app/templates/packages/package_native.json.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/packages/package_native.json.ejs
@@ -5,6 +5,9 @@
   "description": "<%- description %>",
   "copyright": "<%- copyright %>",
   "author": "<%- author %>",
+  "engines": {
+    "node": ">=12"
+  },
   "config": {
     "projectPath": "<%- projectPath %>/"
   },

--- a/packages/tools/generator-widget/generators/app/templates/packages/package_web.json.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/packages/package_web.json.ejs
@@ -5,6 +5,9 @@
   "description": "<%- description %>",
   "copyright": "<%- copyright %>",
   "author": "<%- author %>",
+  "engines": {
+    "node": ">=12"
+  },
   "config": {
     "projectPath": "<%- projectPath %>/",
     "mendixHost": "http://localhost:8080",

--- a/packages/tools/generator-widget/package.json
+++ b/packages/tools/generator-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/generator-widget",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "Mendix Pluggable Widgets Generator",
   "license": "Apache-2.0",
   "copyright": "2020 Mendix Technology B.V.",
@@ -24,7 +24,7 @@
     "scaffold"
   ],
   "engines": {
-    "node": ">=10.15"
+    "node": ">=12"
   },
   "bugs": {
     "url": "https://github.com/mendix/widgets-resources/issues"

--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -8,6 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Set required node version to v12 or higher.
 
 ### Fixed
-- Note in the readme file that installation with NPM v7.x.x requires the flag `--legacy-peer-deps`.
+- Note in the README file that installation with NPM v7.x.x requires the flag `--legacy-peer-deps`.
 
 ## [major.minor.patch] - YYYY-MM-DD

--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this widget will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## Changed
+- Set required node version to v12 or higher.
+
+### Fixed
+- Note in the readme file that installation with NPM v7.x.x requires the flag `--legacy-peer-deps`.
+
+## [major.minor.patch] - YYYY-MM-DD

--- a/packages/tools/pluggable-widgets-tools/README.md
+++ b/packages/tools/pluggable-widgets-tools/README.md
@@ -13,7 +13,8 @@ A toolset to build, test, format, run, release and lint your [Pluggable Widgets]
 
 ## How to install
 
-Install via npm using `npm install @mendix/pluggable-widgets-tools` (use [node.js](https://nodejs.org/) version >= 12.20.1). Even better is creating your widget using [Pluggable Widgets Generator](https://www.npmjs.com/package/@mendix/generator-widget) which scaffolds the correct project setup.
+Install via NPM using `npm install @mendix/pluggable-widgets-tools` (use [node.js](https://nodejs.org/) version >= 12). When installing via NPM v7.x.x, use `npm install @mendix/pluggable-widgets-tools --legacy-peer-deps`.
+Even better is creating your widget using [Pluggable Widgets Generator](https://www.npmjs.com/package/@mendix/generator-widget) which scaffolds the correct project setup.
 
 ## How to use
 

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -19,7 +19,7 @@
     "mendix"
   ],
   "engines": {
-    "node": ">=12.20.1"
+    "node": ">=12"
   },
   "files": [
     "bin",


### PR DESCRIPTION
## Checklist
- Contains script tests ✅ 
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
This PR fixes failing `npm install` executions when scaffolding a widget project with the widget generator with NPM v7.x.x. It also explains users in the readme of generated widget projects how to install dependencies with NPM v7.x.x. 

These failures occur due to NPM v7.x.x installing peer dependencies inside the `node_modules` folder. Not all dependencies inside pluggable-widgets-tools share the same React dependency leading into an unresolvable dependency tree.

## Relevant changes
- Execute `npm install` with the command line flag `--legacy-peer-deps`. This ensures pluggable-widgets-tools dependencies install correctly with NPM v7.x.x. The flag is ignored by lower versions of NPM.
- Add in the readme template details about the development steps including installing dependencies with NPM v7.x.x.
- Set required node version for generator and PIW tools to v12 or higher.
- Note in the readme file for PIW tools that installation with NPM v7.x.x requires the flag.

## What should be covered while testing?
- Scaffold a widget project with the generator with npm v6 and v7. Verify that both succeed.