### PR TITLE
fix(atlas-ui): create dir if doesnt exist and normalize paths parts

### DIFF
--- a/packages/theming/atlas/scripts/build.js
+++ b/packages/theming/atlas/scripts/build.js
@@ -36,10 +36,10 @@ async function main() {
 
     // when targeting a networked windows drive, the cmds executed by concurrently run into a race condition when
     // creating directories. create them here to avoid the error.
-    mkdir(join(outputDir, "theme"));
-    mkdir(join(outputDir, "themesource/atlas_core"));
-    mkdir(join(outputDir, "themesource/atlas_web_content"));
-    mkdir(join(outputDir, "themesource/atlas_nativemobile_content"));
+    mkdir("-p", join(outputDir, "theme"));
+    mkdir("-p", join(outputDir, "themesource/atlas_core"));
+    mkdir("-p", join(outputDir, "themesource/atlas_web_content"));
+    mkdir("-p", join(outputDir, "themesource/atlas_nativemobile_content"));
 
     await buildAndCopyAtlas(mode === "start", outputDir);
 }
@@ -53,20 +53,20 @@ async function buildAndCopyAtlas(watchMode, destination) {
             [
                 {
                     name: "web-theme-content",
-                    command: `copy-and-watch ${watchArg} "src/theme/web/**/*" "${join(destination, "/theme/web")}"`
+                    command: `copy-and-watch ${watchArg} "src/theme/web/**/*" "${join(destination, "theme/web")}"`
                 },
                 {
                     name: "web-themesource-core",
                     command: `copy-and-watch ${watchArg} "src/themesource/atlas_core/web/**/*" "${join(
                         destination,
-                        "/themesource/atlas_core/web"
+                        "themesource/atlas_core/web"
                     )}"`
                 },
                 {
                     name: "web-themesource-content",
                     command: `copy-and-watch ${watchArg} "src/themesource/atlas_web_content/web/**/*" "${join(
                         destination,
-                        "/themesource/atlas_web_content/web"
+                        "themesource/atlas_web_content/web"
                     )}"`
                 },
                 {
@@ -77,7 +77,7 @@ async function buildAndCopyAtlas(watchMode, destination) {
                     name: "native-design-properties-and-manifest",
                     command: `copy-and-watch ${watchArg} "src/themesource/atlas_core/native/**/*.json" "${join(
                         destination,
-                        "/themesource/atlas_core/native"
+                        "themesource/atlas_core/native"
                     )}"`
                 }
             ],


### PR DESCRIPTION
This _hopefully_ fixes a build script issue when running in CI (Atlas: `npm run release`)

https://github.com/mendix/widgets-resources/runs/2735309520?check_suite_focus=true