### PR TITLE
fix(pluggable-widgets-tools): generate correct union types for props …

### DIFF
--- a/packages/pluggableWidgets/bar-chart-native/src/utils/SeriesLoader.ts
+++ b/packages/pluggableWidgets/bar-chart-native/src/utils/SeriesLoader.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { ensure } from "@mendix/pluggable-widgets-tools";
 import { Big } from "big.js";
-import { ObjectItem } from "mendix";
+import { ListAttributeValue, ListExpressionValue, ObjectItem, Option } from "mendix";
 
 import { BarSeriesType } from "../../typings/BarChartProps";
 import { BarChartSeries, BarDataPoints } from "../components/BarChart";
@@ -116,7 +116,7 @@ function loadDynamicSeries(series: BarSeriesType): BarChartSeries[] | null {
 }
 
 function groupDataSourceItems(series: BarSeriesType): DataSourceItemGroup[] | null {
-    const { dynamicDataSource, dynamicSeriesName, dynamicCustomBarStyle, groupByAttribute, dataSet } = series;
+    const { dynamicDataSource, dataSet } = series;
 
     if (dataSet !== "dynamic") {
         throw Error("Expected series to be dynamic");
@@ -131,6 +131,7 @@ function groupDataSourceItems(series: BarSeriesType): DataSourceItemGroup[] | nu
     const dataSourceItemGroupsResult: DataSourceItemGroup[] = [];
 
     for (const item of dataSource.items) {
+        const groupByAttribute = series.groupByAttribute as ListAttributeValue<string | boolean | Date | Big>;
         const groupByAttributeValue = ensure(groupByAttribute).get(item);
 
         if (groupByAttributeValue.value === undefined) {
@@ -155,6 +156,7 @@ function groupDataSourceItems(series: BarSeriesType): DataSourceItemGroup[] | nu
                 items: [item]
             };
 
+            const dynamicSeriesName = series.dynamicSeriesName as Option<ListExpressionValue<string>>;
             if (dynamicSeriesName) {
                 const dynamicSeriesNameValue = dynamicSeriesName.get(item);
 
@@ -165,6 +167,7 @@ function groupDataSourceItems(series: BarSeriesType): DataSourceItemGroup[] | nu
                 newDataSourceItemGroup.dynamicSeriesNameValue = dynamicSeriesNameValue.value;
             }
 
+            const dynamicCustomBarStyle = series.dynamicSeriesName as Option<ListExpressionValue<string>>;
             if (dynamicCustomBarStyle) {
                 const dynamicCustomBarStyleValue = dynamicCustomBarStyle.get(item);
 
@@ -196,12 +199,14 @@ function extractDataPoints(series: BarSeriesType, dataSourceItems?: ObjectItem[]
     const dataPointsExtraction: DataPointsExtraction = { dataPoints: [] };
 
     for (const item of dataSourceItems) {
-        const x = (series.dataSet === "static" ? ensure(series.staticXAttribute) : ensure(series.dynamicXAttribute))(
-            item
-        );
-        const y = (series.dataSet === "static" ? ensure(series.staticYAttribute) : ensure(series.dynamicYAttribute))(
-            item
-        );
+        const xAttribute = (series.dataSet === "static"
+            ? ensure(series.staticXAttribute)
+            : ensure(series.dynamicXAttribute)) as ListAttributeValue<string | Date | Big>;
+        const x = xAttribute.get(item);
+        const yAttribute = (series.dataSet === "static"
+            ? ensure(series.staticYAttribute)
+            : ensure(series.dynamicYAttribute)) as ListAttributeValue<string | Date | Big>;
+        const y = yAttribute.get(item);
 
         if (!x.value || !y.value) {
             return null;

--- a/packages/pluggableWidgets/line-chart-native/src/utils/SeriesLoader.ts
+++ b/packages/pluggableWidgets/line-chart-native/src/utils/SeriesLoader.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { ensure } from "@mendix/pluggable-widgets-tools";
 import { Big } from "big.js";
-import { ObjectItem } from "mendix";
+import { ListAttributeValue, ListExpressionValue, ObjectItem, Option } from "mendix";
 
 import { LinesType } from "../../typings/LineChartProps";
 import { LineChartDataPoints, LineChartSeries } from "../components/LineChart";
@@ -118,7 +118,7 @@ function loadDynamicSeries(series: LinesType): LineChartSeries[] | null {
 }
 
 function groupDataSourceItems(series: LinesType): DataSourceItemGroup[] | null {
-    const { dynamicDataSource, dynamicName, dynamicCustomLineStyle, groupByAttribute, dataSet } = series;
+    const { dynamicDataSource, dataSet } = series;
 
     if (dataSet !== "dynamic") {
         throw Error("Expected series to be dynamic");
@@ -133,6 +133,7 @@ function groupDataSourceItems(series: LinesType): DataSourceItemGroup[] | null {
     const dataSourceItemGroupsResult: DataSourceItemGroup[] = [];
 
     for (const item of dataSource.items) {
+        const groupByAttribute = series.groupByAttribute as ListAttributeValue<string | boolean | Date | Big>;
         const groupByAttributeValue = ensure(groupByAttribute).get(item);
 
         if (groupByAttributeValue.value === undefined) {
@@ -156,6 +157,7 @@ function groupDataSourceItems(series: LinesType): DataSourceItemGroup[] | null {
                 items: [item]
             };
 
+            const dynamicName = series.dynamicName as Option<ListExpressionValue<string>>;
             if (dynamicName) {
                 const dynamicSeriesNameValue = dynamicName.get(item);
 
@@ -166,6 +168,7 @@ function groupDataSourceItems(series: LinesType): DataSourceItemGroup[] | null {
                 newDataSourceItemGroup.dynamicNameValue = dynamicSeriesNameValue.value;
             }
 
+            const dynamicCustomLineStyle = series.dynamicCustomLineStyle as Option<ListExpressionValue<string>>;
             if (dynamicCustomLineStyle) {
                 const dynamicCustomLineStyleValue = dynamicCustomLineStyle.get(item);
 
@@ -184,8 +187,12 @@ function groupDataSourceItems(series: LinesType): DataSourceItemGroup[] | null {
 }
 
 function extractDataPoints(series: LinesType, dataSourceItems?: ObjectItem[]): DataPointsExtraction | null {
-    const xValue = series.dataSet === "static" ? ensure(series.staticXAttribute) : ensure(series.dynamicXAttribute);
-    const yValue = series.dataSet === "static" ? ensure(series.staticYAttribute) : ensure(series.dynamicYAttribute);
+    const xValue = (series.dataSet === "static"
+        ? ensure(series.staticXAttribute)
+        : ensure(series.dynamicXAttribute)) as ListAttributeValue<string | Date | Big>;
+    const yValue = (series.dataSet === "static"
+        ? ensure(series.staticYAttribute)
+        : ensure(series.dynamicYAttribute)) as ListAttributeValue<string | Date | Big>;
 
     if (!dataSourceItems) {
         const dataSource = ensure(series.staticDataSource);

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/datasource.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/datasource.ts
@@ -8,6 +8,10 @@ export const datasourceInput = `<?xml version="1.0" encoding="utf-8"?>
                 <caption>Content data source</caption>
                 <description />
             </property>
+            <property key="optionalSource" type="datasource" isList="true" required="false">
+                <caption>Optional data source</caption>
+                <description />
+            </property>
             <property key="content" type="widgets" dataSource="contentSource">
                 <caption>Content</caption>
                 <description />
@@ -34,6 +38,32 @@ export const datasourceInput = `<?xml version="1.0" encoding="utf-8"?>
                 <description />
                 <returnType type="Decimal"/>
             </property>
+            <property key="optionalDSAttribute" type="attribute" dataSource="optionalSource">
+                <caption>Marker attribute</caption>
+                <description />
+                <attributeTypes>
+                    <attributeType name="String"/>
+                    <attributeType name="Boolean"/>
+                    <attributeType name="Decimal"/>
+                </attributeTypes>
+            </property>
+            <property key="optionalDSAction" type="action" dataSource="optionalSource">
+                <caption>Action</caption>
+                <description />
+            </property>
+            <property key="optionalDSTextTemplate" type="textTemplate" dataSource="optionalSource">
+                <caption>Text Template</caption>
+                <description />
+            </property>
+            <property key="optionalDSExpression" type="expression" dataSource="optionalSource">
+                <caption>Expression</caption>
+                <description />
+                <returnType type="Decimal"/>
+            </property>
+            <property key="optionalContent" type="widgets" dataSource="optionalSource">
+                <caption>Content</caption>
+                <description />
+            </property>
             <property key="datasourceProperties" type="object" isList="true">
                 <caption>Data source properties</caption>
                 <description />
@@ -54,6 +84,32 @@ export const datasourceInput = `<?xml version="1.0" encoding="utf-8"?>
                         </property>
                         <property key="actionAttribute" type="action" dataSource="../contentSource">
                             <caption>Action</caption>
+                            <description />
+                        </property>
+                        <property key="optionalDSAttribute" type="attribute" dataSource="../optionalSource">
+                            <caption>Marker attribute</caption>
+                            <description />
+                            <attributeTypes>
+                                <attributeType name="String"/>
+                                <attributeType name="Boolean"/>
+                                <attributeType name="Decimal"/>
+                            </attributeTypes>
+                        </property>
+                        <property key="optionalDSAction" type="action" dataSource="../optionalSource">
+                            <caption>Action</caption>
+                            <description />
+                        </property>
+                        <property key="optionalDSTextTemplate" type="textTemplate" dataSource="../optionalSource">
+                            <caption>Text Template</caption>
+                            <description />
+                        </property>
+                        <property key="optionalDSExpression" type="expression" dataSource="../optionalSource">
+                            <caption>Expression</caption>
+                            <description />
+                            <returnType type="Decimal"/>
+                        </property>
+                        <property key="optionalContent" type="widgets" dataSource="../optionalSource">
+                            <caption>Content</caption>
                             <description />
                         </property>
                     </propertyGroup>

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
@@ -3,20 +3,30 @@ export const datasourceWebOutput = `/**
  * WARNING: All changes made to this file will be overwritten
  * @author Mendix UI Content Team
  */
-import { ComponentType, CSSProperties } from "react";
-import { ActionValue, EditableValue, ListValue, ListActionValue, ListAttributeValue, ListExpressionValue, ListWidgetValue } from "mendix";
+import { ComponentType, CSSProperties, ReactNode } from "react";
+import { ActionValue, DynamicValue, EditableValue, ListValue, ListActionValue, ListAttributeValue, ListExpressionValue, ListWidgetValue } from "mendix";
 import { Big } from "big.js";
 
 export interface DatasourcePropertiesType {
     contentAttribute: ListWidgetValue;
     markerAttribute: ListAttributeValue<string | boolean | Big>;
     actionAttribute?: ListActionValue;
+    optionalDSAttribute: ListAttributeValue<string | boolean | Big> | EditableValue<string | boolean | Big>;
+    optionalDSAction?: ListActionValue | ActionValue;
+    optionalDSTextTemplate: ListExpressionValue<string> | DynamicValue<string>;
+    optionalDSExpression: ListExpressionValue<Big> | DynamicValue<Big>;
+    optionalContent: ListWidgetValue | ReactNode;
 }
 
 export interface DatasourcePropertiesPreviewType {
     contentAttribute: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     markerAttribute: string;
     actionAttribute: {} | null;
+    optionalDSAttribute: string;
+    optionalDSAction: {} | null;
+    optionalDSTextTemplate: string;
+    optionalDSExpression: string;
+    optionalContent: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
 }
 
 export interface MyWidgetContainerProps {
@@ -26,11 +36,17 @@ export interface MyWidgetContainerProps {
     tabIndex?: number;
     id: string;
     contentSource: ListValue;
+    optionalSource?: ListValue;
     content: ListWidgetValue;
     markerDataAttribute: ListAttributeValue<string | boolean | Big>;
     actionAttribute?: ListActionValue;
     textTemplateAttribute: ListExpressionValue<string>;
     expressionAttribute: ListExpressionValue<Big>;
+    optionalDSAttribute: ListAttributeValue<string | boolean | Big> | EditableValue<string | boolean | Big>;
+    optionalDSAction?: ListActionValue | ActionValue;
+    optionalDSTextTemplate: ListExpressionValue<string> | DynamicValue<string>;
+    optionalDSExpression: ListExpressionValue<Big> | DynamicValue<Big>;
+    optionalContent: ListWidgetValue | ReactNode;
     datasourceProperties: DatasourcePropertiesType[];
     description: EditableValue<string>;
     action?: ActionValue;
@@ -40,11 +56,17 @@ export interface MyWidgetPreviewProps {
     class: string;
     style: string;
     contentSource: {} | null;
+    optionalSource: {} | null;
     content: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     markerDataAttribute: string;
     actionAttribute: {} | null;
     textTemplateAttribute: string;
     expressionAttribute: string;
+    optionalDSAttribute: string;
+    optionalDSAction: {} | null;
+    optionalDSTextTemplate: string;
+    optionalDSExpression: string;
+    optionalContent: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     datasourceProperties: DatasourcePropertiesPreviewType[];
     description: string;
     action: {} | null;


### PR DESCRIPTION
…linked to optional data sources

## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fix the generated typings for properties that are linked to an optional data source.

## Relevant changes
Data source properties that are marked as optional (required="false") can be left empty in the widget configuration. During export, any property that is linked to that data source property will have either the list type or the regular type for that property, depending on the actual presence of the data source. To properly reflect this in the typings, any such property must be defined as a union type.

## What should be covered while testing?
The updated unit test already covers the main scenarios with various property types and data sources which are referred to directly (with just the name of a property at the same level) or with a relative path (starting with `../`), but suggestions for other relevant scenarios are welcome.