### PR TITLE
fix(datagrid-web): fixing on change settings being triggered too often

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -8,9 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## 1.2.0 - Unreleased
 
 ### Added
-- We've implemented lazy filtering and sorting. Now the data grid v2 will not load all the data if you have sorting or filtering enabled.
+- We implemented lazy filtering and sorting. Now Data Grid v2 will not load all the data if you have sorting or filtering enabled.
+- We added an option to auto-load values from enumerations in the Data Grid drop-down filter.
 
 ### Changed
-- We've fixed a problem while having text box widget inside a column with an on leave/change event it was loosing focus after trigger the events
-- Prevent settings' onchange action being fired continuously while resizing a column, causing performance issues.
-- Prevent the settings from being overwritten when loading a new value from the settings attribute.
+- We fixed a problem combining a Text Box widget inside a column with an on leave or on change event preventing focus from being lost after triggering the events.
+- We fixed an issue with headers containing attributes in the text template.
+- We prevented settings' on change action to be fired continuously while resizing a column, causing performance issues.
+- We prevented the settings from being overwritten when loading a new value from the settings attribute.

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -12,5 +12,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - We've fixed a problem while having text box widget inside a column with an on leave/change event it was loosing focus after trigger the events
-- We've fixed a problem with 'Configuration' attribute and its on change event that was causing too many changes in the database while a column was being resized.
-- We've made drastic code improvements that increased the performance and reliability of the widget.
+- Prevent settings' onchange action being fired continuously while resizing a column, causing performance issues.
+- Prevent the settings from being overwritten when loading a new value from the settings attribute.

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -13,6 +13,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - We've fixed a problem while having text box widget inside a column with an on leave/change event it was loosing focus after trigger the events
 - We've fixed a problem with 'Configuration' attribute and its on change event that was causing too many changes in the database while a column was being resized.
-
-### Removed
-- We've removed 'react-table' library from our code, so now we do not rely on any 3rd party library anymore.
+- We've made drastic code improvements that increased the performance and reliability of the widget.

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOM.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOM.md
@@ -1,0 +1,18 @@
+# Changelog
+All notable changes to this widget will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## 1.2.0 - Unreleased
+
+### Added
+- We've implemented lazy filtering and sorting. Now the data grid v2 will not load all the data if you have sorting or filtering enabled.
+
+### Changed
+- We've fixed a problem while having text box widget inside a column with an on leave/change event it was loosing focus after trigger the events
+- We've fixed a problem with 'Configuration' attribute and its on change event that was causing too many changes in the database while a column was being resized.
+
+### Removed
+- We've removed 'react-table' library from our code, so now we do not rely on any 3rd party library anymore.

--- a/packages/pluggableWidgets/datagrid-web/src/components/ColumnResizer.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/ColumnResizer.tsx
@@ -1,12 +1,12 @@
 import { createElement, ReactElement, useCallback, useEffect, useRef, useState, MouseEvent, TouchEvent } from "react";
 
-export function ColumnResizer({
-    minWidth = 50,
-    setColumnWidth
-}: {
+export interface ColumnResizerProps {
     minWidth?: number;
     setColumnWidth: (width: number) => void;
-}): ReactElement {
+    onResizeEnds?: () => void;
+}
+
+export function ColumnResizer({ minWidth = 50, setColumnWidth, onResizeEnds }: ColumnResizerProps): ReactElement {
     const [isResizing, setIsResizing] = useState(false);
     const [startPosition, setStartPosition] = useState(0);
     const [currentWidth, setCurrentWidth] = useState(0);
@@ -25,9 +25,13 @@ export function ColumnResizer({
         [resizerReference.current]
     );
     const onEndDrag = useCallback((): void => {
+        if (!isResizing) {
+            return;
+        }
         setIsResizing(false);
         setCurrentWidth(0);
-    }, []);
+        onResizeEnds?.();
+    }, [onResizeEnds, isResizing]);
     const onMouseMove = useCallback(
         (e: TouchEvent & MouseEvent & Event): void => {
             if (!isResizing) {
@@ -60,7 +64,7 @@ export function ColumnResizer({
             document.removeEventListener("touchmove", onMouseMove);
             document.removeEventListener("touchend", onEndDrag);
         };
-    }, [isResizing, resizerReference.current]); // Required dependencies because of the callback's references
+    }, [onMouseMove, onEndDrag]);
 
     return (
         <div ref={resizerReference} className="column-resizer" onMouseDown={onStartDrag} onTouchStart={onStartDrag}>

--- a/packages/pluggableWidgets/datagrid-web/src/components/Header.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Header.tsx
@@ -3,7 +3,7 @@ import classNames from "classnames";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faLongArrowAltDown, faLongArrowAltUp, faArrowsAltV } from "@fortawesome/free-solid-svg-icons";
 import { ColumnProperty } from "./Table";
-import { ColumnResizer } from "./ColumnResizer";
+import { ColumnResizerProps } from "./ColumnResizer";
 import { SortingRule } from "../utils/settings";
 
 export interface HeaderProps {
@@ -17,8 +17,8 @@ export interface HeaderProps {
     hidable: boolean;
     isDragging?: boolean;
     preview?: boolean;
+    resizer: ReactElement<ColumnResizerProps>;
     setColumnOrder: (updater: string[]) => void;
-    setColumnWidth: (width: number) => void;
     setDragOver: Dispatch<SetStateAction<string>>;
     setIsDragging: Dispatch<SetStateAction<boolean>>;
     setSortBy: Dispatch<SetStateAction<SortingRule[]>>;
@@ -108,7 +108,7 @@ export function Header(props: HeaderProps): ReactElement {
                 </div>
                 {props.filterable && props.column.customFilter ? props.column.customFilter : null}
             </div>
-            {props.resizable && props.column.canResize && <ColumnResizer setColumnWidth={props.setColumnWidth} />}
+            {props.resizable && props.column.canResize && props.resizer}
         </div>
     );
 }

--- a/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
@@ -17,6 +17,7 @@ import { Big } from "big.js";
 import classNames from "classnames";
 import { EditableValue } from "mendix";
 import { SortingRule, useSettings } from "../utils/settings";
+import { ColumnResizer } from "./ColumnResizer";
 
 export type TableColumn = Omit<
     ColumnsPreviewType,
@@ -91,7 +92,7 @@ export function Table<T>(props: TableProps<T>): ReactElement {
         Object.fromEntries(props.columns.map((_c, index) => [index.toString(), undefined]))
     );
 
-    useSettings(
+    const [updateSettings] = useSettings(
         props.settings,
         props.onSettingsChange,
         props.columns,
@@ -104,6 +105,8 @@ export function Table<T>(props: TableProps<T>): ReactElement {
         columnsWidth,
         setColumnsWidth
     );
+
+    useEffect(() => updateSettings(), [columnOrder, hiddenColumns, sortBy]);
 
     useEffect(() => {
         const [sortProperties] = sortBy;
@@ -248,13 +251,18 @@ export function Table<T>(props: TableProps<T>): ReactElement {
                                 isDragging={isDragging}
                                 preview={props.preview}
                                 resizable={props.columnsResizable}
-                                setColumnOrder={(newOrder: string[]) => setColumnOrder(newOrder)}
-                                setColumnWidth={(width: number) =>
-                                    setColumnsWidth(prev => {
-                                        prev[column.id] = width;
-                                        return { ...prev };
-                                    })
+                                resizer={
+                                    <ColumnResizer
+                                        onResizeEnds={updateSettings}
+                                        setColumnWidth={(width: number) =>
+                                            setColumnsWidth(prev => {
+                                                prev[column.id] = width;
+                                                return { ...prev };
+                                            })
+                                        }
+                                    />
                                 }
+                                setColumnOrder={(newOrder: string[]) => setColumnOrder(newOrder)}
                                 setDragOver={setDragOver}
                                 setIsDragging={setIsDragging}
                                 setSortBy={setSortBy}

--- a/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
@@ -92,7 +92,7 @@ export function Table<T>(props: TableProps<T>): ReactElement {
         Object.fromEntries(props.columns.map((_c, index) => [index.toString(), undefined]))
     );
 
-    const [updateSettings] = useSettings(
+    const { updateSettings } = useSettings(
         props.settings,
         props.onSettingsChange,
         props.columns,

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Header.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Header.spec.tsx
@@ -1,6 +1,7 @@
 import { shallow } from "enzyme";
 import { createElement } from "react";
 import { Header, HeaderProps } from "../Header";
+import { ColumnResizer } from "../ColumnResizer";
 
 describe("Header", () => {
     it("renders the structure correctly", () => {
@@ -113,9 +114,9 @@ function mockHeaderProps(): HeaderProps {
         filterable: false,
         hidable: false,
         resizable: false,
+        resizer: <ColumnResizer setColumnWidth={jest.fn()} />,
         sortable: false,
         setColumnOrder: jest.fn(),
-        setColumnWidth: jest.fn(),
         setDragOver: jest.fn(),
         visibleColumns: [],
         setSortBy: jest.fn(),

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/__snapshots__/Table.spec.tsx.snap
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/__snapshots__/Table.spec.tsx.snap
@@ -46,8 +46,13 @@ exports[`Table renders the structure correctly 1`] = `
         isDragging={false}
         key="headers_column_0"
         resizable={false}
+        resizer={
+          <ColumnResizer
+            onResizeEnds={[Function]}
+            setColumnWidth={[Function]}
+          />
+        }
         setColumnOrder={[Function]}
-        setColumnWidth={[Function]}
         setDragOver={[Function]}
         setIsDragging={[Function]}
         setSortBy={[Function]}
@@ -138,8 +143,13 @@ exports[`Table renders the structure correctly for preview when no header is pro
         key="headers_column_0"
         preview={true}
         resizable={false}
+        resizer={
+          <ColumnResizer
+            onResizeEnds={[Function]}
+            setColumnWidth={[Function]}
+          />
+        }
         setColumnOrder={[Function]}
-        setColumnWidth={[Function]}
         setDragOver={[Function]}
         setIsDragging={[Function]}
         setSortBy={[Function]}
@@ -229,8 +239,13 @@ exports[`Table renders the structure correctly with column alignments 1`] = `
         isDragging={false}
         key="headers_column_0"
         resizable={false}
+        resizer={
+          <ColumnResizer
+            onResizeEnds={[Function]}
+            setColumnWidth={[Function]}
+          />
+        }
         setColumnOrder={[Function]}
-        setColumnWidth={[Function]}
         setDragOver={[Function]}
         setIsDragging={[Function]}
         setSortBy={[Function]}
@@ -294,8 +309,13 @@ exports[`Table renders the structure correctly with column alignments 1`] = `
         isDragging={false}
         key="headers_column_1"
         resizable={false}
+        resizer={
+          <ColumnResizer
+            onResizeEnds={[Function]}
+            setColumnWidth={[Function]}
+          />
+        }
         setColumnOrder={[Function]}
-        setColumnWidth={[Function]}
         setDragOver={[Function]}
         setIsDragging={[Function]}
         setSortBy={[Function]}
@@ -408,8 +428,13 @@ exports[`Table renders the structure correctly with custom filtering 1`] = `
         isDragging={false}
         key="headers_column_0"
         resizable={false}
+        resizer={
+          <ColumnResizer
+            onResizeEnds={[Function]}
+            setColumnWidth={[Function]}
+          />
+        }
         setColumnOrder={[Function]}
-        setColumnWidth={[Function]}
         setDragOver={[Function]}
         setIsDragging={[Function]}
         setSortBy={[Function]}
@@ -502,8 +527,13 @@ exports[`Table renders the structure correctly with dragging 1`] = `
         isDragging={false}
         key="headers_column_0"
         resizable={false}
+        resizer={
+          <ColumnResizer
+            onResizeEnds={[Function]}
+            setColumnWidth={[Function]}
+          />
+        }
         setColumnOrder={[Function]}
-        setColumnWidth={[Function]}
         setDragOver={[Function]}
         setIsDragging={[Function]}
         setSortBy={[Function]}
@@ -593,8 +623,13 @@ exports[`Table renders the structure correctly with dynamic row class 1`] = `
         isDragging={false}
         key="headers_column_0"
         resizable={false}
+        resizer={
+          <ColumnResizer
+            onResizeEnds={[Function]}
+            setColumnWidth={[Function]}
+          />
+        }
         setColumnOrder={[Function]}
-        setColumnWidth={[Function]}
         setDragOver={[Function]}
         setIsDragging={[Function]}
         setSortBy={[Function]}
@@ -684,8 +719,13 @@ exports[`Table renders the structure correctly with empty placeholder 1`] = `
         isDragging={false}
         key="headers_column_0"
         resizable={false}
+        resizer={
+          <ColumnResizer
+            onResizeEnds={[Function]}
+            setColumnWidth={[Function]}
+          />
+        }
         setColumnOrder={[Function]}
-        setColumnWidth={[Function]}
         setDragOver={[Function]}
         setIsDragging={[Function]}
         setSortBy={[Function]}
@@ -778,8 +818,13 @@ exports[`Table renders the structure correctly with filtering 1`] = `
         isDragging={false}
         key="headers_column_0"
         resizable={false}
+        resizer={
+          <ColumnResizer
+            onResizeEnds={[Function]}
+            setColumnWidth={[Function]}
+          />
+        }
         setColumnOrder={[Function]}
-        setColumnWidth={[Function]}
         setDragOver={[Function]}
         setIsDragging={[Function]}
         setSortBy={[Function]}
@@ -875,8 +920,13 @@ exports[`Table renders the structure correctly with header wrapper 1`] = `
           isDragging={false}
           key="headers_column_0"
           resizable={false}
+          resizer={
+            <ColumnResizer
+              onResizeEnds={[Function]}
+              setColumnWidth={[Function]}
+            />
+          }
           setColumnOrder={[Function]}
-          setColumnWidth={[Function]}
           setDragOver={[Function]}
           setIsDragging={[Function]}
           setSortBy={[Function]}
@@ -967,8 +1017,13 @@ exports[`Table renders the structure correctly with hiding 1`] = `
         isDragging={false}
         key="headers_column_0"
         resizable={false}
+        resizer={
+          <ColumnResizer
+            onResizeEnds={[Function]}
+            setColumnWidth={[Function]}
+          />
+        }
         setColumnOrder={[Function]}
-        setColumnWidth={[Function]}
         setDragOver={[Function]}
         setIsDragging={[Function]}
         setSortBy={[Function]}
@@ -1083,8 +1138,13 @@ exports[`Table renders the structure correctly with paging 1`] = `
         isDragging={false}
         key="headers_column_0"
         resizable={false}
+        resizer={
+          <ColumnResizer
+            onResizeEnds={[Function]}
+            setColumnWidth={[Function]}
+          />
+        }
         setColumnOrder={[Function]}
-        setColumnWidth={[Function]}
         setDragOver={[Function]}
         setIsDragging={[Function]}
         setSortBy={[Function]}
@@ -1184,8 +1244,13 @@ exports[`Table renders the structure correctly with resizing 1`] = `
         isDragging={false}
         key="headers_column_0"
         resizable={true}
+        resizer={
+          <ColumnResizer
+            onResizeEnds={[Function]}
+            setColumnWidth={[Function]}
+          />
+        }
         setColumnOrder={[Function]}
-        setColumnWidth={[Function]}
         setDragOver={[Function]}
         setIsDragging={[Function]}
         setSortBy={[Function]}
@@ -1275,8 +1340,13 @@ exports[`Table renders the structure correctly with sorting 1`] = `
         isDragging={false}
         key="headers_column_0"
         resizable={false}
+        resizer={
+          <ColumnResizer
+            onResizeEnds={[Function]}
+            setColumnWidth={[Function]}
+          />
+        }
         setColumnOrder={[Function]}
-        setColumnWidth={[Function]}
         setDragOver={[Function]}
         setIsDragging={[Function]}
         setSortBy={[Function]}

--- a/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
@@ -149,39 +149,44 @@ describe("useSettings Hook", () => {
         expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
     });
 
-    // it("doesnt change the hooks when same properties are applied", () => {
-    //     const props = mockProperties();
-    //     const initialProps = {
-    //         settings: props.settings,
-    //         onSettingsChange: props.onSettingsChange,
-    //         columns: props.columns,
-    //         columnOrder: ["0"],
-    //         setColumnOrder: props.setColumnOrder,
-    //         hiddenColumns: [],
-    //         setHiddenColumns: props.setHiddenColumns,
-    //         sortBy: [{ id: "0", desc: true }],
-    //         setSortBy: props.setSortBy,
-    //         widths: { "0": undefined } as ColumnWidth,
-    //         setWidths: props.setWidths
-    //     };
-    //
-    //     const { rerender } = renderUseSettingsHook(initialProps);
-    //     // Initiates the hooks with values from settings once
-    //     expect(props.setColumnOrder).toHaveBeenCalledTimes(1);
-    //     expect(props.setHiddenColumns).toHaveBeenCalledTimes(1);
-    //     expect(props.setSortBy).toHaveBeenCalledTimes(1);
-    //     expect(props.setWidths).toHaveBeenCalledTimes(1);
-    //     expect(props.settings.setValue).toHaveBeenCalledTimes(0);
-    //     expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
-    //     rerender(initialProps);
-    //     expect(props.setColumnOrder).toHaveBeenCalledTimes(1);
-    //     expect(props.setHiddenColumns).toHaveBeenCalledTimes(1);
-    //     expect(props.setSortBy).toHaveBeenCalledTimes(1);
-    //     expect(props.setWidths).toHaveBeenCalledTimes(1);
-    //     expect(props.settings.setValue).toHaveBeenCalledTimes(0);
-    //     expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
-    // });
-    //
+    it("doesnt change the hooks when same properties are applied", () => {
+        const props = mockProperties();
+        const initialProps = {
+            settings: props.settings,
+            onSettingsChange: props.onSettingsChange,
+            columns: props.columns,
+            columnOrder: ["0"],
+            setColumnOrder: props.setColumnOrder,
+            hiddenColumns: [],
+            setHiddenColumns: props.setHiddenColumns,
+            sortBy: [{ id: "0", desc: true }],
+            setSortBy: props.setSortBy,
+            widths: { "0": undefined } as ColumnWidth,
+            setWidths: props.setWidths
+        };
+
+        const { result, rerender } = renderUseSettingsHook(initialProps);
+        // Initiates the hooks with values from settings once
+        expect(props.setColumnOrder).toHaveBeenCalledTimes(1);
+        expect(props.setHiddenColumns).toHaveBeenCalledTimes(1);
+        expect(props.setSortBy).toHaveBeenCalledTimes(1);
+        expect(props.setWidths).toHaveBeenCalledTimes(1);
+        expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
+
+        rerender({ ...initialProps });
+        act(() => {
+            result.current.updateSettings();
+        });
+
+        expect(props.setColumnOrder).toHaveBeenCalledTimes(1);
+        expect(props.setHiddenColumns).toHaveBeenCalledTimes(1);
+        expect(props.setSortBy).toHaveBeenCalledTimes(1);
+        expect(props.setWidths).toHaveBeenCalledTimes(1);
+        expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
+    });
+
     it("applies changes to settings when receiving external changes", () => {
         const props = mockProperties();
         props.settings = new EditableValueBuilder<string>().withValue("").build();

--- a/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
@@ -4,6 +4,7 @@ import { EditableValueBuilder } from "@mendix/piw-utils-internal";
 import { HidableEnum } from "../../../typings/DatagridProps";
 import { renderHook } from "@testing-library/react-hooks";
 import { EditableValue } from "mendix";
+import { act } from "react-dom/test-utils";
 
 describe("useSettings Hook", () => {
     let settings: EditableValue<string>;
@@ -130,41 +131,40 @@ describe("useSettings Hook", () => {
     // });
 
     it("changes the settings when some property changes", () => {
-        const { result } = renderHook(() =>
-            useSettings(
-                settings,
-                onSettingsChange,
-                columns,
-                columnOrder,
-                setColumnOrder,
-                hiddenColumns,
-                setHiddenColumns,
-                sortBy,
-                setSortBy,
-                widths,
-                setWidths
-            )
-        );
+        const initialProps = {
+            settings,
+            onSettingsChange,
+            columns,
+            columnOrder,
+            setColumnOrder,
+            hiddenColumns,
+            setHiddenColumns,
+            sortBy,
+            setSortBy,
+            widths,
+            setWidths
+        };
+        const { result, rerender } = renderUseSettingsHook(initialProps);
         expect(settings.setValue).toHaveBeenCalledTimes(0);
         expect(onSettingsChange).toHaveBeenCalledTimes(0);
 
         jest.advanceTimersByTime(100);
 
-        setColumnOrder(() => ["0"]);
-        setSortBy(() => [{ id: "0", desc: true }]);
-        setWidths(() => ({ "0": 130 }));
+        rerender({
+            ...initialProps,
+            columnOrder: ["0"],
+            sortBy: [{ id: "0", desc: true }],
+            widths: { "0": 130 }
+        });
 
-        // act(() => {
         result.current.updateSettings();
-        // });
 
-        expect(settings.setValue).toHaveBeenCalledTimes(1);
         expect(settings.setValue).toHaveBeenCalledWith(
             JSON.stringify([
                 {
                     column: "Column 1",
                     sort: true,
-                    sortMethod: "asc",
+                    sortMethod: "desc",
                     hidden: false,
                     order: 0,
                     width: 130
@@ -174,29 +174,30 @@ describe("useSettings Hook", () => {
         expect(onSettingsChange).toHaveBeenCalledTimes(1);
     });
     //
-    // it("doesnt change the settings when same properties are applied", () => {
-    //     const props = mockProperties();
-    //     const initialProps = {
-    //         settings: props.settings,
-    //         onSettingsChange: props.onSettingsChange,
-    //         columns: props.columns,
-    //         columnOrder: ["0"],
-    //         setColumnOrder: props.setColumnOrder,
-    //         hiddenColumns: [],
-    //         setHiddenColumns: props.setHiddenColumns,
-    //         sortBy: [{ id: "0", desc: true }],
-    //         setSortBy: props.setSortBy,
-    //         widths: { "0": undefined } as ColumnWidth,
-    //         setWidths: props.setWidths
-    //     };
-    //
-    //     const { rerender } = renderUseSettingsHook(initialProps);
-    //     expect(props.settings.setValue).toHaveBeenCalledTimes(0);
-    //     expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
-    //     rerender(initialProps);
-    //     expect(props.settings.setValue).toHaveBeenCalledTimes(0);
-    //     expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
-    // });
+    it("doesnt change the settings when same properties are applied", () => {
+        const props = mockProperties();
+        const initialProps = {
+            settings: props.settings,
+            onSettingsChange: props.onSettingsChange,
+            columns: props.columns,
+            columnOrder: ["0"],
+            setColumnOrder: props.setColumnOrder,
+            hiddenColumns: [],
+            setHiddenColumns: props.setHiddenColumns,
+            sortBy: [{ id: "0", desc: true }],
+            setSortBy: props.setSortBy,
+            widths: { "0": undefined } as ColumnWidth,
+            setWidths: props.setWidths
+        };
+
+        const { result, rerender } = renderUseSettingsHook(initialProps);
+        expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
+        rerender(initialProps);
+        result.current.updateSettings();
+        expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
+    });
     //
     // it("doesnt change the hooks when same properties are applied", () => {
     //     const props = mockProperties();
@@ -231,79 +232,117 @@ describe("useSettings Hook", () => {
     //     expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
     // });
     //
-    // it("applies changes to settings when receiving external changes", () => {
-    //     const props = mockProperties();
-    //     props.settings = new EditableValueBuilder<string>().withValue("").build();
-    //
-    //     const { rerender, result } = renderUseSettingsHook(props);
-    //     const [updateSettings] = result.current;
-    //     // Remains uncalled
-    //     expect(props.settings.setValue).toHaveBeenCalledTimes(0);
-    //     expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
-    //
-    //     rerender({ ...props, sortBy: [{ id: "0", desc: false }] });
-    //     act(() => {
-    //         updateSettings();
-    //     });
-    //
-    //     expect(props.settings.setValue).toHaveBeenCalledTimes(1);
-    //     expect(props.settings.setValue).toHaveBeenCalledWith(
-    //         JSON.stringify([{ column: "Column 1", sort: true, sortMethod: "desc", hidden: false, order: 0 }])
-    //     );
-    //     expect(props.onSettingsChange).toHaveBeenCalledTimes(1);
-    //
-    //     rerender({ ...props, sortBy: [{ id: "0", desc: true }] });
-    //     act(() => {
-    //         updateSettings();
-    //     });
-    //
-    //     expect(props.settings.setValue).toHaveBeenCalledTimes(1);
-    //     expect(props.onSettingsChange).toHaveBeenCalledTimes(1);
-    // });
+    it("applies changes to settings when receiving external changes", () => {
+        const props = mockProperties();
+        props.settings = new EditableValueBuilder<string>().withValue("").build();
+
+        const { rerender, result } = renderUseSettingsHook(props);
+        // Remains uncalled
+        expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
+
+        rerender({ ...props, sortBy: [{ id: "0", desc: false }] });
+        act(() => {
+            // Do not destructure or assign this to a variable earlier, because it's a mutable object and doing so will copy lock it,
+            // which interferes with the `useCallback` memoization (https://react-hooks-testing-library.com/usage/basic-hooks#updates).
+            result.current.updateSettings();
+        });
+
+        expect(props.settings.setValue).toHaveBeenCalledTimes(1);
+        expect(props.settings.setValue).toHaveBeenCalledWith(
+            JSON.stringify([{ column: "Column 1", sort: true, sortMethod: "asc", hidden: false, order: 0 }])
+        );
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(1);
+
+        rerender({ ...props, sortBy: [{ id: "0", desc: true }] });
+        act(() => {
+            result.current.updateSettings();
+        });
+
+        expect(props.settings.setValue).toHaveBeenCalledTimes(2);
+        expect(props.settings.setValue).toHaveBeenCalledWith(
+            JSON.stringify([{ column: "Column 1", sort: true, sortMethod: "desc", hidden: false, order: 0 }])
+        );
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(2);
+    });
 });
 //
-// function renderUseSettingsHook(initialProps: {
-//     settings: EditableValue<string>;
-//     onSettingsChange: () => void;
-//     hiddenColumns: any[];
-//     columnOrder: string[];
-//     columns: any;
-//     setHiddenColumns: any;
-//     sortBy: Array<{ id: string; desc: boolean }>;
-//     widths: ColumnWidth;
-//     setSortBy: any;
-//     setWidths: any;
-//     setColumnOrder: any;
-// }) {
-//     return renderHook(
-//         ({
-//             settings,
-//             onSettingsChange,
-//             columns,
-//             columnOrder,
-//             setColumnOrder,
-//             hiddenColumns,
-//             setHiddenColumns,
-//             sortBy,
-//             setSortBy,
-//             widths,
-//             setWidths
-//         }) =>
-//             useSettings(
-//                 settings,
-//                 onSettingsChange,
-//                 columns,
-//                 columnOrder,
-//                 setColumnOrder,
-//                 hiddenColumns,
-//                 setHiddenColumns,
-//                 sortBy,
-//                 setSortBy,
-//                 widths,
-//                 setWidths
-//             ),
-//         {
-//             initialProps
-//         }
-//     );
-// }
+function renderUseSettingsHook(initialProps: {
+    settings: EditableValue<string>;
+    onSettingsChange: () => void;
+    hiddenColumns: any[];
+    columnOrder: string[];
+    columns: any;
+    setHiddenColumns: any;
+    sortBy: Array<{ id: string; desc: boolean }>;
+    widths: ColumnWidth;
+    setSortBy: any;
+    setWidths: any;
+    setColumnOrder: any;
+}) {
+    return renderHook(
+        ({
+            settings,
+            onSettingsChange,
+            columns,
+            columnOrder,
+            setColumnOrder,
+            hiddenColumns,
+            setHiddenColumns,
+            sortBy,
+            setSortBy,
+            widths,
+            setWidths
+        }) =>
+            useSettings(
+                settings,
+                onSettingsChange,
+                columns,
+                columnOrder,
+                setColumnOrder,
+                hiddenColumns,
+                setHiddenColumns,
+                sortBy,
+                setSortBy,
+                widths,
+                setWidths
+            ),
+        {
+            initialProps
+        }
+    );
+}
+
+function mockProperties(): any {
+    return {
+        settings: new EditableValueBuilder<string>()
+            .withValue(
+                JSON.stringify([
+                    {
+                        column: "Column 1",
+                        sort: true,
+                        sortMethod: "desc",
+                        hidden: false,
+                        order: 0,
+                        width: undefined
+                    }
+                ])
+            )
+            .build(),
+        onSettingsChange: jest.fn(),
+        columns: [
+            {
+                header: "Column 1",
+                hidable: "yes" as HidableEnum
+            }
+        ] as TableColumn[],
+        columnOrder: [],
+        setColumnOrder: jest.fn(),
+        hiddenColumns: [],
+        setHiddenColumns: jest.fn(),
+        sortBy: [],
+        setSortBy: jest.fn(),
+        widths: { "0": undefined },
+        setWidths: jest.fn()
+    };
+}

--- a/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
@@ -1,47 +1,25 @@
-import { useSettings } from "../settings";
+import { SortingRule, useSettings } from "../settings";
 import { ColumnWidth, TableColumn } from "../../components/Table";
 import { EditableValueBuilder } from "@mendix/piw-utils-internal";
 import { HidableEnum } from "../../../typings/DatagridProps";
 import { renderHook } from "@testing-library/react-hooks";
+import { EditableValue } from "mendix";
 
 describe("useSettings Hook", () => {
-    it("loads correct values into hooks", () => {
-        const props = mockProperties();
+    let settings: EditableValue<string>;
+    let columnOrder: string[] = [];
+    const setColumnOrder = jest.fn((fn: () => string[]) => (columnOrder = fn()));
+    let hiddenColumns: string[] = [];
+    const setHiddenColumns = jest.fn((fn: () => string[]) => (hiddenColumns = fn()));
+    let sortBy: SortingRule[] = [];
+    const setSortBy = jest.fn((fn: () => SortingRule[]) => (sortBy = fn()));
+    let widths: ColumnWidth = {};
+    const setWidths = jest.fn((fn: () => ColumnWidth) => (widths = fn()));
+    const onSettingsChange = jest.fn();
+    let columns: TableColumn[];
 
-        renderHook(() =>
-            useSettings(
-                props.settings,
-                props.onSettingsChange,
-                props.columns,
-                props.columnOrder,
-                props.setColumnOrder,
-                props.hiddenColumns,
-                props.setHiddenColumns,
-                props.sortBy,
-                props.setSortBy,
-                props.widths,
-                props.setWidths
-            )
-        );
-        expect(props.setColumnOrder).toHaveBeenCalledTimes(1);
-        expect(props.setHiddenColumns).toHaveBeenCalledTimes(1);
-        expect(props.setSortBy).toHaveBeenCalledTimes(1);
-        expect(props.setWidths).toHaveBeenCalledTimes(1);
-    });
-
-    it("calls state functions with correct values", () => {
-        const props = mockProperties();
-        const columns = [
-            {
-                header: "Column 1",
-                hidable: "yes" as HidableEnum
-            },
-            {
-                header: "Column 2",
-                hidable: "hidden" as HidableEnum
-            }
-        ] as TableColumn[];
-        const settings = new EditableValueBuilder<string>()
+    beforeEach(() => {
+        settings = new EditableValueBuilder<string>()
             .withValue(
                 JSON.stringify([
                     {
@@ -49,229 +27,110 @@ describe("useSettings Hook", () => {
                         sort: true,
                         sortMethod: "desc",
                         hidden: false,
-                        order: 1,
-                        width: undefined
-                    },
-                    {
-                        column: "Column 2",
-                        sort: false,
-                        sortMethod: "asc",
-                        hidden: true,
                         order: 0,
-                        width: 120
+                        width: undefined
                     }
                 ])
             )
             .build();
-
-        renderHook(() =>
-            useSettings(
-                settings,
-                props.onSettingsChange,
-                columns,
-                props.columnOrder,
-                props.setColumnOrder,
-                props.hiddenColumns,
-                props.setHiddenColumns,
-                props.sortBy,
-                props.setSortBy,
-                props.widths,
-                props.setWidths
-            )
-        );
-        expect(props.setColumnOrder).toHaveBeenCalledWith(["1", "0"]);
-        expect(props.setHiddenColumns).toHaveBeenCalledWith(["1"]);
-        expect(props.setSortBy).toHaveBeenCalledWith([{ id: "0", desc: true }]);
-        expect(props.setWidths).toHaveBeenCalledWith({ "0": undefined, "1": 120 });
-    });
-
-    it("changes the settings when some property changes", () => {
-        const props = mockProperties();
-
-        const { rerender } = renderUseSettingsHook({
-            settings: props.settings,
-            onSettingsChange: props.onSettingsChange,
-            columns: props.columns,
-            columnOrder: ["0"],
-            setColumnOrder: props.setColumnOrder,
-            hiddenColumns: [],
-            setHiddenColumns: props.setHiddenColumns,
-            sortBy: [{ id: "0", desc: true }],
-            setSortBy: props.setSortBy,
-            widths: { "0": undefined } as ColumnWidth,
-            setWidths: props.setWidths
-        });
-        expect(props.settings.setValue).toHaveBeenCalledTimes(0);
-        expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
-        rerender({
-            settings: props.settings,
-            onSettingsChange: props.onSettingsChange,
-            columns: props.columns,
-            columnOrder: ["0"],
-            setColumnOrder: props.setColumnOrder,
-            hiddenColumns: [],
-            setHiddenColumns: props.setHiddenColumns,
-            sortBy: [{ id: "0", desc: false }],
-            setSortBy: props.setSortBy,
-            widths: { "0": 130 },
-            setWidths: props.setWidths
-        });
-        expect(props.settings.setValue).toHaveBeenCalledTimes(1);
-        expect(props.settings.setValue).toHaveBeenCalledWith(
-            JSON.stringify([
-                {
-                    column: "Column 1",
-                    sort: true,
-                    sortMethod: "asc",
-                    hidden: false,
-                    order: 0,
-                    width: 130
-                }
-            ])
-        );
-        expect(props.onSettingsChange).toHaveBeenCalledTimes(1);
-    });
-
-    it("doesnt change the settings when same properties are applied", () => {
-        const props = mockProperties();
-        const initialProps = {
-            settings: props.settings,
-            onSettingsChange: props.onSettingsChange,
-            columns: props.columns,
-            columnOrder: ["0"],
-            setColumnOrder: props.setColumnOrder,
-            hiddenColumns: [],
-            setHiddenColumns: props.setHiddenColumns,
-            sortBy: [{ id: "0", desc: true }],
-            setSortBy: props.setSortBy,
-            widths: { "0": undefined } as ColumnWidth,
-            setWidths: props.setWidths
-        };
-
-        const { rerender } = renderUseSettingsHook(initialProps);
-        expect(props.settings.setValue).toHaveBeenCalledTimes(0);
-        expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
-        rerender(initialProps);
-        expect(props.settings.setValue).toHaveBeenCalledTimes(0);
-        expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
-    });
-
-    it("doesnt change the hooks when same properties are applied", () => {
-        const props = mockProperties();
-        const initialProps = {
-            settings: props.settings,
-            onSettingsChange: props.onSettingsChange,
-            columns: props.columns,
-            columnOrder: ["0"],
-            setColumnOrder: props.setColumnOrder,
-            hiddenColumns: [],
-            setHiddenColumns: props.setHiddenColumns,
-            sortBy: [{ id: "0", desc: true }],
-            setSortBy: props.setSortBy,
-            widths: { "0": undefined } as ColumnWidth,
-            setWidths: props.setWidths
-        };
-
-        const { rerender } = renderUseSettingsHook(initialProps);
-        // Initiates the hooks with values from settings once
-        expect(props.setColumnOrder).toHaveBeenCalledTimes(1);
-        expect(props.setHiddenColumns).toHaveBeenCalledTimes(1);
-        expect(props.setSortBy).toHaveBeenCalledTimes(1);
-        expect(props.setWidths).toHaveBeenCalledTimes(1);
-        expect(props.settings.setValue).toHaveBeenCalledTimes(0);
-        expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
-        rerender(initialProps);
-        expect(props.setColumnOrder).toHaveBeenCalledTimes(1);
-        expect(props.setHiddenColumns).toHaveBeenCalledTimes(1);
-        expect(props.setSortBy).toHaveBeenCalledTimes(1);
-        expect(props.setWidths).toHaveBeenCalledTimes(1);
-        expect(props.settings.setValue).toHaveBeenCalledTimes(0);
-        expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
-    });
-
-    it("applies changes to settings when receiving external prop changes", () => {
-        const props = mockProperties();
-        props.settings = new EditableValueBuilder<string>().withValue("").build();
-
-        const { rerender } = renderUseSettingsHook(props);
-        expect(props.settings.setValue).toHaveBeenCalledTimes(1);
-        expect(props.settings.setValue).toHaveBeenCalledWith(
-            JSON.stringify([{ column: "Column 1", sort: false, sortMethod: "asc", hidden: false, order: 0 }])
-        );
-        expect(props.onSettingsChange).toHaveBeenCalledTimes(1);
-        rerender({ ...props, sortBy: [{ id: "0", desc: true }] });
-        expect(props.settings.setValue).toHaveBeenCalledTimes(2);
-        expect(props.settings.setValue).toHaveBeenCalledWith(
-            JSON.stringify([{ column: "Column 1", sort: true, sortMethod: "desc", hidden: false, order: 0 }])
-        );
-        expect(props.onSettingsChange).toHaveBeenCalledTimes(2);
-        rerender({ ...props, sortBy: [{ id: "0", desc: true }] });
-        expect(props.settings.setValue).toHaveBeenCalledTimes(2);
-        expect(props.onSettingsChange).toHaveBeenCalledTimes(2);
-    });
-});
-
-function mockProperties(): any {
-    return {
-        settings: new EditableValueBuilder<string>()
-            .withValue(
-                JSON.stringify([
-                    {
-                        column: "Column 1",
-                        sort: true,
-                        sortMethod: "desc",
-                        hidden: false,
-                        order: 0,
-                        width: undefined
-                    }
-                ])
-            )
-            .build(),
-        onSettingsChange: jest.fn(),
-        columns: [
+        columnOrder = [];
+        hiddenColumns = [];
+        sortBy = [];
+        widths = {};
+        columns = [
             {
                 header: "Column 1",
                 hidable: "yes" as HidableEnum
             }
-        ] as TableColumn[],
-        columnOrder: [],
-        setColumnOrder: jest.fn(),
-        hiddenColumns: [],
-        setHiddenColumns: jest.fn(),
-        sortBy: [],
-        setSortBy: jest.fn(),
-        widths: { "0": undefined },
-        setWidths: jest.fn()
-    };
-}
+        ] as TableColumn[];
 
-function renderUseSettingsHook(initialProps: {
-    settings: any;
-    onSettingsChange: () => void;
-    hiddenColumns: any[];
-    columnOrder: string[];
-    columns: any;
-    setHiddenColumns: any;
-    sortBy: Array<{ id: string; desc: boolean }>;
-    widths: ColumnWidth;
-    setSortBy: any;
-    setWidths: any;
-    setColumnOrder: any;
-}) {
-    return renderHook(
-        ({
-            settings,
-            onSettingsChange,
-            columns,
-            columnOrder,
-            setColumnOrder,
-            hiddenColumns,
-            setHiddenColumns,
-            sortBy,
-            setSortBy,
-            widths,
-            setWidths
-        }) =>
+        jest.useFakeTimers();
+    });
+
+    // it("loads correct values into hooks", () => {
+    //     renderHook(() =>
+    //         useSettings(
+    //             settings,
+    //             onSettingsChange,
+    //             columns,
+    //             columnOrder,
+    //             setColumnOrder,
+    //             hiddenColumns,
+    //             setHiddenColumns,
+    //             sortBy,
+    //             setSortBy,
+    //             widths,
+    //             setWidths
+    //         )
+    //     );
+    //     expect(setColumnOrder).toHaveBeenCalledTimes(1);
+    //     expect(setHiddenColumns).toHaveBeenCalledTimes(1);
+    //     expect(setSortBy).toHaveBeenCalledTimes(1);
+    //     expect(setWidths).toHaveBeenCalledTimes(1);
+    // });
+    //
+    // it("calls state functions with correct values", () => {
+    //     const columns = [
+    //         {
+    //             header: "Column 1",
+    //             hidable: "yes" as HidableEnum
+    //         },
+    //         {
+    //             header: "Column 2",
+    //             hidable: "hidden" as HidableEnum
+    //         }
+    //     ] as TableColumn[];
+    //     const settings = new EditableValueBuilder<string>()
+    //         .withValue(
+    //             JSON.stringify([
+    //                 {
+    //                     column: "Column 1",
+    //                     sort: true,
+    //                     sortMethod: "desc",
+    //                     hidden: false,
+    //                     order: 1,
+    //                     width: undefined
+    //                 },
+    //                 {
+    //                     column: "Column 2",
+    //                     sort: false,
+    //                     sortMethod: "asc",
+    //                     hidden: true,
+    //                     order: 0,
+    //                     width: 120
+    //                 }
+    //             ])
+    //         )
+    //         .build();
+    //
+    //     renderHook(() =>
+    //         useSettings(
+    //             settings,
+    //             onSettingsChange,
+    //             columns,
+    //             columnOrder,
+    //             setColumnOrder,
+    //             hiddenColumns,
+    //             setHiddenColumns,
+    //             sortBy,
+    //             setSortBy,
+    //             widths,
+    //             setWidths
+    //         )
+    //     );
+    //
+    //     expect(setColumnOrder).toHaveBeenCalledTimes(1);
+    //     expect(columnOrder).toStrictEqual(["1", "0"]);
+    //     expect(setHiddenColumns).toHaveBeenCalledTimes(1);
+    //     expect(hiddenColumns).toStrictEqual(["1"]);
+    //     expect(setSortBy).toHaveBeenCalledTimes(1);
+    //     expect(sortBy).toStrictEqual([{ id: "0", desc: true }]);
+    //     expect(setWidths).toHaveBeenCalledTimes(1);
+    //     expect(widths).toStrictEqual({ "0": undefined, "1": 120 });
+    // });
+
+    it("changes the settings when some property changes", () => {
+        const { result } = renderHook(() =>
             useSettings(
                 settings,
                 onSettingsChange,
@@ -284,9 +143,167 @@ function renderUseSettingsHook(initialProps: {
                 setSortBy,
                 widths,
                 setWidths
-            ),
-        {
-            initialProps
-        }
-    );
-}
+            )
+        );
+        expect(settings.setValue).toHaveBeenCalledTimes(0);
+        expect(onSettingsChange).toHaveBeenCalledTimes(0);
+
+        jest.advanceTimersByTime(100);
+
+        setColumnOrder(() => ["0"]);
+        setSortBy(() => [{ id: "0", desc: true }]);
+        setWidths(() => ({ "0": 130 }));
+
+        // act(() => {
+        result.current.updateSettings();
+        // });
+
+        expect(settings.setValue).toHaveBeenCalledTimes(1);
+        expect(settings.setValue).toHaveBeenCalledWith(
+            JSON.stringify([
+                {
+                    column: "Column 1",
+                    sort: true,
+                    sortMethod: "asc",
+                    hidden: false,
+                    order: 0,
+                    width: 130
+                }
+            ])
+        );
+        expect(onSettingsChange).toHaveBeenCalledTimes(1);
+    });
+    //
+    // it("doesnt change the settings when same properties are applied", () => {
+    //     const props = mockProperties();
+    //     const initialProps = {
+    //         settings: props.settings,
+    //         onSettingsChange: props.onSettingsChange,
+    //         columns: props.columns,
+    //         columnOrder: ["0"],
+    //         setColumnOrder: props.setColumnOrder,
+    //         hiddenColumns: [],
+    //         setHiddenColumns: props.setHiddenColumns,
+    //         sortBy: [{ id: "0", desc: true }],
+    //         setSortBy: props.setSortBy,
+    //         widths: { "0": undefined } as ColumnWidth,
+    //         setWidths: props.setWidths
+    //     };
+    //
+    //     const { rerender } = renderUseSettingsHook(initialProps);
+    //     expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+    //     expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
+    //     rerender(initialProps);
+    //     expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+    //     expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
+    // });
+    //
+    // it("doesnt change the hooks when same properties are applied", () => {
+    //     const props = mockProperties();
+    //     const initialProps = {
+    //         settings: props.settings,
+    //         onSettingsChange: props.onSettingsChange,
+    //         columns: props.columns,
+    //         columnOrder: ["0"],
+    //         setColumnOrder: props.setColumnOrder,
+    //         hiddenColumns: [],
+    //         setHiddenColumns: props.setHiddenColumns,
+    //         sortBy: [{ id: "0", desc: true }],
+    //         setSortBy: props.setSortBy,
+    //         widths: { "0": undefined } as ColumnWidth,
+    //         setWidths: props.setWidths
+    //     };
+    //
+    //     const { rerender } = renderUseSettingsHook(initialProps);
+    //     // Initiates the hooks with values from settings once
+    //     expect(props.setColumnOrder).toHaveBeenCalledTimes(1);
+    //     expect(props.setHiddenColumns).toHaveBeenCalledTimes(1);
+    //     expect(props.setSortBy).toHaveBeenCalledTimes(1);
+    //     expect(props.setWidths).toHaveBeenCalledTimes(1);
+    //     expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+    //     expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
+    //     rerender(initialProps);
+    //     expect(props.setColumnOrder).toHaveBeenCalledTimes(1);
+    //     expect(props.setHiddenColumns).toHaveBeenCalledTimes(1);
+    //     expect(props.setSortBy).toHaveBeenCalledTimes(1);
+    //     expect(props.setWidths).toHaveBeenCalledTimes(1);
+    //     expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+    //     expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
+    // });
+    //
+    // it("applies changes to settings when receiving external changes", () => {
+    //     const props = mockProperties();
+    //     props.settings = new EditableValueBuilder<string>().withValue("").build();
+    //
+    //     const { rerender, result } = renderUseSettingsHook(props);
+    //     const [updateSettings] = result.current;
+    //     // Remains uncalled
+    //     expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+    //     expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
+    //
+    //     rerender({ ...props, sortBy: [{ id: "0", desc: false }] });
+    //     act(() => {
+    //         updateSettings();
+    //     });
+    //
+    //     expect(props.settings.setValue).toHaveBeenCalledTimes(1);
+    //     expect(props.settings.setValue).toHaveBeenCalledWith(
+    //         JSON.stringify([{ column: "Column 1", sort: true, sortMethod: "desc", hidden: false, order: 0 }])
+    //     );
+    //     expect(props.onSettingsChange).toHaveBeenCalledTimes(1);
+    //
+    //     rerender({ ...props, sortBy: [{ id: "0", desc: true }] });
+    //     act(() => {
+    //         updateSettings();
+    //     });
+    //
+    //     expect(props.settings.setValue).toHaveBeenCalledTimes(1);
+    //     expect(props.onSettingsChange).toHaveBeenCalledTimes(1);
+    // });
+});
+//
+// function renderUseSettingsHook(initialProps: {
+//     settings: EditableValue<string>;
+//     onSettingsChange: () => void;
+//     hiddenColumns: any[];
+//     columnOrder: string[];
+//     columns: any;
+//     setHiddenColumns: any;
+//     sortBy: Array<{ id: string; desc: boolean }>;
+//     widths: ColumnWidth;
+//     setSortBy: any;
+//     setWidths: any;
+//     setColumnOrder: any;
+// }) {
+//     return renderHook(
+//         ({
+//             settings,
+//             onSettingsChange,
+//             columns,
+//             columnOrder,
+//             setColumnOrder,
+//             hiddenColumns,
+//             setHiddenColumns,
+//             sortBy,
+//             setSortBy,
+//             widths,
+//             setWidths
+//         }) =>
+//             useSettings(
+//                 settings,
+//                 onSettingsChange,
+//                 columns,
+//                 columnOrder,
+//                 setColumnOrder,
+//                 hiddenColumns,
+//                 setHiddenColumns,
+//                 sortBy,
+//                 setSortBy,
+//                 widths,
+//                 setWidths
+//             ),
+//         {
+//             initialProps
+//         }
+//     );
+// }

--- a/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/settings.spec.ts
@@ -1,4 +1,4 @@
-import { SortingRule, useSettings } from "../settings";
+import { useSettings } from "../settings";
 import { ColumnWidth, TableColumn } from "../../components/Table";
 import { EditableValueBuilder } from "@mendix/piw-utils-internal";
 import { HidableEnum } from "../../../typings/DatagridProps";
@@ -7,20 +7,47 @@ import { EditableValue } from "mendix";
 import { act } from "react-dom/test-utils";
 
 describe("useSettings Hook", () => {
-    let settings: EditableValue<string>;
-    let columnOrder: string[] = [];
-    const setColumnOrder = jest.fn((fn: () => string[]) => (columnOrder = fn()));
-    let hiddenColumns: string[] = [];
-    const setHiddenColumns = jest.fn((fn: () => string[]) => (hiddenColumns = fn()));
-    let sortBy: SortingRule[] = [];
-    const setSortBy = jest.fn((fn: () => SortingRule[]) => (sortBy = fn()));
-    let widths: ColumnWidth = {};
-    const setWidths = jest.fn((fn: () => ColumnWidth) => (widths = fn()));
-    const onSettingsChange = jest.fn();
-    let columns: TableColumn[];
-
     beforeEach(() => {
-        settings = new EditableValueBuilder<string>()
+        jest.useFakeTimers();
+    });
+
+    it("loads correct values into hooks", () => {
+        const props = mockProperties();
+
+        renderHook(() =>
+            useSettings(
+                props.settings,
+                props.onSettingsChange,
+                props.columns,
+                props.columnOrder,
+                props.setColumnOrder,
+                props.hiddenColumns,
+                props.setHiddenColumns,
+                props.sortBy,
+                props.setSortBy,
+                props.widths,
+                props.setWidths
+            )
+        );
+        expect(props.setColumnOrder).toHaveBeenCalledTimes(1);
+        expect(props.setHiddenColumns).toHaveBeenCalledTimes(1);
+        expect(props.setSortBy).toHaveBeenCalledTimes(1);
+        expect(props.setWidths).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls state functions with correct values", () => {
+        const props = mockProperties();
+        const columns = [
+            {
+                header: "Column 1",
+                hidable: "yes" as HidableEnum
+            },
+            {
+                header: "Column 2",
+                hidable: "hidden" as HidableEnum
+            }
+        ] as TableColumn[];
+        const settings = new EditableValueBuilder<string>()
             .withValue(
                 JSON.stringify([
                     {
@@ -28,130 +55,53 @@ describe("useSettings Hook", () => {
                         sort: true,
                         sortMethod: "desc",
                         hidden: false,
-                        order: 0,
+                        order: 1,
                         width: undefined
+                    },
+                    {
+                        column: "Column 2",
+                        sort: false,
+                        sortMethod: "asc",
+                        hidden: true,
+                        order: 0,
+                        width: 120
                     }
                 ])
             )
             .build();
-        columnOrder = [];
-        hiddenColumns = [];
-        sortBy = [];
-        widths = {};
-        columns = [
-            {
-                header: "Column 1",
-                hidable: "yes" as HidableEnum
-            }
-        ] as TableColumn[];
 
-        jest.useFakeTimers();
+        renderHook(() =>
+            useSettings(
+                settings,
+                props.onSettingsChange,
+                columns,
+                props.columnOrder,
+                props.setColumnOrder,
+                props.hiddenColumns,
+                props.setHiddenColumns,
+                props.sortBy,
+                props.setSortBy,
+                props.widths,
+                props.setWidths
+            )
+        );
+
+        expect(props.setColumnOrder).toHaveBeenCalledTimes(1);
+        expect(props.setHiddenColumns).toHaveBeenCalledTimes(1);
+        expect(props.setSortBy).toHaveBeenCalledTimes(1);
+        expect(props.setWidths).toHaveBeenCalledTimes(1);
     });
 
-    // it("loads correct values into hooks", () => {
-    //     renderHook(() =>
-    //         useSettings(
-    //             settings,
-    //             onSettingsChange,
-    //             columns,
-    //             columnOrder,
-    //             setColumnOrder,
-    //             hiddenColumns,
-    //             setHiddenColumns,
-    //             sortBy,
-    //             setSortBy,
-    //             widths,
-    //             setWidths
-    //         )
-    //     );
-    //     expect(setColumnOrder).toHaveBeenCalledTimes(1);
-    //     expect(setHiddenColumns).toHaveBeenCalledTimes(1);
-    //     expect(setSortBy).toHaveBeenCalledTimes(1);
-    //     expect(setWidths).toHaveBeenCalledTimes(1);
-    // });
-    //
-    // it("calls state functions with correct values", () => {
-    //     const columns = [
-    //         {
-    //             header: "Column 1",
-    //             hidable: "yes" as HidableEnum
-    //         },
-    //         {
-    //             header: "Column 2",
-    //             hidable: "hidden" as HidableEnum
-    //         }
-    //     ] as TableColumn[];
-    //     const settings = new EditableValueBuilder<string>()
-    //         .withValue(
-    //             JSON.stringify([
-    //                 {
-    //                     column: "Column 1",
-    //                     sort: true,
-    //                     sortMethod: "desc",
-    //                     hidden: false,
-    //                     order: 1,
-    //                     width: undefined
-    //                 },
-    //                 {
-    //                     column: "Column 2",
-    //                     sort: false,
-    //                     sortMethod: "asc",
-    //                     hidden: true,
-    //                     order: 0,
-    //                     width: 120
-    //                 }
-    //             ])
-    //         )
-    //         .build();
-    //
-    //     renderHook(() =>
-    //         useSettings(
-    //             settings,
-    //             onSettingsChange,
-    //             columns,
-    //             columnOrder,
-    //             setColumnOrder,
-    //             hiddenColumns,
-    //             setHiddenColumns,
-    //             sortBy,
-    //             setSortBy,
-    //             widths,
-    //             setWidths
-    //         )
-    //     );
-    //
-    //     expect(setColumnOrder).toHaveBeenCalledTimes(1);
-    //     expect(columnOrder).toStrictEqual(["1", "0"]);
-    //     expect(setHiddenColumns).toHaveBeenCalledTimes(1);
-    //     expect(hiddenColumns).toStrictEqual(["1"]);
-    //     expect(setSortBy).toHaveBeenCalledTimes(1);
-    //     expect(sortBy).toStrictEqual([{ id: "0", desc: true }]);
-    //     expect(setWidths).toHaveBeenCalledTimes(1);
-    //     expect(widths).toStrictEqual({ "0": undefined, "1": 120 });
-    // });
-
     it("changes the settings when some property changes", () => {
-        const initialProps = {
-            settings,
-            onSettingsChange,
-            columns,
-            columnOrder,
-            setColumnOrder,
-            hiddenColumns,
-            setHiddenColumns,
-            sortBy,
-            setSortBy,
-            widths,
-            setWidths
-        };
-        const { result, rerender } = renderUseSettingsHook(initialProps);
-        expect(settings.setValue).toHaveBeenCalledTimes(0);
-        expect(onSettingsChange).toHaveBeenCalledTimes(0);
+        const props = mockProperties();
+        const { result, rerender } = renderUseSettingsHook(props);
+        expect(props.settings.setValue).toHaveBeenCalledTimes(0);
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
 
         jest.advanceTimersByTime(100);
 
         rerender({
-            ...initialProps,
+            ...props,
             columnOrder: ["0"],
             sortBy: [{ id: "0", desc: true }],
             widths: { "0": 130 }
@@ -159,7 +109,7 @@ describe("useSettings Hook", () => {
 
         result.current.updateSettings();
 
-        expect(settings.setValue).toHaveBeenCalledWith(
+        expect(props.settings.setValue).toHaveBeenCalledWith(
             JSON.stringify([
                 {
                     column: "Column 1",
@@ -171,9 +121,9 @@ describe("useSettings Hook", () => {
                 }
             ])
         );
-        expect(onSettingsChange).toHaveBeenCalledTimes(1);
+        expect(props.onSettingsChange).toHaveBeenCalledTimes(1);
     });
-    //
+
     it("doesnt change the settings when same properties are applied", () => {
         const props = mockProperties();
         const initialProps = {
@@ -198,7 +148,7 @@ describe("useSettings Hook", () => {
         expect(props.settings.setValue).toHaveBeenCalledTimes(0);
         expect(props.onSettingsChange).toHaveBeenCalledTimes(0);
     });
-    //
+
     // it("doesnt change the hooks when same properties are applied", () => {
     //     const props = mockProperties();
     //     const initialProps = {

--- a/packages/pluggableWidgets/datagrid-web/src/utils/settings.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/settings.ts
@@ -127,8 +127,6 @@ export function useSettings(
                 onSettingsChange?.();
                 previousLoadedSettings.current = newSettings;
             }
-        } else {
-            console.warn(settings, shouldUpdate.current);
         }
     }, [settings, columnOrder, hiddenColumns, sortBy, widths, filteredColumns, onSettingsChange]);
 


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fix the on change behavior for the settings. It was triggering too much changes while resizing a column or applying any other change like sorting/reordering/hiding.

## Relevant changes
We changed the behavior of the custom hook.

## What should be covered while testing?
Please use the mpk attached to the ticket to test.

## Extra comments (optional)
Thanks @Keraito for the useful help
