### PR TITLE
[WC-438] overwrite -webkit-overflow-scrolling in mxui with auto

### DIFF
--- a/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScanner.scss
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScanner.scss
@@ -124,5 +124,5 @@
 // iOS Safari will in certain cases put the top and/or bottom bar on top of the overlay of this widget.
 .mx-dataview-content,
 .mx-scrollcontainer-wrapper:not(.mx-scrollcontainer-nested) {
-    -webkit-overflow-scrolling: auto;
+    -webkit-overflow-scrolling: auto !important;
 }

--- a/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScanner.scss
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScanner.scss
@@ -122,6 +122,7 @@
 
 // Overwrite `atlas_core/web/core/_legacy/_mxui.scss` for this particular widget because otherwise
 // iOS Safari will in certain cases put the top and/or bottom bar on top of the overlay of this widget.
+.mx-dataview-content,
 .mx-scrollcontainer-wrapper:not(.mx-scrollcontainer-nested) {
     -webkit-overflow-scrolling: auto;
 }

--- a/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScanner.scss
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScanner.scss
@@ -122,9 +122,6 @@
 
 // Overwrite `atlas_core/web/core/_legacy/_mxui.scss` for this particular widget because otherwise
 // iOS Safari will in certain cases put the top and/or bottom bar on top of the overlay of this widget.
-.mx-dataview-content,
-.mx-scrollcontainer-wrapper:not(.mx-scrollcontainer-nested),
-.mx-tabcontainer-content,
-.mx-grid-content {
+.mx-scrollcontainer-wrapper:not(.mx-scrollcontainer-nested) {
     -webkit-overflow-scrolling: auto;
 }

--- a/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScanner.scss
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScanner.scss
@@ -119,3 +119,12 @@
         }
     }
 }
+
+// Overwrite `atlas_core/web/core/_legacy/_mxui.scss` for this particular widget because otherwise
+// iOS Safari will in certain cases put the top and/or bottom bar on top of the overlay of this widget.
+.mx-dataview-content,
+.mx-scrollcontainer-wrapper:not(.mx-scrollcontainer-nested),
+.mx-tabcontainer-content,
+.mx-grid-content {
+    -webkit-overflow-scrolling: auto;
+}


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ✅ 
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ❌
- Compatible with Studio ❌
- Cross-browser compatible ✅

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR and relevant changes
For the barcode scanner widget, the bottom and top bar elements (part of atlas) were showing on top of the full screen canvas overlay that opens with this widget that allows users to scan barcodes. Turns out this is caused by the usage of `-webkit-overflow-scrolling: touch`, which somehow interferes with other css properties like z-index in this case. 

If we look at [the documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-overflow-scrolling) for this css property, it only minorly affects the experience of users and I don't think this is considered a breaking change. It does touch some legacy CSS that is used across mendix application, but based on what this change does and local testing, it does not seem to regress anything else.

The next question is where to overwrite this CSS.
- In Atlas
- In the widget
- Somewhere more core in Mendix.

In this case I think it made most sense to do it in the widget, also because otherwise the widget is not _fundamentally usable_ as a standalone widget without Atlas. So therefore, I included it in the widget styling itself.

## What should be covered while testing?
Check on iOS Safari device whether the navigation layout items are not on top of the black canvas overlay when the barcode scanner widget is open.
