### PR TITLE
feat(pluggable-widgets-tools): suppress unused Platform warnings with both single and double quotes

### DIFF
--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -105,7 +105,7 @@ export default async args => {
                     })
                 ],
                 onwarn: warning => {
-                    if (warning.code === "UNUSED_EXTERNAL_IMPORT" && /'Platform'/.test(warning.message)) {
+                    if (warning.code === "UNUSED_EXTERNAL_IMPORT" && /('|")Platform('|")/.test(warning.message)) {
                         return;
                     }
                     onwarn(warning);


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌

## This PR contains
- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Since we replace `Platform.{something}` with our own values during rollup, the variable is unused during compilation.
Previously, we tested for `'Platform'`, but for some reason the warning was changed to use double quotes 🤷  Now we just check for both.

## What should be covered while testing?
Not necessary
