### PR TITLE
[WC-559] Data grid: moving advanced group to last tab

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -194,6 +194,8 @@
                     <description/>
                 </property>
             </propertyGroup>
+        </propertyGroup>
+        <propertyGroup caption="Advanced">
             <propertyGroup caption="Advanced">
                 <property key="advanced" type="boolean" defaultValue="false">
                     <caption>Advanced settings</caption>


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

#### Feature specific
- Comply with designs ✅
- Comply with PM's requirements ✅

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Moving advanced group to a new tab and as the last tab.

Why? It was causing confusion to users, we've received some feedbacks about it.

## Relevant changes
Just xml

## What should be covered while testing?
--
