### PR TITLE
Introduce Runtime docker image

### DIFF
--- a/packages/tools/pluggable-widgets-tools/scripts/m2ee.yml
+++ b/packages/tools/pluggable-widgets-tools/scripts/m2ee.yml
@@ -31,4 +31,4 @@ logging:
       max_size: 10485760
       max_rotation: 10
 mxnode:
-    mxjar_repo: /opt/mendix
+    mxjar_repo: /var/opt/runtime

--- a/packages/tools/pluggable-widgets-tools/scripts/runtime.Dockerfile
+++ b/packages/tools/pluggable-widgets-tools/scripts/runtime.Dockerfile
@@ -1,0 +1,46 @@
+FROM adoptopenjdk/openjdk11:jdk-11.0.3_7
+
+ARG MENDIX_VERSION
+
+ENV RUNTIME_PORT=8080 \
+    ADMIN_PORT=8090 \
+    LANG="C.UTF-8"
+
+EXPOSE $RUNTIME_PORT $ADMIN_PORT
+
+#install dependency -> git
+RUN apt-get update -qqy && \
+    apt-get install -qqy git wget && \
+    # Install m2ee + dependencies
+    # https://github.com/mendix/m2ee-tools
+    git clone https://github.com/mendix/m2ee-tools.git /tmp/m2ee && \
+    mkdir -p /var/log /var/opt/m2ee && \
+    mv /tmp/m2ee/src/* /var/opt/m2ee && \
+    chmod a=rwx /var/log/ /var/run/ && \
+\
+    apt-get install -qqy \
+        python3 \
+        python3-pip \
+        unzip \
+        libfontconfig1 && \
+\
+    pip3 install -q --upgrade pip && \
+    pip install -q pyyaml httplib2 && \
+\
+    echo "Downloading runtime ${MENDIX_VERSION}..." && \
+    wget -q https://cdn.mendix.com/runtime/mendix-${MENDIX_VERSION}.tar.gz -O /tmp/runtime.tar.gz && \
+    mkdir /var/opt/runtime && \
+    tar xfz /tmp/runtime.tar.gz --directory /var/opt/runtime && \
+    rm /tmp/runtime.tar.gz && \
+    chown -R root:root /var/opt/runtime && \
+\
+    apt-get -qqy remove --auto-remove git wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+\
+    ln -s $JAVA_HOME/bin/* /usr/bin/ && \
+\
+    echo "#!/bin/bash -x" >/bin/m2ee && \
+    echo "python3 /var/opt/m2ee/m2ee.py \$@" >>/bin/m2ee && \
+    chmod +x /bin/m2ee
+

--- a/packages/tools/pluggable-widgets-tools/scripts/runtime.sh
+++ b/packages/tools/pluggable-widgets-tools/scripts/runtime.sh
@@ -1,16 +1,6 @@
 #!/bin/sh
 set -e
 
-echo "Installing runtime dependencies..."
-microdnf install unzip tar python2 > /dev/null
-alternatives --set python /usr/bin/python2
-rpm --install --quiet --nodeps https://packages.mendix.com/platform/rpm/m2ee-tools-7.0.1-1.el7.noarch.rpm
-pip2 install -q PyYAML httplib2
-
-mkdir /opt/mendix/${MENDIX_VERSION}
-mv /opt/mendix/runtime /opt/mendix/${MENDIX_VERSION}/
-echo "Installing runtime dependencies done!"
-
 echo "Starting runtime..."
 # printf is needed to issue "create database" command that is not available via CLI
 printf "c\nc\n" | m2ee -c /shared/m2ee.yml --yolo start


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ✅
- Contains Atlas changes ❌
- Compatible with: MX 8️⃣, 9️⃣

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Introduces our own docker image for runtime to stop relying on images being published by Cloud team.

## Relevant changes
For now, it will only work with one specific version declared in a environment variable. If the var is not available it will try to find via mendix-version.json from monorepo

## What should be covered while testing?
--
