### PR TITLE
[WC-467] Remove github issues link in generator and package.json from widget-generator

### DIFF
--- a/packages/tools/generator-widget/CHANGELOG.md
+++ b/packages/tools/generator-widget/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Links to unsupported Github issues page for bug reporting.
 
 ## 9.0.1 - 2021-04-26
 

--- a/packages/tools/generator-widget/generators/app/lib/text.js
+++ b/packages/tools/generator-widget/generators/app/lib/text.js
@@ -15,7 +15,6 @@ module.exports = {
     ${chalk.bold.bgBlueBright("                ")}                    __/ |          
                                        |___/           
      Generator, version: ${pkg.version}
-     Issues? Please report them at : ${chalk.italic.blueBright(pkg.bugs.url)}
                 
     `,
 

--- a/packages/tools/generator-widget/package.json
+++ b/packages/tools/generator-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/generator-widget",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "Mendix Pluggable Widgets Generator",
   "license": "Apache-2.0",
   "copyright": "2020 Mendix Technology B.V.",

--- a/packages/tools/generator-widget/package.json
+++ b/packages/tools/generator-widget/package.json
@@ -26,9 +26,6 @@
   "engines": {
     "node": ">=12"
   },
-  "bugs": {
-    "url": "https://github.com/mendix/widgets-resources/issues"
-  },
   "dependencies": {
     "chalk": "^4.1.0",
     "semver": "^7.3.2",


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 7️⃣, 8️⃣, 9️⃣

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (Maintenance)

## What is the purpose of this PR?
We don't support issues through GH anymore, so removing the prompts and link in package.json.
