### PR TITLE
[WC-474] Get rid of studio pro errors console.warned by @zxing/library

### DIFF
--- a/packages/pluggableWidgets/barcode-scanner-web/package.json
+++ b/packages/pluggableWidgets/barcode-scanner-web/package.json
@@ -28,7 +28,8 @@
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
-    "@types/classnames": "^2.2.6"
+    "@types/classnames": "^2.2.6",
+    "@rollup/plugin-replace": "^2.4.1"
   },
   "dependencies": {
     "@mendix/piw-utils-internal": "^1.0.0",

--- a/packages/pluggableWidgets/barcode-scanner-web/rollup.config.js
+++ b/packages/pluggableWidgets/barcode-scanner-web/rollup.config.js
@@ -1,3 +1,5 @@
+import replace from "@rollup/plugin-replace";
+
 export default args => {
     const result = args.configDefaultConfig;
     result.forEach(config => {
@@ -6,6 +8,7 @@ export default args => {
             // The library itself throws a lot of esm module related errors on compilation.
             // For now they don't seem related to us and everything still works, so I ignored them.
             if (
+                warning.loc &&
                 warning.loc.file.includes("@zxing/library") &&
                 (warning.code === "THIS_IS_UNDEFINED" || warning.code === "SOURCEMAP_ERROR")
             ) {
@@ -13,6 +16,24 @@ export default args => {
             }
             onwarn(warning);
         };
+        const plugins = config.plugins || [];
+        config.plugins = [
+            /**
+             * https://github.com/zxing-js/library/blob/99525fbf71fc4902424673067a120b0c09197c27/src/browser/BrowserCodeReader.ts#L432-L444
+             * We remove all these specific `console.warn`s because otherwise they end up in Mendix Studio Pro console, but
+             * the warnings themselves are not interesting for Mendix developers. I tried to prevent this function from being called unnecessary,
+             * but the library itself calls it twice just in case, but that means a warning is always logged which is not what we want.
+             */
+            replace({
+                values: {
+                    "console.warn('Trying to play video that is already playing.');": "",
+                    "console.warn('It was not possible to play the video.');": ""
+                },
+                delimiters: ["", ""],
+                preventAssignment: true
+            }),
+            ...plugins
+        ];
     });
     return result;
 };

--- a/packages/pluggableWidgets/barcode-scanner-web/src/hooks/useCodeScanner.tsx
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/hooks/useCodeScanner.tsx
@@ -2,8 +2,12 @@ import { useEffect, useState } from "react";
 import { BarcodeFormat, BrowserMultiFormatReader, DecodeHintType } from "@zxing/library";
 
 const hints = new Map();
+// RSS_Expanded is not production ready yet.
+const exclusions: BarcodeFormat[] = [BarcodeFormat.RSS_EXPANDED];
 // `BarcodeFormat` is a TypeScript enum. Calling `Object.values` on it returns an array of string and ints, we only want the latter.
-const formats = Object.values(BarcodeFormat).filter(format => typeof format !== "string") as BarcodeFormat[];
+const formats = Object.values(BarcodeFormat)
+    .filter((format: string | BarcodeFormat) => typeof format !== "string")
+    .filter((format: BarcodeFormat) => !exclusions.includes(format)) as BarcodeFormat[];
 hints.set(DecodeHintType.POSSIBLE_FORMATS, formats);
 
 export type CodeScannerHookError = "ERROR_CODE_SCANNER";


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ❌
- Compatible with Studio ❌
- Cross-browser compatible ✅

#### Feature specific
- Comply with designs ✅
- Comply with PM's requirements ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
See JIRA issue: there were a few console.warns that end up in the studio mendix pro console, which is not what we want.

## Relevant changes
- Do not support an experimental feature
- Replace specific console.warns

## Testing
1. Start app with barcode scanner widget
2. Go to the app and open the barcode widget
3. Observe in Mendix SP that no warnings are logged
