### PR TITLE
fix(calendar-web): fixing calendar drop events between different widgets

### DIFF
--- a/packages/customWidgets/calendar-web/package.json
+++ b/packages/customWidgets/calendar-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar-web",
   "widgetName": "Calendar",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Display and manage calendar events",
   "copyright": "Mendix BV",
   "repository": {

--- a/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
+++ b/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
@@ -480,7 +480,10 @@ export default class CalendarContainer extends Component<Container.CalendarConta
 
     private handleOnChangeEvent = (eventInfo: Container.EventInfo) => {
         const { events } = this.state;
-        const eventPosition = events.indexOf(eventInfo.event);
+        const eventPosition = events.findIndex(value => value.guid === eventInfo.event.guid);
+        if (eventPosition === -1) {
+            return;
+        }
         const updatedEvent: CalendarEvent = {
             title: eventInfo.event.title,
             allDay: eventInfo.event.allDay,

--- a/packages/customWidgets/calendar-web/src/package.xml
+++ b/packages/customWidgets/calendar-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Calendar2" version="1.0.11" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Calendar2" version="1.0.12" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Calendar.xml"/>
         </widgetFiles>


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 7️⃣, 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ❌
- Compatible with Studio ❌
- Cross-browser compatible ❌

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Avoid events arriving from other widgets to appear in the calendar.

## Relevant changes
Only added a check if the event existed before.

## What should be covered while testing?
Test drag and drop between days/same day, also resize. And try to drop into another calendar
