### PR TITLE
fix(datagrid-web): fixing header size when empty

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -10,9 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - We implemented lazy filtering and sorting. Now Data Grid v2 will not load all the data if you have sorting or filtering enabled.
 - We added an option to auto-load values from enumerations in the Data Grid drop-down filter.
+- We added the capability to keep filter values and filtered rows when navigating back from another page.
 
 ### Changed
 - We fixed a problem combining a Text Box widget inside a column with an on leave or on change event preventing focus from being lost after triggering the events.
 - We fixed an issue with headers containing attributes in the text template.
 - We prevented settings' on change action to be fired continuously while resizing a column, causing performance issues.
 - We prevented the settings from being overwritten when loading a new value from the settings attribute.
+- We fixed a misalignment between column when a column header was empty, and a filter was placed in it.

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -10,11 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - We implemented lazy filtering and sorting. Now Data Grid v2 will not load all the data if you have sorting or filtering enabled.
 - We added an option to auto-load values from enumerations in the Data Grid drop-down filter.
-- We added the capability to keep filter values and filtered rows when navigating back from another page.
+- We added the capability to restore filter values and filtered rows when navigating back from another page.
 
 ### Changed
 - We fixed a problem combining a Text Box widget inside a column with an on leave or on change event preventing focus from being lost after triggering the events.
 - We fixed an issue with headers containing attributes in the text template.
 - We prevented settings' on change action to be fired continuously while resizing a column, causing performance issues.
 - We prevented the settings from being overwritten when loading a new value from the settings attribute.
-- We fixed a misalignment between column when a column header was empty, and a filter was placed in it.
+- We fixed a misalignment between columns when a column header was empty and a filter was placed in it.

--- a/packages/pluggableWidgets/datagrid-web/src/components/Header.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Header.tsx
@@ -49,7 +49,7 @@ export function Header(props: HeaderProps): ReactElement {
             : faArrowsAltV
         : undefined;
 
-    const caption = props.column.header;
+    const caption = props.column.header.trim();
 
     const onSortBy = (): void => {
         /**

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Header.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Header.spec.tsx
@@ -102,6 +102,15 @@ describe("Header", () => {
 
         expect(component).toMatchSnapshot();
     });
+
+    it("renders the structure correctly when value is empty", () => {
+        const props = mockHeaderProps();
+        props.column.header = " ";
+
+        const component = shallow(<Header {...props} />);
+
+        expect(component).toMatchSnapshot();
+    });
 });
 
 function mockHeaderProps(): HeaderProps {

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/__snapshots__/Header.spec.tsx.snap
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/__snapshots__/Header.spec.tsx.snap
@@ -286,3 +286,33 @@ exports[`Header renders the structure correctly when sortable 1`] = `
   </div>
 </div>
 `;
+
+exports[`Header renders the structure correctly when value is empty 1`] = `
+<div
+  className="th"
+  role="columnheader"
+  style={
+    Object {
+      "cursor": "unset",
+    }
+  }
+  title=""
+>
+  <div
+    className="column-container"
+  >
+    <div
+      className="column-header"
+      style={
+        Object {
+          "pointerEvents": undefined,
+        }
+      }
+    >
+      <span>
+         
+      </span>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fix the column header height when the caption is empty.

## Relevant changes
-

## What should be covered while testing?
-
