### PR TITLE
fix: fixing git diff for gh actions

### DIFF
--- a/.github/workflows/ScriptTests.yml
+++ b/.github/workflows/ScriptTests.yml
@@ -3,13 +3,23 @@ name: Script tests
 on:
     push:
         branches: [master]
-    pull_request:
+    pull_request_target:
         branches: [master]
+        types: [opened, synchronize, reopened]
 
 jobs:
+    approve:
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        runs-on: ubuntu-latest
+        steps:
+            - name: Approve
+              run: echo For security reasons, all forked pull requests need to be approved first before running any automated CI.
+        environment:
+            name: Integrated Forked PRs
     test:
         name: "Script tests (Node ${{ matrix.node }}, ${{ matrix.os }})"
         runs-on: ${{ matrix.os }}
+        if: jobs.approve.result == 'sucess' || jobs.approve.result == 'skipped'
         strategy:
             matrix:
                 node: [14]

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -3,13 +3,23 @@ name: Run unit tests
 on:
     push:
         branches: [master]
-    pull_request:
+    pull_request_target:
         branches: [master]
+        types: [opened, synchronize, reopened]
 
 jobs:
+    approve:
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        runs-on: ubuntu-latest
+        steps:
+            - name: Approve
+              run: echo For security reasons, all forked pull requests need to be approved first before running any automated CI.
+        environment:
+            name: Integrated Forked PRs
     test:
         name: "Unit tests"
         runs-on: ubuntu-latest
+        if: jobs.approve.result == 'sucess' || jobs.approve.result == 'skipped'
 
         steps:
             - name: "Checking changed files"

--- a/.github/workflows/WebAutomatedTests.yml
+++ b/.github/workflows/WebAutomatedTests.yml
@@ -3,13 +3,23 @@ name: Run automated end-to-end tests
 on:
     push:
         branches: [master]
-    pull_request:
+    pull_request_target:
         branches: [master]
+        types: [opened, synchronize, reopened]
 
 jobs:
+    approve:
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        runs-on: ubuntu-latest
+        steps:
+            - name: Approve
+              run: echo For security reasons, all forked pull requests need to be approved first before running any automated CI.
+        environment:
+            name: Integrated Forked PRs
     test:
         name: "Automated tests"
         runs-on: ubuntu-latest
+        if: jobs.approve.result == 'sucess' || jobs.approve.result == 'skipped'
 
         steps:
             - name: "Checking changed files"


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX ❌

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fixes GH Actions being used for diffing the changed files when a PR comes from a Forked repo due to `GITHUB_TOKEN` not being available for them.

## Relevant changes
Changed the current way of diff files.

## What should be covered while testing?
Not needed.
