### PR TITLE
[WC-364]: use CSS transform on custom marker icon using Leaflet.DivIcon to center its anchor

### DIFF
--- a/packages/pluggableWidgets/maps-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/maps-web/CHANGELOG.md
@@ -7,5 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Add a structure preview for each map provider.
 
+### Changed
+- Change the anchor of custom marker icons to be the center of the icon instead of the top left corner.
+
 ## Older releases
 See [marketplace](https://marketplace.mendix.com/link/component/108261) for previous releases.

--- a/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
+++ b/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
@@ -5,7 +5,7 @@ import { SharedProps } from "../../typings/shared";
 import { MapProviderEnum } from "../../typings/MapsProps";
 import { getDimensions } from "../utils/dimension";
 import { translateZoom } from "../utils/zoom";
-import { latLngBounds, Icon as LeafletIcon } from "leaflet";
+import { latLngBounds, Icon as LeafletIcon, DivIcon } from "leaflet";
 import { baseMapLayer } from "../utils/leaflet";
 
 export interface LeafletProps extends SharedProps {
@@ -98,9 +98,9 @@ export function LeafletMap(props: LeafletProps): ReactElement {
                                 title={marker.title}
                                 icon={
                                     marker.url
-                                        ? new LeafletIcon({
-                                              iconUrl: marker.url,
-                                              iconRetinaUrl: marker.url
+                                        ? new DivIcon({
+                                              html: `<img src="${marker.url}" class="custom-leaflet-map-icon-marker-icon"}></img>`,
+                                              className: "custom-leaflet-map-icon-marker"
                                           })
                                         : defaultMarkerIcon
                                 }

--- a/packages/pluggableWidgets/maps-web/src/components/__tests__/__snapshots__/LeafletMap.spec.ts.snap
+++ b/packages/pluggableWidgets/maps-web/src/components/__tests__/__snapshots__/LeafletMap.spec.ts.snap
@@ -155,8 +155,8 @@ exports[`Leaflet maps renders a map with current location 1`] = `
           NewClass {
             "_initHooksCalled": true,
             "options": Object {
-              "iconRetinaUrl": "image:url",
-              "iconUrl": "image:url",
+              "className": "custom-leaflet-map-icon-marker",
+              "html": "<img src=\\"image:url\\" class=\\"custom-leaflet-map-icon-marker-icon\\"}></img>",
             },
           }
         }
@@ -212,8 +212,8 @@ exports[`Leaflet maps renders a map with markers 1`] = `
           NewClass {
             "_initHooksCalled": true,
             "options": Object {
-              "iconRetinaUrl": "image:url",
-              "iconUrl": "image:url",
+              "className": "custom-leaflet-map-icon-marker",
+              "html": "<img src=\\"image:url\\" class=\\"custom-leaflet-map-icon-marker-icon\\"}></img>",
             },
           }
         }
@@ -244,8 +244,8 @@ exports[`Leaflet maps renders a map with markers 1`] = `
           NewClass {
             "_initHooksCalled": true,
             "options": Object {
-              "iconRetinaUrl": "image:url",
-              "iconUrl": "image:url",
+              "className": "custom-leaflet-map-icon-marker",
+              "html": "<img src=\\"image:url\\" class=\\"custom-leaflet-map-icon-marker-icon\\"}></img>",
             },
           }
         }

--- a/packages/pluggableWidgets/maps-web/src/ui/Maps.css
+++ b/packages/pluggableWidgets/maps-web/src/ui/Maps.css
@@ -47,3 +47,18 @@ Leaflet maps
     z-index: 10;
     width: 100%;
 }
+
+.custom-leaflet-map-icon-marker {
+    /* Since we're moving the icon with translate, the clickable surface area would mismatch meaning users
+    could click next to the icon and still trigger the tooltip on click. Instead, we just get rid of this
+    hitbox by resetting the height and width and only use the actual icon as a hitbox. */
+    height: 0px !important;
+    width: 0px !important;
+    /* Leaflet does some tweaking based on their own assumptions. But they are wrong, we are correct. So we override them. */
+    margin-left: inherit !important;
+    margin-top: inherit !important;
+}
+
+.custom-leaflet-map-icon-marker-icon {
+    transform: translate(-50%, -50%);
+}


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌ (icons will be moved a bit, but we could argue that it's improved. maps will stay workable for users)
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Currently, a custom marker's anchor (the point on the icon that 'points' to the user specified coordinate) is always the top left of the icon. But in most of the cases this does not make sense, so we want to center this.

## Relevant changes
Unfortunately it isn't possible to change the `LeafletIcon` in any way. 
- Through JavaScript: we can only set the anchor beforehand, but for that we need specific coordinates, for which we need the dimensions of the icon. We just don't have these available until runtime, so this is not possible. We could do something along the lines of rendering it, retrieving it, measuring it, re-setting it. But that's not very trivial and not quite performant.
- Through CSS: Leaflet already applies some `transform` CSS rule onto the custom marker. Unfortunately there's no way to append another CSS rule (`translate(-50%, -50%)`) onto it. It can only override it, which means that we lose all the styling from leaflet, which is not what we want. Using margins combined with percentages is also not possible, because the HTML structure in Leaflet is super weird: there's basically one big canvas div element that contains all the custom markers, which renders percentage CSS values useless.

So the final solution is as follows:
1. Use `Leaflet.DivIcon`, which is basically a less opinionated version of `Leaflet.LeafletIcon`, renders a `div` and allows control over the html. Then we inject the image tag ourselves.
2. Then to properly move the icon, we apply `translate(-50%, -50%)` onto the icon image tag, which we can now do because the structure has changed from `<Markers Pane> -> <img icon>` to `<Markers Pane> -> <div> -> <img icon>`.
3. Reset some of the styling leaflet does themselves on the `<div>` based on their own assumptions (reset margins)
4. However, because we're transforming the icon rather than actually moving it entirely, the hitbox for onclick handlers does not match between the `div` and the `img` icon. The latter works perfectly, so we get rid of the hitbox on the `div` entirely.

## What should be covered while testing?
Make sure an icon is placed centered on top of the coordinate or address, not the corner of the icon.
