### PR TITLE
[WC-582] Calendar: removing truncated events

### DIFF
--- a/packages/customWidgets/calendar-web/CHANGELOG.md
+++ b/packages/customWidgets/calendar-web/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this widget will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 1.0.13 2021-06-24
+
+### Removed
+- We removed the option 'Show truncated events'
+
+### Changed
+-  We changed the behavior when clicking '+ more' to redirect to day view.

--- a/packages/customWidgets/calendar-web/package.json
+++ b/packages/customWidgets/calendar-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar-web",
   "widgetName": "Calendar",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Display and manage calendar events",
   "copyright": "Mendix BV",
   "repository": {

--- a/packages/customWidgets/calendar-web/src/Calendar.webmodeler.ts
+++ b/packages/customWidgets/calendar-web/src/Calendar.webmodeler.ts
@@ -76,7 +76,6 @@ export class preview extends Component<Container.CalendarContainerProps> {
             heightUnit: props.heightUnit,
             messages: [],
             startPosition: new Date(),
-            popup: props.popup,
             editable: props.editable,
             style: parseStyle(props.style),
             viewOption: props.view,

--- a/packages/customWidgets/calendar-web/src/Calendar.xml
+++ b/packages/customWidgets/calendar-web/src/Calendar.xml
@@ -262,11 +262,6 @@
                 </property>
             </properties>
         </property>
-        <property key="popup" type="boolean" defaultValue="true">
-            <caption>Show truncated events</caption>
-            <category>View</category>
-            <description>Show truncated events in an overlay when you click the "+x more" link</description>
-        </property>
         <property key="editable" type="enumeration" defaultValue="default">
             <caption>Editable</caption>
             <category>View</category>

--- a/packages/customWidgets/calendar-web/src/components/Calendar.ts
+++ b/packages/customWidgets/calendar-web/src/components/Calendar.ts
@@ -32,7 +32,6 @@ export interface CalendarProps {
     loading?: boolean;
     startPosition?: Date;
     messages: {};
-    popup: boolean;
     editable: string;
     titleFormat?: (date: Date) => void;
     weekdayFormat?: (date: Date) => void;
@@ -156,7 +155,7 @@ class Calendar extends Component<CalendarProps, State> {
             defaultView: this.defaultView(),
             formats: this.props.viewOption === "custom" ? this.props.formats : "",
             messages: this.props.viewOption === "custom" ? this.props.messages : "",
-            popup: this.props.popup,
+            popup: false,
             selectable: this.props.enableCreate,
             step: 60,
             showMultiDayTimes: true,

--- a/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
+++ b/packages/customWidgets/calendar-web/src/components/CalendarContainer.ts
@@ -73,7 +73,6 @@ export default class CalendarContainer extends Component<Container.CalendarConta
                 messages: this.setCustomViews(),
                 events: this.state.events,
                 defaultView: this.props.defaultView,
-                popup: this.props.popup,
                 startPosition: this.state.startPosition,
                 loading: this.state.loading,
                 style: parseStyle(this.props.style),

--- a/packages/customWidgets/calendar-web/src/components/__tests__/Calendar.spec.ts
+++ b/packages/customWidgets/calendar-web/src/components/__tests__/Calendar.spec.ts
@@ -31,7 +31,6 @@ describe("Calendar", () => {
         height: 580,
         heightUnit: "pixels",
         messages: [],
-        popup: true,
         editable: "default",
         style: {},
         viewOption: "standard",

--- a/packages/customWidgets/calendar-web/src/components/__tests__/Toobar.spec.ts
+++ b/packages/customWidgets/calendar-web/src/components/__tests__/Toobar.spec.ts
@@ -16,7 +16,6 @@ describe("Toolbar", () => {
         height: 580,
         heightUnit: "pixels",
         messages: [],
-        popup: true,
         editable: "default",
         style: {},
         viewOption: "standard",

--- a/packages/customWidgets/calendar-web/src/package.xml
+++ b/packages/customWidgets/calendar-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Calendar2" version="1.0.12" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Calendar2" version="1.0.13" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Calendar.xml"/>
         </widgetFiles>


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 7️⃣, 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ❌
- Compatible with Studio ✅
- Cross-browser compatible ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Removing truncated events options due to React 17, this causes the events to go through the day view instead of open the popup. @cjfhodges agreed with the solution.

## Relevant changes
--

## What should be covered while testing?
--
