### PR TITLE
 [NC-312] Dropdown width

### DIFF
--- a/packages/theming/atlas/scripts/build.js
+++ b/packages/theming/atlas/scripts/build.js
@@ -1,6 +1,6 @@
 const concurrently = require("concurrently");
 const { join } = require("path");
-const { rm } = require("shelljs");
+const { rm, mkdir } = require("shelljs");
 
 main().catch(e => {
     console.error(e);
@@ -34,6 +34,13 @@ async function main() {
         throw new Error(`Invalid mode: "${mode}"`);
     }
 
+    // when targeting a networked windows drive, the cmds executed by concurrently run into a race condition when
+    // creating directories. create them here to avoid the error.
+    mkdir(join(outputDir, "theme"));
+    mkdir(join(outputDir, "themesource/atlas_core"));
+    mkdir(join(outputDir, "themesource/atlas_web_content"));
+    mkdir(join(outputDir, "themesource/atlas_nativemobile_content"));
+
     await buildAndCopyAtlas(mode === "start", outputDir);
 }
 
@@ -46,15 +53,21 @@ async function buildAndCopyAtlas(watchMode, destination) {
             [
                 {
                     name: "web-theme-content",
-                    command: `copy-and-watch ${watchArg} "src/theme/web/**/*" "${destination}/theme/web"`
+                    command: `copy-and-watch ${watchArg} "src/theme/web/**/*" "${join(destination, "/theme/web")}"`
                 },
                 {
                     name: "web-themesource-core",
-                    command: `copy-and-watch ${watchArg} "src/themesource/atlas_core/web/**/*" "${destination}/themesource/atlas_core/web"`
+                    command: `copy-and-watch ${watchArg} "src/themesource/atlas_core/web/**/*" "${join(
+                        destination,
+                        "/themesource/atlas_core/web"
+                    )}"`
                 },
                 {
                     name: "web-themesource-content",
-                    command: `copy-and-watch ${watchArg} "src/themesource/atlas_web_content/web/**/*" "${destination}/themesource/atlas_web_content/web"`
+                    command: `copy-and-watch ${watchArg} "src/themesource/atlas_web_content/web/**/*" "${join(
+                        destination,
+                        "/themesource/atlas_web_content/web"
+                    )}"`
                 },
                 {
                     name: "native-typescript",
@@ -62,7 +75,10 @@ async function buildAndCopyAtlas(watchMode, destination) {
                 },
                 {
                     name: "native-design-properties-and-manifest",
-                    command: `copy-and-watch ${watchArg} "src/themesource/atlas_core/native/**/*.json" "${destination}/themesource/atlas_core/native"`
+                    command: `copy-and-watch ${watchArg} "src/themesource/atlas_core/native/**/*.json" "${join(
+                        destination,
+                        "/themesource/atlas_core/native"
+                    )}"`
                 }
             ],
             {

--- a/packages/theming/atlas/src/theme/native/custom-variables.ts
+++ b/packages/theming/atlas/src/theme/native/custom-variables.ts
@@ -262,7 +262,6 @@ export const input: VariablesInput = {
         rippleColor: contrast.lowest
     },
     itemContainer: {
-        maxWidth: 500,
         paddingVertical: 12,
         paddingHorizontal: spacing.regular,
         backgroundColor: background.primary

--- a/packages/theming/atlas/src/themesource/atlas_core/native/core/widgets/dropdown.ts
+++ b/packages/theming/atlas/src/themesource/atlas_core/native/core/widgets/dropdown.ts
@@ -92,7 +92,6 @@ export const DropDown: DropDownType = {
     },
     itemContainer: {
         // All ViewStyle properties & rippleColor & activeOpacity & underlayColor are allowed
-        maxWidth: input.itemContainer.maxWidth,
         paddingVertical: input.itemContainer.paddingVertical,
         paddingHorizontal: input.itemContainer.paddingHorizontal,
         backgroundColor: input.itemContainer.backgroundColor,

--- a/packages/theming/atlas/src/themesource/atlas_core/native/core/widgets/dropdown.ts
+++ b/packages/theming/atlas/src/themesource/atlas_core/native/core/widgets/dropdown.ts
@@ -92,6 +92,8 @@ export const DropDown: DropDownType = {
     },
     itemContainer: {
         // All ViewStyle properties & rippleColor & activeOpacity & underlayColor are allowed
+        width: "100%",
+        maxWidth: undefined, // unset core widget's default maxWidth value (prior to 9.3)
         paddingVertical: input.itemContainer.paddingVertical,
         paddingHorizontal: input.itemContainer.paddingHorizontal,
         backgroundColor: input.itemContainer.backgroundColor,
@@ -111,6 +113,8 @@ export const DropDown: DropDownType = {
     },
     selectedItemContainer: {
         // All ViewStyle properties are allowed
+        width: "100%",
+        maxWidth: undefined, // unset core widget's default maxWidth value (prior to 9.3)
         borderWidth: input.selectedItemContainer.borderWidth,
         borderRadius: input.selectedItemContainer.borderRadius,
         borderColor: input.selectedItemContainer.borderColor,

--- a/packages/theming/atlas/src/themesource/atlas_core/native/types/variables.d.ts
+++ b/packages/theming/atlas/src/themesource/atlas_core/native/types/variables.d.ts
@@ -206,7 +206,6 @@ export interface VariablesInput {
         rippleColor: string;
     };
     itemContainer: {
-        maxWidth: number;
         paddingVertical: number;
         paddingHorizontal: number;
         backgroundColor: string;

--- a/packages/theming/atlas/src/themesource/atlas_core/native/variables.ts
+++ b/packages/theming/atlas/src/themesource/atlas_core/native/variables.ts
@@ -266,7 +266,6 @@ let input: VariablesInput = {
         rippleColor: contrast.lowest
     },
     itemContainer: {
-        maxWidth: 500,
         paddingVertical: 12,
         paddingHorizontal: spacing.regular,
         backgroundColor: background.primary


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌ (end-user projects will change in that dropdowns will be differently sized)
- Contains Atlas changes ✅ 
- Compatible with: MX 9️⃣

## This PR contains
- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
### Feature: 

Remove `maxWidth` here in Atlas and add `width: "100%"` in client code for dropdowns so that they take up all available width of their parent.

Atlas set dropdown's `maxWidth` to 500. Why? Neither Wesley or I know why 500 was chosen. Based on customer feedback, when the device viewport is large, customers expect the menu items to be the same width as the element that renders the selected value. This change ensures that.

### Bugfix (bonus)
Atlas build script did not handle network drive paths and a race condition was encountered when cmds tried to create directories and conflicted.

## What should be covered while testing?
Native dropdown renders appropriately in different modelled scenarios.