### PR TITLE
[WC-557] Enable on click test spec for image viewer

### DIFF
--- a/packages/pluggableWidgets/image-viewer-web/tests/e2e/objects/constants.ts
+++ b/packages/pluggableWidgets/image-viewer-web/tests/e2e/objects/constants.ts
@@ -1,4 +1,4 @@
 export const dynamicImage = "https://silkui.outsystems.com/IframePreview/img/IframePreview.landscape_3.png";
 export const dynamicImageNoUrl = "emptyUrl";
-export const staticImage = "img/Atlas_UI_Resources$Content$indonesia.jpg";
+export const staticImage = "img/ImageViewer$Images$landscape_2.png";
 export const staticUrl = "https://picsum.photos/200/300";

--- a/packages/pluggableWidgets/image-viewer-web/tests/e2e/objects/imageViewer.widget.ts
+++ b/packages/pluggableWidgets/image-viewer-web/tests/e2e/objects/imageViewer.widget.ts
@@ -28,7 +28,7 @@ class ImageViewer {
     }
 
     static get lightbox(): WebdriverIO.Element {
-        return $(".ReactModal__Overlay.ReactModal__Overlay--after-open");
+        return $(".mx-image-viewer-lightbox");
     }
 }
 

--- a/packages/pluggableWidgets/image-viewer-web/tests/e2e/specs/onClick.spec.ts
+++ b/packages/pluggableWidgets/image-viewer-web/tests/e2e/specs/onClick.spec.ts
@@ -9,10 +9,8 @@ describe("Image viewer", () => {
         const imageViewer = new ImageViewer("imageViewer1");
         imageViewer.element.waitForDisplayed();
         imageViewer.element.click();
-
-        browser.pause(1000);
-
         page.modalDialog.waitForDisplayed();
+
         expect(page.modalDialog.getText()).toContain("You clicked this image");
     });
 
@@ -22,23 +20,19 @@ describe("Image viewer", () => {
         const imageViewer = new ImageViewer("imageViewer1");
         imageViewer.element.waitForDisplayed();
         imageViewer.element.click();
-
-        browser.pause(1000);
-
         page.modalDialog.waitForDisplayed();
+
         expect(page.modalDialog.getText()).toContain(html.dynamicImage);
     });
 
-    it("open a Page on click", () => {
+    it("opens a Page on click", () => {
         page.open("p/onClickShowPage");
 
         const imageViewer = new ImageViewer("imageViewer1");
         imageViewer.element.waitForDisplayed();
         imageViewer.element.click();
-
-        browser.pause(1000);
-
         page.modalDialog.waitForDisplayed();
+
         expect(page.modalDialogHeader.getText()).toBe("GazaLand");
     });
 
@@ -48,8 +42,8 @@ describe("Image viewer", () => {
         const imageViewer = new ImageViewer("imageViewer1");
         imageViewer.element.waitForDisplayed();
         imageViewer.element.click();
-
         ImageViewer.lightbox.waitForDisplayed();
+
         expect(ImageViewer.lightbox.$("img").getProperty("src")).toContain(html.staticImage);
     });
 });

--- a/packages/pluggableWidgets/image-viewer-web/tests/e2e/specs/onClick.spec.ts
+++ b/packages/pluggableWidgets/image-viewer-web/tests/e2e/specs/onClick.spec.ts
@@ -2,9 +2,8 @@ import page from "../../../../../../configs/e2e/src/pages/page";
 import ImageViewer from "../objects/imageViewer.widget";
 import * as html from "../objects/constants";
 
-// eslint-disable-next-line jest/no-disabled-tests
-xdescribe("Image viewer", () => {
-    it("should trigger Microflow on click", () => {
+describe("Image viewer", () => {
+    it("triggers a Microflow on click", () => {
         page.open("p/onClickMicroflow");
 
         const imageViewer = new ImageViewer("imageViewer1");
@@ -17,7 +16,7 @@ xdescribe("Image viewer", () => {
         expect(page.modalDialog.getText()).toContain("You clicked this image");
     });
 
-    it("should trigger Nanoflow on click", () => {
+    it("triggers a Nanoflow on click", () => {
         page.open("p/onClickNanoflow");
 
         const imageViewer = new ImageViewer("imageViewer1");
@@ -30,10 +29,10 @@ xdescribe("Image viewer", () => {
         expect(page.modalDialog.getText()).toContain(html.dynamicImage);
     });
 
-    it("should Open a Page on click", () => {
+    it("open a Page on click", () => {
         page.open("p/onClickShowPage");
 
-        const imageViewer = new ImageViewer("imageViewer2");
+        const imageViewer = new ImageViewer("imageViewer1");
         imageViewer.element.waitForDisplayed();
         imageViewer.element.click();
 
@@ -43,7 +42,7 @@ xdescribe("Image viewer", () => {
         expect(page.modalDialogHeader.getText()).toBe("GazaLand");
     });
 
-    it("should show full screen on click", () => {
+    it("shows full screen image on click", () => {
         page.open("p/onClickOpenFullScreen");
 
         const imageViewer = new ImageViewer("imageViewer1");


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅ 
- Is accessible ❌
- Compatible with Studio ❌
- Cross-browser compatible  ❌

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (test)

## What is the purpose of this PR?
Enable the on click actions test spec again for image viewer widget.

## Relevant changes
Fixed the test spec and test project to works with new image viewer widget.

## What should be covered while testing?
Automation should pass.



