### PR TITLE
[WC-381] Widget generator: fix NPM v7.x.x peer dependency install issue (backport)

### DIFF
--- a/packages/tools/generator-widget/README.md
+++ b/packages/tools/generator-widget/README.md
@@ -13,73 +13,54 @@
 
 This generator uses the Yeoman scaffolding tool to let you quickly create a [Mendix Pluggable Widget](https://docs.mendix.com/howto/extensibility/pluggable-widgets).
 
----
-
 ## Installation
 
-First, install [Yeoman](http://yeoman.io) and @mendix/widget using [npm](https://www.npmjs.com/) (we assume you have pre-installed [node.js](https://nodejs.org/)).
+1. Install [node.js](https://nodejs.org/) (version >= 12).
+1. Install [Yeoman](http://yeoman.io):
 
-```bash
-npm install -g yo
-npm install -g @mendix/generator-widget
-```
+    ```bash
+    npm install -g yo
+    ```
 
----
+1. Install Pluggable Widgets Generator:
 
-Then generate your new project inside an empty folder:
+    ```bash
+    npm install -g @mendix/generator-widget
+    ```
 
-```bash
-yo @mendix/widget
-```
+## Scaffold a widget project
 
-or automatically create the folder using:
+1. Generate your new project inside an empty folder:
 
-```bash
-yo @mendix/widget widget name
-```
+    ```bash
+    yo @mendix/widget
+    ```
 
-## Scaffold a widget
+    or automatically create the folder using:
 
-### 1. Provide the following information about your widget:
+    ```bash
+    yo @mendix/widget MyWidgetName
+    ```
 
-The following information needs to be provided about your widget:
+    Note that `MyWidgetName` can consist of space characters as well.
 
--   name
--   description
--   organization
--   copyright
--   license
--   version
--   author
--   Mendix Project path
--   programming language
--   platform
+1. Provide the following information about your widget project (press <Enter> if you want to skip and use the default values):
 
-Press <Enter> if you want to skip and use default values.
+    - Widget name
+    - Description
+    - Organization
+    - Copyright
+    - License
+    - Version
+    - Author
+    - Mendix project path
+    - Programming language
+    - Platform
+    - Template
+    - Add unit tests
+    - Add end to end tests
 
-### 2.1. Using the task runner
-
-The widget generator will include the necessary files and tasks to your package.json for running the tasks over The Pluggable Widgets Tools.
-
-If necessary you can run the tasks using the commands
-
-```bash
-npm start
-```
-
-```bash
-npm run build
-```
-
-```bash
-npm run release
-```
-
----
-
-For more information, visit our [Mendix Pluggable Widget Tools repository](https://github.com/mendix/widgets-resources/tree/master/packages/tools/pluggable-widgets-tools).
-
-### 2.2. Which template do you want to use for the widget?
+### Template
 
 #### Full boilerplate
 
@@ -94,27 +75,43 @@ It has the following features:
 
 The empty template is a Mendix React hello world widget recommended for more experienced developers.
 
-### 2.3 Add unit tests for the widget ?
+### Add unit tests
 
 If `Yes` is selected, unit tests are included to ensure individual units of the component are tested to determine whether they are fit for use. Default value is `No`.
 
-### 2.4 Add end to end tests for the widget ?
+### Add end to end tests
 
-If Yes is selected, end to end tests are included to ensure that the integrated components of an application function as expected. Default value is `No`.
+If `Yes` is selected, end to end tests are included to ensure that the integrated components of an application function as expected. Default value is `No`.
 
 Note: Both `Unit` and `End to end` tests apply only to the Full Boilerplate. `End to End` is exclusive for web and hybrid mobile apps.
 
 The tool will then create copied files, and run `npm install` to install development dependencies.
 
-### NOTE
+## Using the task runner
 
-To use the webpack-dev-server while developing:
+The widget generator will include the necessary files and tasks to your package.json for running the tasks over the [Pluggable Widgets Tools](https://github.com/mendix/widgets-resources/tree/master/packages/tools/pluggable-widgets-tools).
 
--   Start Mendix Studio Pro from your Mendix project path or by default `/dist/MxTestProject` and run:
+If necessary you can run the tasks using the commands:
 
 ```bash
 npm start
 ```
+
+```bash
+npm run build
+```
+
+```bash
+npm run release
+```
+
+## Note
+
+-   To build and watch for source code changes while developing, run the Mendix project located at the specified `Mendix project path` and run:
+
+    ```bash
+    npm start
+    ```
 
 -   If you are running the generator through multiple operating systems (e.g. running a virtualized OS with Parallels on MacOS or any other virtualization software), make sure you have the right privileges and use the same OS for generation and file manipulation.
 

--- a/packages/tools/generator-widget/generators/app/index.js
+++ b/packages/tools/generator-widget/generators/app/index.js
@@ -61,7 +61,7 @@ class MxGenerator extends Generator {
 
     install() {
         this.log(text.INSTALL_FINISH_MSG);
-        this.npmInstall();
+        this.npmInstall(undefined, { legacyPeerDeps: true });
     }
 
     async end() {

--- a/packages/tools/generator-widget/generators/app/templates/commons/README.md.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/commons/README.md.ejs
@@ -14,4 +14,11 @@
 [link to GitHub issues]
 
 ## Development and contribution
-[specify contribute]
+
+1. Install NPM package dependencies by using: `npm install`. If you use NPM v7.x.x, which can be checked by executing `npm -v`, execute: `npm install --legacy-peer-deps`.
+1. Run `npm start` to watch for code changes. On every change:
+    - the widget will be bundled;
+    - the bundle will be included in a `dist` folder in the root directory of the project;
+    - the bundle will be included in the `deployment` and `widgets` folder of the Mendix test project.
+
+[specify contribution]

--- a/packages/tools/generator-widget/generators/app/templates/packages/package_native.json.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/packages/package_native.json.ejs
@@ -5,6 +5,9 @@
   "description": "<%- description %>",
   "copyright": "<%- copyright %>",
   "author": "<%- author %>",
+  "engines": {
+    "node": ">=12"
+  },
   "config": {
     "projectPath": "<%- projectPath %>/"
   },

--- a/packages/tools/generator-widget/generators/app/templates/packages/package_web.json.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/packages/package_web.json.ejs
@@ -5,6 +5,9 @@
   "description": "<%- description %>",
   "copyright": "<%- copyright %>",
   "author": "<%- author %>",
+  "engines": {
+    "node": ">=12"
+  },
   "config": {
     "projectPath": "<%- projectPath %>/",
     "mendixHost": "http://localhost:8080",

--- a/packages/tools/generator-widget/package.json
+++ b/packages/tools/generator-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/generator-widget",
-  "version": "8.14.0",
+  "version": "8.18.0",
   "description": "Mendix Pluggable Widgets Generator",
   "license": "Apache-2.0",
   "copyright": "2020 Mendix Technology B.V.",
@@ -24,7 +24,7 @@
     "scaffold"
   ],
   "engines": {
-    "node": ">=10.15"
+    "node": ">=12"
   },
   "bugs": {
     "url": "https://github.com/mendix/widgets-resources/issues"

--- a/packages/tools/pluggable-widgets-tools/README.md
+++ b/packages/tools/pluggable-widgets-tools/README.md
@@ -13,7 +13,8 @@ A toolset to build, test, format, run, release and lint your [Pluggable Widgets]
 
 ## How to install
 
-Install from npm using `npm install @mendix/pluggable-widgets-tools`. Or better create your widget using [Pluggable Widgets Generator](https://www.npmjs.com/package/@mendix/generator-widget) that scaffolds the correct project setup.
+Install via NPM using `npm install @mendix/pluggable-widgets-tools` (use [node.js](https://nodejs.org/) version >= 12). When installing via NPM v7.x.x, use `npm install @mendix/pluggable-widgets-tools --legacy-peer-deps`.
+Even better is creating your widget using [Pluggable Widgets Generator](https://www.npmjs.com/package/@mendix/generator-widget) which scaffolds the correct project setup.
 
 ## How to use
 

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -19,7 +19,7 @@
     "mendix"
   ],
   "engines": {
-    "node": ">=10.15"
+    "node": ">=12"
   },
   "files": [
     "bin",


### PR DESCRIPTION
## Checklist
- Contains tests ✅ 
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 8️⃣

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
[Backport of #596]

This PR fixes failing `npm install` executions when scaffolding a widget project with the widget generator with NPM v7.x.x. It also explains users in the readme of generated widget projects how to install dependencies with NPM v7.x.x. 

These failures occur due to NPM v7.x.x installing peer dependencies inside the `node_modules` folder. Not all dependencies inside pluggable-widgets-tools share the same React dependency leading into an unresolvable dependency tree.

## Relevant changes
- Execute `npm install` with the command line flag `--legacy-peer-deps`. This ensures pluggable-widgets-tools dependencies install correctly with NPM v7.x.x. The flag is ignored by lower versions of NPM.
- Add in the readme template details about the development steps including installing dependencies with NPM v7.x.x.
- Set required node version for generator, generated widget projects and PIW tools to v12 or higher.
- Note in the readme file for PIW tools that installation with NPM v7.x.x requires the flag.

## What should be covered while testing?
- Scaffold a widget project with the generator with npm v6 and v7. Verify that both succeed.