### PR TITLE
[WC-408] Accordion web - Add design mode

### DIFF
--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorPreview.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorPreview.tsx
@@ -1,0 +1,73 @@
+import { parseStyle } from "@mendix/piw-utils-internal";
+import { createElement, ReactElement } from "react";
+
+import { Accordion } from "./components/Accordion";
+import { useIconGenerator } from "./utils/iconGenerator";
+
+import { AccordionPreviewProps } from "../typings/AccordionProps";
+
+export function getPreviewCss(): string {
+    return require("./ui/accordion-main.scss");
+}
+
+export function preview(props: AccordionPreviewProps): ReactElement {
+    const style = parseStyle(props.style);
+
+    const accordionGroups = props.groups.map(group => ({
+        header:
+            group.headerRenderMode === "text" ? (
+                <h3>{group.headerText}</h3>
+            ) : (
+                <group.headerContent.renderer>
+                    <div />
+                </group.headerContent.renderer>
+            ),
+        content: (
+            <group.content.renderer>
+                <div />
+            </group.content.renderer>
+        ),
+        visible: (group.visible as unknown) as boolean,
+        dynamicClassName: group.dynamicClass.slice(1, -1) // expression result is surrounded by single quotes
+    }));
+
+    const generateIcon = useIconGenerator(
+        props.advancedMode,
+        props.animateIcon,
+        {
+            data: props.icon
+                ? props.icon.type === "image"
+                    ? { type: props.icon.type, iconUrl: props.icon.imageUrl }
+                    : props.icon
+                : undefined
+        },
+        {
+            data: props.expandIcon
+                ? props.expandIcon.type === "image"
+                    ? { type: props.expandIcon.type, iconUrl: props.expandIcon.imageUrl }
+                    : props.expandIcon
+                : undefined
+        },
+        {
+            data: props.collapseIcon
+                ? props.collapseIcon.type === "image"
+                    ? { type: props.collapseIcon.type, iconUrl: props.collapseIcon.imageUrl }
+                    : props.collapseIcon
+                : undefined
+        }
+    );
+
+    return (
+        <Accordion
+            id={"Accordion"}
+            class={props.class}
+            style={style}
+            groups={accordionGroups}
+            collapsible={props.collapsible}
+            animateCollapsing={props.animate}
+            singleExpandedGroup={props.collapsible ? props.collapseBehavior === "singleExpanded" : undefined}
+            generateHeaderIcon={generateIcon}
+            showGroupHeaderIcon={props.showIcon}
+        />
+    );
+}

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorPreview.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorPreview.tsx
@@ -6,11 +6,16 @@ import { useIconGenerator } from "./utils/iconGenerator";
 
 import { AccordionPreviewProps } from "../typings/AccordionProps";
 
+// This interface is necessary to overcome incorrect exposure of class names with the "className" prop. In the future they will be exposed with a "class" prop (Jira Issue PAG-1317).
+interface PreviewProps extends Omit<AccordionPreviewProps, "class"> {
+    className: string;
+}
+
 export function getPreviewCss(): string {
     return require("./ui/accordion-main.scss");
 }
 
-export function preview(props: AccordionPreviewProps): ReactElement {
+export function preview(props: PreviewProps): ReactElement {
     const style = parseStyle(props.style);
 
     const accordionGroups = props.groups.map(group => ({
@@ -60,7 +65,7 @@ export function preview(props: AccordionPreviewProps): ReactElement {
     return (
         <Accordion
             id={"Accordion"}
-            class={props.class}
+            class={props.className}
             style={style}
             groups={accordionGroups}
             collapsible={props.collapsible}
@@ -68,6 +73,7 @@ export function preview(props: AccordionPreviewProps): ReactElement {
             singleExpandedGroup={props.collapsible ? props.collapseBehavior === "singleExpanded" : undefined}
             generateHeaderIcon={generateIcon}
             showGroupHeaderIcon={props.showIcon}
+            previewMode
         />
     );
 }

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorPreview.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorPreview.tsx
@@ -70,7 +70,7 @@ export function preview(props: PreviewProps): ReactElement {
             groups={accordionGroups}
             collapsible={props.collapsible}
             animateCollapsing={props.animate}
-            singleExpandedGroup={props.collapsible ? props.collapseBehavior === "singleExpanded" : undefined}
+            singleExpandedGroup={props.collapsible ? props.expandBehavior === "singleExpanded" : undefined}
             generateHeaderIcon={generateIcon}
             showGroupHeaderIcon={props.showIcon}
             previewMode

--- a/packages/pluggableWidgets/accordion-web/src/components/Accordion.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/Accordion.tsx
@@ -23,7 +23,7 @@ export function Accordion(props: AccordionProps): ReactElement | null {
 
     const [collapsedAccordionGroups, collapsedAccordionGroupsDispatch] = useReducer(
         reducer.current,
-        props.groups.map(() => (props.previewMode ? false : props.collapsible))
+        props.groups.map(() => !props.previewMode && props.collapsible)
     );
 
     const accordionGroupElements = props.groups.map((group, index) => (

--- a/packages/pluggableWidgets/accordion-web/src/components/Accordion.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/Accordion.tsx
@@ -15,6 +15,7 @@ export interface AccordionProps extends Pick<AccordionContainerProps, "class" | 
     singleExpandedGroup?: boolean;
     generateHeaderIcon?: (collapsed: boolean) => ReactElement;
     showGroupHeaderIcon?: "right" | "left" | "no";
+    previewMode?: boolean;
 }
 
 export function Accordion(props: AccordionProps): ReactElement | null {
@@ -22,7 +23,7 @@ export function Accordion(props: AccordionProps): ReactElement | null {
 
     const [collapsedAccordionGroups, collapsedAccordionGroupsDispatch] = useReducer(
         reducer.current,
-        props.groups.map(() => props.collapsible)
+        props.groups.map(() => (props.previewMode ? false : props.collapsible))
     );
 
     const accordionGroupElements = props.groups.map((group, index) => (
@@ -41,7 +42,7 @@ export function Accordion(props: AccordionProps): ReactElement | null {
     return (
         <div
             id={props.id}
-            className={classNames("widget-accordion", props.class)}
+            className={classNames("widget-accordion", { "widget-accordion-preview": props.previewMode }, props.class)}
             style={props.style}
             tabIndex={props.tabIndex}
         >

--- a/packages/pluggableWidgets/accordion-web/src/ui/accordion-main.scss
+++ b/packages/pluggableWidgets/accordion-web/src/ui/accordion-main.scss
@@ -121,3 +121,23 @@ $header-color-hover: #264ae5;
         padding: 8px 16px 24px 16px;
     }
 }
+
+.widget-accordion-preview {
+    .widget-accordion-group {
+        .widget-accordion-group-header {
+            > div > :is(h1, h2, h3, h4, h5, h6) {
+                font-size: 18px;
+                font-weight: 600;
+            }
+
+            > div > :is(h1, h2, h3, h4, h5, h6, p) {
+                color: $header-color;
+                margin-bottom: 0;
+            }
+
+            > div > span {
+                color: $header-color;
+            }
+        }
+    }
+}

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_accordion.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_accordion.scss
@@ -66,6 +66,30 @@
             }
         }
 
+        &.widget-accordion-preview {
+            .widget-accordion-group {
+                &.widget-accordion-brand-primary {
+                    @include get-accordion-preview-group-styles($accordion-header-primary-color);
+                }
+
+                &.widget-accordion-brand-secondary {
+                    @include get-accordion-preview-group-styles($accordion-header-secondary-color);
+                }
+
+                &.widget-accordion-brand-success {
+                    @include get-accordion-preview-group-styles($accordion-header-success-color);
+                }
+
+                &.widget-accordion-brand-warning {
+                    @include get-accordion-preview-group-styles($accordion-header-warning-color);
+                }
+
+                &.widget-accordion-brand-danger {
+                    @include get-accordion-preview-group-styles($accordion-header-danger-color);
+                }
+            }
+        }
+
         &.widget-accordion-bordered-all {
             .widget-accordion-group {
                 &:first-child {

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_accordion.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_accordion.scss
@@ -14,6 +14,7 @@
 
     .widget-accordion {
         background-color: $bg-color-secondary;
+        border-radius: $border-radius-default;
 
         .widget-accordion-group {
             @include get-accordion-group-styles(

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_accordion.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_accordion.scss
@@ -24,6 +24,12 @@
                 $accordion-default-border-color
             );
         }
+
+        &.widget-accordion-preview {
+            .widget-accordion-group {
+                @include get-accordion-preview-group-styles($accordion-header-default-color);
+            }
+        }
     }
 }
 
@@ -82,5 +88,18 @@
     .widget-accordion-group-content {
         border-color: $border-color;
         padding: $spacing-small $spacing-medium $spacing-large $spacing-medium;
+    }
+}
+
+@mixin get-accordion-preview-group-styles($color) {
+    .widget-accordion-group-header {
+        > div > :is(h1, h2, h3, h4, h5, h6) {
+            font-size: $font-size-h5;
+            font-weight: $font-weight-header;
+        }
+
+        > div > :is(h1, h2, h3, h4, h5, h6, p, span) {
+            color: $color;
+        }
     }
 }


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ❌
- Contains Atlas changes ✅ 
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

#### Feature specific
- Comply with designs ✅
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
This PR introduces a design mode for the accordion web widget.

## Relevant changes
- Add design mode.
- Fix border radius.

## What should be covered while testing?
Test design mode in Studio (different browsers) and Studio Pro with functional styles only and Atlas styles enabled.
