### PR TITLE
[WC-517] Add widget properties to control barcode scanner dimensions

### DIFF
--- a/packages/pluggableWidgets/barcode-scanner-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/barcode-scanner-web/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this widget will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Add Barcode Scanner pluggable widget with structure and design preview.

--- a/packages/pluggableWidgets/barcode-scanner-web/src/BarcodeScanner.editorPreview.tsx
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/BarcodeScanner.editorPreview.tsx
@@ -6,7 +6,15 @@ import previewQrCodeSvg from "./assets/previewQrCode.svg";
 
 export function preview(props: BarcodeScannerPreviewProps): ReactElement {
     return (
-        <BarcodeScannerOverlay showMask={props.showMask} class={props.class}>
+        <BarcodeScannerOverlay
+            showMask={props.showMask}
+            class={props.class}
+            heightUnit={props.heightUnit}
+            widthUnit={props.widthUnit}
+            // These are set by default values in widget properties.
+            height={props.height!}
+            width={props.width!}
+        >
             <img src={previewQrCodeSvg} className="design-preview-qr-code" />
         </BarcodeScannerOverlay>
     );

--- a/packages/pluggableWidgets/barcode-scanner-web/src/BarcodeScanner.tsx
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/BarcodeScanner.tsx
@@ -22,6 +22,10 @@ export const BarcodeScanner: FunctionComponent<BarcodeScannerContainerProps> = p
             onDetect={props.onDetect ? onDetect : undefined}
             showMask={props.showMask}
             class={props.class}
+            heightUnit={props.heightUnit}
+            height={props.height}
+            widthUnit={props.widthUnit}
+            width={props.width}
         />
     );
 };

--- a/packages/pluggableWidgets/barcode-scanner-web/src/BarcodeScanner.xml
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/BarcodeScanner.xml
@@ -33,5 +33,35 @@
                 <systemProperty key="Visibility"/>
             </propertyGroup>
         </propertyGroup>
+
+        <propertyGroup caption="Dimensions">
+            <propertyGroup caption="Dimensions">
+                <property key="widthUnit" type="enumeration" defaultValue="percentage">
+                    <caption>Width unit</caption>
+                    <description>Percentage: portion of parent size. Pixels: absolute amount of pixels.</description>
+                    <enumerationValues>
+                        <enumerationValue key="percentage">Percentage</enumerationValue>
+                        <enumerationValue key="pixels">Pixels</enumerationValue>
+                    </enumerationValues>
+                </property>
+                <property key="width" type="integer" defaultValue="100">
+                    <caption>Width</caption>
+                    <description/>
+                </property>
+                <property key="heightUnit" type="enumeration" defaultValue="percentageOfWidth">
+                    <caption>Height unit</caption>
+                    <description/>
+                    <enumerationValues>
+                        <enumerationValue key="percentageOfWidth">Percentage of width</enumerationValue>
+                        <enumerationValue key="pixels">Pixels</enumerationValue>
+                        <enumerationValue key="percentageOfParent">Percentage of parent</enumerationValue>
+                    </enumerationValues>
+                </property>
+                <property key="height" type="integer" defaultValue="75">
+                    <caption>Height</caption>
+                    <description/>
+                </property>
+            </propertyGroup>
+        </propertyGroup>
     </properties>
 </widget>

--- a/packages/pluggableWidgets/barcode-scanner-web/src/components/BarcodeScanner.tsx
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/components/BarcodeScanner.tsx
@@ -1,16 +1,15 @@
 import { createElement, ReactElement, ReactNode, useEffect, useRef } from "react";
 import classNames from "classnames";
-import { Alert } from "@mendix/piw-utils-internal";
+import { Alert, Dimensions, getDimensions } from "@mendix/piw-utils-internal";
 import { useCodeScanner, CodeScannerHookError } from "../hooks/useCodeScanner";
 import { browserSupportsCameraAccess, useMediaStream, MediaStreamHookError } from "../hooks/useMediaStream";
 
 import "../ui/BarcodeScanner.scss";
 
-export interface BarcodeScannerProps {
+export interface BarcodeScannerProps extends Dimensions {
     onDetect?: (data: string) => void;
     showMask: boolean;
     class: string;
-    preview?: boolean;
 }
 
 function getErrorMessage(errorEnum: MediaStreamHookError | CodeScannerHookError | null): string | null {
@@ -27,7 +26,7 @@ function getErrorMessage(errorEnum: MediaStreamHookError | CodeScannerHookError 
     }
 }
 
-interface BarcodeScannerOverlayProps {
+interface BarcodeScannerOverlayProps extends Dimensions {
     showMask: boolean;
     class: string;
     children?: ReactNode;
@@ -36,32 +35,40 @@ interface BarcodeScannerOverlayProps {
 export function BarcodeScannerOverlay({
     children,
     class: className,
-    showMask
+    showMask,
+    ...dimensions
 }: BarcodeScannerOverlayProps): ReactElement {
     return (
-        <div className={classNames("mx-barcode-scanner", className)}>
-            {children}
-            {showMask ? (
-                <div className={classNames("video-canvas")}>
-                    <div className={classNames("canvas-left", "canvas-background")} />
-                    <div className={classNames("canvas-middle")}>
-                        <div className={classNames("canvas-middle-top", "canvas-background")} />
-                        <div className={classNames("canvas-middle-middle")}>
-                            <div className={classNames("corner", "corner-top-left")} />
-                            <div className={classNames("corner", "corner-top-right")} />
-                            <div className={classNames("corner", "corner-bottom-right")} />
-                            <div className={classNames("corner", "corner-bottom-left")} />
+        <div className={classNames("mx-barcode-scanner", className)} style={getDimensions(dimensions)}>
+            <div className={classNames("mx-barcode-scanner-content")}>
+                {children}
+                {showMask ? (
+                    <div className={classNames("video-canvas")}>
+                        <div className={classNames("canvas-left", "canvas-background")} />
+                        <div className={classNames("canvas-middle")}>
+                            <div className={classNames("canvas-middle-top", "canvas-background")} />
+                            <div className={classNames("canvas-middle-middle")}>
+                                <div className={classNames("corner", "corner-top-left")} />
+                                <div className={classNames("corner", "corner-top-right")} />
+                                <div className={classNames("corner", "corner-bottom-right")} />
+                                <div className={classNames("corner", "corner-bottom-left")} />
+                            </div>
+                            <div className={classNames("canvas-middle-bottom", "canvas-background")} />
                         </div>
-                        <div className={classNames("canvas-middle-bottom", "canvas-background")} />
+                        <div className={classNames("canvas-right", "canvas-background")} />
                     </div>
-                    <div className={classNames("canvas-right", "canvas-background")} />
-                </div>
-            ) : null}
+                ) : null}
+            </div>
         </div>
     );
 }
 
-export function BarcodeScanner({ onDetect, showMask, class: className }: BarcodeScannerProps): ReactElement | null {
+export function BarcodeScanner({
+    onDetect,
+    showMask,
+    class: className,
+    ...dimensions
+}: BarcodeScannerProps): ReactElement | null {
     const videoElement = useRef<HTMLVideoElement | null>(null);
     const hasDetectedOnce = useRef<boolean>(false);
     const { streamObject, error: errorMediaStream } = useMediaStream();
@@ -106,7 +113,7 @@ export function BarcodeScanner({ onDetect, showMask, class: className }: Barcode
         }
     }
     return (
-        <BarcodeScannerOverlay class={className} showMask={showMask}>
+        <BarcodeScannerOverlay class={className} showMask={showMask} {...dimensions}>
             <video
                 className={classNames("video")}
                 ref={videoElement}

--- a/packages/pluggableWidgets/barcode-scanner-web/src/components/__tests__/BarcodeScanner.spec.tsx
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/components/__tests__/BarcodeScanner.spec.tsx
@@ -1,6 +1,7 @@
 import { mount, shallow } from "enzyme";
 import { createElement } from "react";
 import * as zxing from "@zxing/library";
+import { Dimensions } from "@mendix/piw-utils-internal";
 import { BarcodeScanner, BarcodeScannerOverlay } from "../BarcodeScanner";
 import * as mediaStreamFunctions from "../../hooks/useMediaStream";
 import { act } from "react-dom/test-utils";
@@ -15,6 +16,12 @@ jest.mock("@zxing/library", () => {
 
 describe("Barcode scanner", () => {
     const backupMediaDevices = window.navigator.mediaDevices;
+    const dimensions: Dimensions = {
+        widthUnit: "percentage",
+        width: 100,
+        heightUnit: "percentageOfParent",
+        height: 100
+    };
 
     afterEach(() => {
         // reset the mocking
@@ -35,7 +42,7 @@ describe("Barcode scanner", () => {
 
     it("shows an appropriate error when the mediaDevices API is not present (like over http)", () => {
         expect(navigator.mediaDevices).toBe(undefined);
-        const barcodeScanner = mount(<BarcodeScanner class="" showMask />);
+        const barcodeScanner = mount(<BarcodeScanner class="" showMask {...dimensions} />);
         expect(barcodeScanner.text()).toBe(
             "The barcode scanner widget is only compatible with certain browsers and requires a secure HTTPS connection in certain browsers. If you encounter this error message as an user, please contact your system administrator. If you are a Mendix developer, please refer to the appropriate docs on how to resolve this issue."
         );
@@ -43,12 +50,12 @@ describe("Barcode scanner", () => {
 
     it("shows a loading screen while waiting for the user to give persmission to access the media device", () => {
         mockGetUserMedia(jest.fn());
-        expect(shallow(<BarcodeScanner class="" showMask />)).toMatchSnapshot();
+        expect(shallow(<BarcodeScanner class="" showMask {...dimensions} />)).toMatchSnapshot();
     });
 
     it("does not show the overlay when the user opts out of it", () => {
         mockGetUserMedia(jest.fn());
-        expect(shallow(<BarcodeScanner class="" showMask={false} />)).toMatchSnapshot();
+        expect(shallow(<BarcodeScanner class="" showMask={false} {...dimensions} />)).toMatchSnapshot();
     });
 
     it("calls the onDetect function if it has been provided and a barcode has been detected", async () => {
@@ -63,7 +70,7 @@ describe("Barcode scanner", () => {
             decodeOnceFromStream: jest.fn(() => handleScanResult)
         }));
 
-        mount(<BarcodeScanner class="" showMask onDetect={onDetectMock} />);
+        mount(<BarcodeScanner class="" showMask onDetect={onDetectMock} {...dimensions} />);
 
         await act(async () => {
             await handleFakeMediaStream;
@@ -80,7 +87,7 @@ describe("Barcode scanner", () => {
                 })
             );
 
-            const barcodeScanner = mount(<BarcodeScanner class="" showMask />);
+            const barcodeScanner = mount(<BarcodeScanner class="" showMask {...dimensions} />);
             expect(barcodeScanner.text()).toBe(
                 "Error in barcode scanner: an unexpected error occurred while retrieving the camera media stream."
             );
@@ -95,7 +102,7 @@ describe("Barcode scanner", () => {
                 })
             );
 
-            const barcodeScanner = mount(<BarcodeScanner class="" showMask />);
+            const barcodeScanner = mount(<BarcodeScanner class="" showMask {...dimensions} />);
             expect(barcodeScanner.text()).toBe("Error in barcode scanner: no camera media devices were found.");
         });
 
@@ -108,7 +115,7 @@ describe("Barcode scanner", () => {
                 })
             );
 
-            const barcodeScanner = mount(<BarcodeScanner class="" showMask />);
+            const barcodeScanner = mount(<BarcodeScanner class="" showMask {...dimensions} />);
             expect(barcodeScanner.text()).not.toContain("Error in barcode scanner");
         });
 
@@ -122,7 +129,7 @@ describe("Barcode scanner", () => {
                 throw new Error("This is an error");
             });
 
-            const barcodeScanner = mount(<BarcodeScanner class="" showMask />);
+            const barcodeScanner = mount(<BarcodeScanner class="" showMask {...dimensions} />);
 
             await act(async () => {
                 await handleFakeMediaStream;
@@ -138,6 +145,6 @@ describe("Barcode scanner", () => {
     });
 
     it("the overlay structure should be correct", () => {
-        expect(shallow(<BarcodeScannerOverlay class="" showMask />)).toMatchSnapshot();
+        expect(shallow(<BarcodeScannerOverlay class="" showMask {...dimensions} />)).toMatchSnapshot();
     });
 });

--- a/packages/pluggableWidgets/barcode-scanner-web/src/components/__tests__/__snapshots__/BarcodeScanner.spec.tsx.snap
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/components/__tests__/__snapshots__/BarcodeScanner.spec.tsx.snap
@@ -3,7 +3,11 @@
 exports[`Barcode scanner does not show the overlay when the user opts out of it 1`] = `
 <BarcodeScannerOverlay
   class=""
+  height={100}
+  heightUnit="percentageOfParent"
   showMask={false}
+  width={100}
+  widthUnit="percentage"
 >
   <video
     className="video"
@@ -15,7 +19,11 @@ exports[`Barcode scanner does not show the overlay when the user opts out of it 
 exports[`Barcode scanner shows a loading screen while waiting for the user to give persmission to access the media device 1`] = `
 <BarcodeScannerOverlay
   class=""
+  height={100}
+  heightUnit="percentageOfParent"
   showMask={true}
+  width={100}
+  widthUnit="percentage"
 >
   <video
     className="video"
@@ -27,6 +35,12 @@ exports[`Barcode scanner shows a loading screen while waiting for the user to gi
 exports[`Barcode scanner the overlay structure should be correct 1`] = `
 <div
   className="mx-barcode-scanner"
+  style={
+    Object {
+      "height": "100%",
+      "width": "100%",
+    }
+  }
 >
   <div
     className="video-canvas"

--- a/packages/pluggableWidgets/barcode-scanner-web/src/components/__tests__/__snapshots__/BarcodeScanner.spec.tsx.snap
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/components/__tests__/__snapshots__/BarcodeScanner.spec.tsx.snap
@@ -43,40 +43,44 @@ exports[`Barcode scanner the overlay structure should be correct 1`] = `
   }
 >
   <div
-    className="video-canvas"
+    className="mx-barcode-scanner-content"
   >
     <div
-      className="canvas-left canvas-background"
-    />
-    <div
-      className="canvas-middle"
+      className="video-canvas"
     >
       <div
-        className="canvas-middle-top canvas-background"
+        className="canvas-left canvas-background"
       />
       <div
-        className="canvas-middle-middle"
+        className="canvas-middle"
       >
         <div
-          className="corner corner-top-left"
+          className="canvas-middle-top canvas-background"
         />
         <div
-          className="corner corner-top-right"
-        />
+          className="canvas-middle-middle"
+        >
+          <div
+            className="corner corner-top-left"
+          />
+          <div
+            className="corner corner-top-right"
+          />
+          <div
+            className="corner corner-bottom-right"
+          />
+          <div
+            className="corner corner-bottom-left"
+          />
+        </div>
         <div
-          className="corner corner-bottom-right"
-        />
-        <div
-          className="corner corner-bottom-left"
+          className="canvas-middle-bottom canvas-background"
         />
       </div>
       <div
-        className="canvas-middle-bottom canvas-background"
+        className="canvas-right canvas-background"
       />
     </div>
-    <div
-      className="canvas-right canvas-background"
-    />
   </div>
 </div>
 `;

--- a/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScanner.scss
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScanner.scss
@@ -1,104 +1,108 @@
 .mx-barcode-scanner {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: #000000;
-    // Should be higher than the z-index of `.layout-atlas .region-sidebar` so it sits on top of the page.
-    z-index: 110;
+    position: relative;
 
-    .video {
-        position: relative;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-    }
-
-    .video-canvas {
+    .mx-barcode-scanner-content {
         position: absolute;
         top: 0;
         left: 0;
-        width: 100%;
-        height: 100%;
-        display: flex;
-        flex-direction: row;
-        align-items: stretch;
+        right: 0;
+        bottom: 0;
+        background: #000000;
+        // Should be higher than the z-index of `.layout-atlas .region-sidebar` so it sits on top of the page.
+        z-index: 110;
 
-        .canvas-background {
-            background-color: rgba(0, 0, 0, 0.7);
+        .video {
+            position: relative;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
         }
 
-        .canvas-left {
-            flex: 1;
-        }
-
-        $screen-md: 768px;
-        $screen-lg: 992px;
-        $screen-xl: 1200px;
-        .canvas-middle {
-            flex: 0;
-            flex-basis: 60%;
-            @media screen and (min-width: $screen-md) {
-                flex-basis: 50%;
-            }
-            @media screen and (min-width: $screen-lg) {
-                flex-basis: 40%;
-            }
-            @media screen and (min-width: $screen-xl) {
-                flex-basis: 30%;
-            }
+        .video-canvas {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
             display: flex;
-            flex-direction: column;
+            flex-direction: row;
+            align-items: stretch;
 
-            .canvas-middle-top {
+            .canvas-background {
+                background-color: rgba(0, 0, 0, 0.7);
+            }
+
+            .canvas-left {
                 flex: 1;
             }
 
-            .canvas-middle-middle {
+            $screen-md: 768px;
+            $screen-lg: 992px;
+            $screen-xl: 1200px;
+            .canvas-middle {
                 flex: 0;
-                padding-top: 100%;
-                position: relative;
+                flex-basis: 60%;
+                @media screen and (min-width: $screen-md) {
+                    flex-basis: 50%;
+                }
+                @media screen and (min-width: $screen-lg) {
+                    flex-basis: 40%;
+                }
+                @media screen and (min-width: $screen-xl) {
+                    flex-basis: 30%;
+                }
+                display: flex;
+                flex-direction: column;
 
-                $corner-offset: 13px;
-                .corner {
-                    position: absolute;
-                    width: 32px;
-                    height: 32px;
-                    box-sizing: border-box;
-                    $corner-border: 5px solid #ffffff;
-                    border-left: $corner-border;
-                    border-top: $corner-border;
+                .canvas-middle-top {
+                    flex: 1;
+                }
 
-                    &.corner-top-left {
-                        top: -$corner-offset;
-                        left: -$corner-offset;
+                .canvas-middle-middle {
+                    flex: 0;
+                    padding-top: 100%;
+                    position: relative;
+
+                    $corner-offset: 13px;
+                    .corner {
+                        position: absolute;
+                        width: 32px;
+                        height: 32px;
+                        box-sizing: border-box;
+                        $corner-border: 5px solid #ffffff;
+                        border-left: $corner-border;
+                        border-top: $corner-border;
+
+                        &.corner-top-left {
+                            top: -$corner-offset;
+                            left: -$corner-offset;
+                        }
+                        &.corner-top-right {
+                            top: -$corner-offset;
+                            right: -$corner-offset;
+                            transform: rotate(90deg);
+                        }
+                        &.corner-bottom-right {
+                            bottom: -$corner-offset;
+                            right: -$corner-offset;
+                            transform: rotate(180deg);
+                        }
+                        &.corner-bottom-left {
+                            bottom: -$corner-offset;
+                            left: -$corner-offset;
+                            transform: rotate(270deg);
+                        }
                     }
-                    &.corner-top-right {
-                        top: -$corner-offset;
-                        right: -$corner-offset;
-                        transform: rotate(90deg);
-                    }
-                    &.corner-bottom-right {
-                        bottom: -$corner-offset;
-                        right: -$corner-offset;
-                        transform: rotate(180deg);
-                    }
-                    &.corner-bottom-left {
-                        bottom: -$corner-offset;
-                        left: -$corner-offset;
-                        transform: rotate(270deg);
-                    }
+                }
+
+                .canvas-middle-bottom {
+                    flex: 1;
                 }
             }
 
-            .canvas-middle-bottom {
+            .canvas-right {
                 flex: 1;
             }
-        }
-
-        .canvas-right {
-            flex: 1;
         }
     }
 }

--- a/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScannerPreview.scss
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/ui/BarcodeScannerPreview.scss
@@ -1,23 +1,25 @@
 .mx-barcode-scanner {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    .mx-barcode-scanner-content {
+        display: flex;
+        align-items: center;
+        justify-content: center;
 
-    .design-preview-qr-code {
-        $screen-md: 768px;
-        $screen-lg: 992px;
-        $screen-xl: 1200px;
+        .design-preview-qr-code {
+            $screen-md: 768px;
+            $screen-lg: 992px;
+            $screen-xl: 1200px;
 
-        flex: 0;
-        flex-basis: 50%;
-        @media screen and (min-width: $screen-md) {
-            flex-basis: 40%;
-        }
-        @media screen and (min-width: $screen-lg) {
-            flex-basis: 30%;
-        }
-        @media screen and (min-width: $screen-xl) {
-            flex-basis: 20%;
+            flex: 0;
+            flex-basis: 50%;
+            @media screen and (min-width: $screen-md) {
+                flex-basis: 40%;
+            }
+            @media screen and (min-width: $screen-lg) {
+                flex-basis: 30%;
+            }
+            @media screen and (min-width: $screen-xl) {
+                flex-basis: 20%;
+            }
         }
     }
 }

--- a/packages/pluggableWidgets/barcode-scanner-web/typings/BarcodeScannerProps.d.ts
+++ b/packages/pluggableWidgets/barcode-scanner-web/typings/BarcodeScannerProps.d.ts
@@ -6,6 +6,10 @@
 import { CSSProperties } from "react";
 import { ActionValue, EditableValue } from "mendix";
 
+export type WidthUnitEnum = "percentage" | "pixels";
+
+export type HeightUnitEnum = "percentageOfWidth" | "pixels" | "percentageOfParent";
+
 export interface BarcodeScannerContainerProps {
     name: string;
     class: string;
@@ -14,6 +18,10 @@ export interface BarcodeScannerContainerProps {
     datasource: EditableValue<string>;
     showMask: boolean;
     onDetect?: ActionValue;
+    widthUnit: WidthUnitEnum;
+    width: number;
+    heightUnit: HeightUnitEnum;
+    height: number;
 }
 
 export interface BarcodeScannerPreviewProps {
@@ -22,4 +30,8 @@ export interface BarcodeScannerPreviewProps {
     datasource: string;
     showMask: boolean;
     onDetect: {} | null;
+    widthUnit: WidthUnitEnum;
+    width: number | null;
+    heightUnit: HeightUnitEnum;
+    height: number | null;
 }

--- a/packages/pluggableWidgets/maps-web/src/components/GoogleMap.tsx
+++ b/packages/pluggableWidgets/maps-web/src/components/GoogleMap.tsx
@@ -8,10 +8,9 @@ import {
 } from "@react-google-maps/api";
 import { Marker, SharedProps } from "../../typings/shared";
 import { getGoogleMapsStyles } from "../utils/google";
-import { getDimensions } from "../utils/dimension";
 import { translateZoom } from "../utils/zoom";
 import { Option } from "../utils/data";
-import { Alert } from "@mendix/piw-utils-internal";
+import { Alert, getDimensions } from "@mendix/piw-utils-internal";
 
 export interface GoogleMapsProps extends SharedProps {
     mapStyles?: string;

--- a/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
+++ b/packages/pluggableWidgets/maps-web/src/components/LeafletMap.tsx
@@ -1,9 +1,9 @@
 import { createElement, ReactElement, useEffect, useRef } from "react";
 import { Map, Marker as MarkerComponent, Popup, TileLayer } from "react-leaflet";
 import classNames from "classnames";
+import { getDimensions } from "@mendix/piw-utils-internal";
 import { SharedProps } from "../../typings/shared";
 import { MapProviderEnum } from "../../typings/MapsProps";
-import { getDimensions } from "../utils/dimension";
 import { translateZoom } from "../utils/zoom";
 import { latLngBounds, Icon as LeafletIcon, DivIcon } from "leaflet";
 import { baseMapLayer } from "../utils/leaflet";

--- a/packages/pluggableWidgets/maps-web/typings/shared.d.ts
+++ b/packages/pluggableWidgets/maps-web/typings/shared.d.ts
@@ -1,13 +1,5 @@
-import { HeightUnitEnum, WidthUnitEnum } from "./MapsProps";
+import { Dimensions } from "@mendix/piw-utils-internal";
 import { CSSProperties } from "react";
-
-export interface Dimensions {
-    widthUnit: WidthUnitEnum;
-    width: number;
-    heightUnit: HeightUnitEnum;
-    height: number;
-}
-
 export interface ModeledMarker {
     address?: string;
     latitude?: number;

--- a/packages/tools/piw-utils-internal/src/utils/StylingPropertyUtils.ts
+++ b/packages/tools/piw-utils-internal/src/utils/StylingPropertyUtils.ts
@@ -1,5 +1,15 @@
 import { CSSProperties } from "react";
-import { Dimensions } from "../../typings/shared";
+
+export type WidthUnitEnum = "percentage" | "pixels";
+
+export type HeightUnitEnum = "percentageOfWidth" | "pixels" | "percentageOfParent";
+
+export interface Dimensions {
+    widthUnit: WidthUnitEnum;
+    width: number;
+    heightUnit: HeightUnitEnum;
+    height: number;
+}
 
 export function getDimensions<T extends Dimensions>(props: T): CSSProperties {
     const style: CSSProperties = {

--- a/packages/tools/piw-utils-internal/src/utils/index.ts
+++ b/packages/tools/piw-utils-internal/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./dom";
 export * from "./PageEditorUtils";
 export * from "./DataGridFilterIcons";
+export * from "./StylingPropertyUtils";


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ❌
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Just like with the maps widget, add "Dimensions" widget properties to control the dimensions of the widget rather than always relying on the HTML elements or `height: 100%; width: 100%`.

## Relevant changes
This basically reuses the entire widget properties section from maps widget, so I extracted it into `packages/tools/piw-utils-internal/src/utils/StylingPropertyUtils.ts`.

## What should be covered while testing?
- Whether any default settings for the dimensions does not lead to a non visible barcode scanner
- usage of dimensions properties in maps widget is not affected
- Make sure that in Studio the "Dimensions" tab also shows up

## Extra comments (optional)
### **Please review this without whitespace changes `?w=1`, makes it 10 times easier.**

Link: https://github.com/mendix/widgets-resources/pull/635/files?w=1
