### PR TITLE
fix(popup-menu-web): fixing onclick while inside a parent containing onclick

### DIFF
--- a/packages/pluggableWidgets/popup-menu-web/package.json
+++ b/packages/pluggableWidgets/popup-menu-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "popup-menu-web",
   "widgetName": "PopupMenu",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "copyright": "Mendix Technology B.V.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/pluggableWidgets/popup-menu-web/src/__tests__/PopupMenu.spec.ts
+++ b/packages/pluggableWidgets/popup-menu-web/src/__tests__/PopupMenu.spec.ts
@@ -48,7 +48,7 @@ describe("Popup menu", () => {
         it("triggers action", () => {
             basicItemProps.action = actionValue();
             const popupMenu = createPopupMenu(defaultProps);
-            const event: any = { target: {} };
+            const event: any = { target: {}, preventDefault: jest.fn(), stopPropagation: jest.fn() };
             popupMenu.find(".popupmenu-basic-item").prop("onClick")!(event);
 
             expect(basicItemProps.action.execute).toHaveBeenCalledTimes(1);

--- a/packages/pluggableWidgets/popup-menu-web/src/__tests__/PopupMenu.spec.ts
+++ b/packages/pluggableWidgets/popup-menu-web/src/__tests__/PopupMenu.spec.ts
@@ -48,9 +48,17 @@ describe("Popup menu", () => {
         it("triggers action", () => {
             basicItemProps.action = actionValue();
             const popupMenu = createPopupMenu(defaultProps);
-            const event: any = { target: {}, preventDefault: jest.fn(), stopPropagation: jest.fn() };
+            const preventDefaultAction = jest.fn();
+            const stopPropagationAction = jest.fn();
+            const event: any = {
+                preventDefault: preventDefaultAction,
+                stopPropagation: stopPropagationAction,
+                target: {}
+            };
             popupMenu.find(".popupmenu-basic-item").prop("onClick")!(event);
 
+            expect(stopPropagationAction).toHaveBeenCalled();
+            expect(preventDefaultAction).toHaveBeenCalled();
             expect(basicItemProps.action.execute).toHaveBeenCalledTimes(1);
         });
 
@@ -106,9 +114,17 @@ describe("Popup menu", () => {
         it("triggers action", () => {
             const action = (customItemProps.action = actionValue());
             const popupMenu = createPopupMenu(defaultProps);
-            const event: any = { target: {} };
+            const preventDefaultAction = jest.fn();
+            const stopPropagationAction = jest.fn();
+            const event: any = {
+                preventDefault: preventDefaultAction,
+                stopPropagation: stopPropagationAction,
+                target: {}
+            };
             popupMenu.find(".popupmenu-custom-item").prop("onClick")!(event);
 
+            expect(stopPropagationAction).toHaveBeenCalled();
+            expect(preventDefaultAction).toHaveBeenCalled();
             expect(action.execute).toHaveBeenCalledTimes(1);
         });
     });

--- a/packages/pluggableWidgets/popup-menu-web/src/components/PopupMenu.tsx
+++ b/packages/pluggableWidgets/popup-menu-web/src/components/PopupMenu.tsx
@@ -34,7 +34,7 @@ export function PopupMenu(props: PopupMenuProps): ReactElement {
             e.stopPropagation();
             setVisibility(prev => !prev);
         },
-        [visibility, setVisibility]
+        [setVisibility]
     );
     const handleOnClickItem = useCallback(
         (itemAction?: ActionValue): void => {
@@ -66,7 +66,7 @@ export function PopupMenu(props: PopupMenuProps): ReactElement {
                 correctPosition(element, props.position);
             }
         }
-    }, [visibility]);
+    }, [props.position, visibility]);
     useEffect(() => {
         setVisibility(props.menuToggle);
     }, [props.menuToggle]);
@@ -111,7 +111,15 @@ function createMenuOptions(
         });
     } else {
         return props.customItems.map((item, index) => (
-            <div key={index} className={"popupmenu-custom-item"} onClick={() => handleOnClickItem(item.action)}>
+            <div
+                key={index}
+                className={"popupmenu-custom-item"}
+                onClick={e => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    handleOnClickItem(item.action);
+                }}
+            >
                 {item.content}
             </div>
         ));

--- a/packages/pluggableWidgets/popup-menu-web/src/components/PopupMenu.tsx
+++ b/packages/pluggableWidgets/popup-menu-web/src/components/PopupMenu.tsx
@@ -28,9 +28,14 @@ export function PopupMenu(props: PopupMenuProps): ReactElement {
     if (!preview) {
         handleOnClickOutsideElement(ref, () => setVisibility(false));
     }
-    const handleOnClickTrigger = useCallback((): void => {
-        setVisibility(prev => !prev);
-    }, [visibility, setVisibility]);
+    const handleOnClickTrigger = useCallback(
+        (e): void => {
+            e.preventDefault();
+            e.stopPropagation();
+            setVisibility(prev => !prev);
+        },
+        [visibility, setVisibility]
+    );
     const handleOnClickItem = useCallback(
         (itemAction?: ActionValue): void => {
             setVisibility(false);
@@ -93,7 +98,11 @@ function createMenuOptions(
                     <div
                         key={index}
                         className={classNames("popupmenu-basic-item", pickedStyle)}
-                        onClick={() => handleOnClickItem(item.action)}
+                        onClick={e => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            handleOnClickItem(item.action);
+                        }}
                     >
                         {item.caption?.value ?? ""}
                     </div>

--- a/packages/pluggableWidgets/popup-menu-web/src/package.xml
+++ b/packages/pluggableWidgets/popup-menu-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="PopupMenu" version="2.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="PopupMenu" version="2.0.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="PopupMenu.xml"/>
         </widgetFiles>


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

#### Feature specific
- Comply with designs ✅
- Comply with PM's requirements ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
This PR fixes the onclick events of pop-up menu if it was modeled inside a parent containing also an onclick event like clickable container or data grid v2.

## Relevant changes
Just added preventDefault and stopPropagation to avoid the event of the parent to be triggered.

## What should be covered while testing?
--
