### PR TITLE
fix(pluggable-widgets-tools): fix mxbuild version in docker image

### DIFF
--- a/packages/tools/pluggable-widgets-tools/scripts/mxbuild.Dockerfile
+++ b/packages/tools/pluggable-widgets-tools/scripts/mxbuild.Dockerfile
@@ -1,4 +1,4 @@
-FROM mono:latest
+FROM mono:5.20.1
 ARG MENDIX_VERSION
 
 RUN \


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
This PR fixed failing mxbuild for Mendix 9.2 due to mono version.

## Relevant changes
5.20 is the version being used in appdev and also mentioned in the requirements.

## What should be covered while testing?
Not necessary
