### PR TITLE
fix(pluggable-widgets-tools): fix commonjs imports

### DIFF
--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## 9.2.0 - 2021-05-26
+
+## 9.2.0 - 2021-05-28
 
 ### Changed
 - Update Mendix package to version 9.2.
+
+### Fixed
+- We fixed an issue with external dependencies while code was being converted to CommonJS code.
 
 ## 9.1.0 - 2021-05-25
 

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -305,18 +305,18 @@ const imagesAndFonts = [
     "**/*.eot"
 ];
 
-const webExternal = [/^mendix($|\/)/, /^react(\/|$)/, /^react-dom(\/|$)/, /^big.js(\/|$)/];
+const webExternal = [/^mendix($|\/)/, /^react($|\/)/, /^react-dom($|\/)/, /^big.js$/];
 
-const editorPreviewExternal = [/^mendix($|\/)/, /^react(\/|$)/, /^react-dom(\/|$)/];
+const editorPreviewExternal = [/^mendix($|\/)/, /^react($|\/)/, /^react-dom($|\/)/];
 
 const nativeExternal = [
     /^mendix($|\/)/,
-    /^react-native(\/|$)/,
-    /^big.js(\/|$)/,
-    /^react(\/|$)/,
-    /^react-native-gesture-handler(\/|$)/,
-    /^react-native-reanimated(\/|$)/,
-    /^react-native-svg(\/|$)/,
-    /^react-native-vector-icons(\/|$)/,
-    /^react-navigation(\/|$)/
+    /^react-native($|\/)/,
+    /^big.js$/,
+    /^react($|\/)/,
+    /^react-native-gesture-handler($|\/)/,
+    /^react-native-reanimated($|\/)/,
+    /^react-native-svg($|\/)/,
+    /^react-native-vector-icons($|\/)/,
+    /^react-navigation($|\/)/
 ];

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -305,15 +305,15 @@ const imagesAndFonts = [
     "**/*.eot"
 ];
 
-const webExternal = [/^mendix($|\/)/, "react", "react-dom", "big.js"];
+const webExternal = [/^mendix($|\/)/, /^react(\/|$)/, /^react-dom(\/|$)/, /^big.js(\/|$)/];
 
-const editorPreviewExternal = [/^mendix($|\/)/, "react", "react-dom"];
+const editorPreviewExternal = [/^mendix($|\/)/, /^react(\/|$)/, /^react-dom(\/|$)/];
 
 const nativeExternal = [
     /^mendix($|\/)/,
     /^react-native(\/|$)/,
-    "big.js",
-    "react",
+    /^big.js(\/|$)/,
+    /^react(\/|$)/,
     /^react-native-gesture-handler(\/|$)/,
     /^react-native-reanimated(\/|$)/,
     /^react-native-svg(\/|$)/,

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -56,7 +56,7 @@ export default async args => {
                 file: join(outDir, `${outWidgetFile}.js`),
                 sourcemap: !production ? "inline" : false
             },
-            external: [/^mendix($|\/)/, "react", "react-dom", "big.js"],
+            external: webExternal,
             plugins: [
                 ...getClientComponentPlugins(),
                 url({ include: imagesAndFonts, limit: 100000 }),
@@ -73,7 +73,8 @@ export default async args => {
                     babelConfig: {
                         presets: [["@babel/preset-env", { targets: { safari: "12" } }]],
                         allowAllFormats: true
-                    }
+                    },
+                    external: webExternal
                 })
             ],
             onwarn
@@ -105,7 +106,8 @@ export default async args => {
                     ...getCommonPlugins({
                         sourceMaps: false,
                         extensions: [`.${os}.js`, ".native.js", ".js", ".jsx", ".ts", ".tsx"],
-                        transpile: false
+                        transpile: false,
+                        external: nativeExternal
                     })
                 ],
                 onwarn: warning => {
@@ -126,14 +128,15 @@ export default async args => {
                 file: join(outDir, `${widgetName}.editorPreview.js`),
                 sourcemap: !production ? "inline" : false
             },
-            external: [/^mendix($|\/)/, "react", "react-dom"],
+            external: editorPreviewExternal,
             plugins: [
                 sass({ output: false, include: /\.(css|sass|scss)$/, processor }),
                 ...getCommonPlugins({
                     sourceMaps: !production,
                     extensions: webExtensions,
                     transpile: production,
-                    babelConfig: { presets: [["@babel/preset-env", { targets: { safari: "12" } }]] }
+                    babelConfig: { presets: [["@babel/preset-env", { targets: { safari: "12" } }]] },
+                    external: editorPreviewExternal
                 })
             ],
             onwarn
@@ -203,7 +206,12 @@ export default async args => {
                     }
                 ]
             }),
-            commonjs({ extensions: config.extensions, transformMixedEsModules: true, requireReturnsDefault: true }),
+            commonjs({
+                extensions: config.extensions,
+                transformMixedEsModules: true,
+                requireReturnsDefault: true,
+                ignore: id => (config.external || []).some(value => new RegExp(value).test(id))
+            }),
             replace({
                 patterns: [
                     {
@@ -297,12 +305,16 @@ const imagesAndFonts = [
     "**/*.eot"
 ];
 
+const webExternal = [/^mendix($|\/)/, "react", "react-dom", "big.js"];
+
+const editorPreviewExternal = [/^mendix($|\/)/, "react", "react-dom"];
+
 const nativeExternal = [
-    /^mendix\//,
+    /^mendix($|\/)/,
     /^react-native(\/|$)/,
     "big.js",
     "react",
-    /react-native-gesture-handler\/*/,
+    /^react-native-gesture-handler(\/|$)/,
     /^react-native-reanimated(\/|$)/,
     /^react-native-svg(\/|$)/,
     /^react-native-vector-icons(\/|$)/,


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Native specific
- Works in Android ✅
- Works in iOS ✅
- Works in Tablet ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
This PR fixes external libraries being imported from es5 code (require) and being transpiled to commonjs (import).

## Relevant changes
Added ignore for the commonjs plugin in order to not generate code for external libraries.

## What should be covered while testing?
All native widgets should be tested in order to guarantee the quality of the change. To do this, you need to run: `npm run build` in the root of the mono repo. To define a project, please do `export MX_PROJECT_PATH=YOUR_PATH_TO_TEST_PROJECT` in your terminal before execure `npm run build`, this will automatically copy all the widgets to one specific project.