### PR TITLE
[WC-528] Video player web - Improve dimensions tab

### DIFF
--- a/packages/pluggableWidgets/video-player-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/video-player-web/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+-   We added specific aspect ratio configuration options.
+
 ### Changed
 
 -   We renamed the video URL and Poster URL widget properties.

--- a/packages/pluggableWidgets/video-player-web/package.json
+++ b/packages/pluggableWidgets/video-player-web/package.json
@@ -28,12 +28,10 @@
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
-    "@types/classnames": "^2.2.6",
-    "@types/react-resize-detector": "^5.0.0"
+    "@types/classnames": "^2.2.6"
   },
   "dependencies": {
     "classnames": "^2.2.6",
-    "react-resize-detector": "^5.2.0",
     "@mendix/piw-utils-internal": "^1.0.0"
   }
 }

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.editorConfig.ts
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.editorConfig.ts
@@ -1,12 +1,18 @@
-import { Properties, transformGroupsIntoTabs } from "@mendix/piw-utils-internal";
+import { hidePropertyIn, Properties, transformGroupsIntoTabs } from "@mendix/piw-utils-internal";
 
 import { VideoPlayerContainerProps } from "../typings/VideoPlayerProps";
 
 export function getProperties(
-    _values: VideoPlayerContainerProps,
+    values: VideoPlayerContainerProps,
     defaultProperties: Properties,
     platform: "web" | "desktop"
 ): Properties {
+    if (values.heightUnit === "aspectRatio") {
+        hidePropertyIn(defaultProperties, values, "height");
+    } else {
+        hidePropertyIn(defaultProperties, values, "heightAspectRatio");
+    }
+
     if (platform === "web") {
         transformGroupsIntoTabs(defaultProperties);
     }

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.editorPreview.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.editorPreview.tsx
@@ -20,6 +20,7 @@ export class preview extends Component<VideoPlayerPreviewProps, {}> {
                 width={this.props.width ?? 0}
                 heightUnit={this.props.heightUnit}
                 height={this.props.height ?? 0}
+                heightAspectRatio={this.props.heightAspectRatio}
                 tabIndex={0}
             >
                 {this.renderPlayers()}

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.tsx
@@ -17,6 +17,7 @@ export default class VideoPlayer extends Component<VideoPlayerContainerProps> {
                 width={this.props.width}
                 heightUnit={this.props.heightUnit}
                 height={this.props.height}
+                heightAspectRatio={this.props.heightAspectRatio}
                 tabIndex={this.props.tabIndex}
             >
                 <Video

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
@@ -44,6 +44,7 @@
             </property>
         </propertyGroup>
         <propertyGroup caption="Dimensions">
+            <propertyGroup caption="Dimensions">
                 <property key="widthUnit" type="enumeration" defaultValue="percentage">
                     <caption>Width Unit</caption>
                     <description/>
@@ -70,17 +71,18 @@
                     <caption>Aspect ratio</caption>
                     <description />
                     <enumerationValues>
-                        <enumerationValue key="oneByOne">1:1</enumerationValue>
+                        <enumerationValue key="sixteenByNine">16:9</enumerationValue>
                         <enumerationValue key="fourByThree">4:3</enumerationValue>
                         <enumerationValue key="threeByTwo">3:2</enumerationValue>
-                        <enumerationValue key="sixteenByNine">16:9</enumerationValue>
                         <enumerationValue key="TwentyOneByNine">21:9</enumerationValue>
+                        <enumerationValue key="oneByOne">1:1</enumerationValue>
                     </enumerationValues>
                 </property>
                 <property key="height" type="integer" defaultValue="500">
                     <caption>Height</caption>
                     <description />
                 </property>
+            </propertyGroup>
         </propertyGroup>
     </properties>
 </widget>

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
@@ -10,12 +10,12 @@
             <propertyGroup caption="Data source">
                 <property key="urlExpression" type="expression">
                     <caption>Video link</caption>
-                    <description>A full link of the video: YouTube, Vimeo, Dailymotion or MP4.</description>
+                    <description>The web address of the video: YouTube, Vimeo, Dailymotion or MP4.</description>
                     <returnType type="String"/>
                 </property>
                 <property key="posterExpression" type="expression" required="false">
                     <caption>Poster link</caption>
-                    <description>The poster image is a custom preview image that will be shown in the player until the user starts the video.</description>
+                    <description>The web address of the poster image. A poster image is a custom preview image that will be shown in the player until the user starts the video.</description>
                     <returnType type="String"/>
                 </property>
             </propertyGroup>
@@ -27,7 +27,7 @@
         <propertyGroup caption="Behavior">
             <property key="autoStart" type="boolean" defaultValue="false">
                 <caption>Auto start</caption>
-                <description>Automatically start playing the video when the page loads</description>
+                <description>Automatically start playing the video when the page loads.</description>
             </property>
             <property key="showControls" type="boolean" defaultValue="true">
                 <caption>Show Controls</caption>
@@ -35,7 +35,7 @@
             </property>
             <property key="muted" type="boolean" defaultValue="false">
                 <caption>Muted</caption>
-                <description>Start the video on mute</description>
+                <description>Start the video on mute.</description>
             </property>
             <property key="loop" type="boolean" defaultValue="false">
                 <caption>Loop</caption>
@@ -47,7 +47,7 @@
             <propertyGroup caption="Dimensions">
                 <property key="widthUnit" type="enumeration" defaultValue="percentage">
                     <caption>Width Unit</caption>
-                    <description/>
+                    <description>Percentage: portion of parent size. Pixels: absolute amount of pixels.</description>
                     <enumerationValues>
                         <enumerationValue key="percentage">Percentage</enumerationValue>
                         <enumerationValue key="pixels">Pixels</enumerationValue>
@@ -59,7 +59,7 @@
                 </property>
                 <property key="heightUnit" type="enumeration" defaultValue="aspectRatio">
                     <caption>Height unit</caption>
-                    <description>Note: when "Percentage of parent" is selected, the parent container must have a height.</description>
+                    <description>Aspect ratio: ratio of width to height. Percentage of parent: portion of parent height. Percentage of width: portion of the width. Pixels: absolute amount of pixels.</description>
                     <enumerationValues>
                         <enumerationValue key="aspectRatio">Aspect ratio</enumerationValue>
                         <enumerationValue key="percentageOfParent">Percentage of parent</enumerationValue>
@@ -69,7 +69,7 @@
                 </property>
                 <property key="heightAspectRatio" type="enumeration" defaultValue="sixteenByNine">
                     <caption>Aspect ratio</caption>
-                    <description />
+                    <description>16:9 (Widescreen, HD Video), 4:3 (Classic TV, Standard monitor) , 3:2 (Classic film), 21:9 (Cinemascope), 1:1 (Square, Social media).</description>
                     <enumerationValues>
                         <enumerationValue key="sixteenByNine">16:9</enumerationValue>
                         <enumerationValue key="fourByThree">4:3</enumerationValue>

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
@@ -44,9 +44,8 @@
             </property>
         </propertyGroup>
         <propertyGroup caption="Dimensions">
-            <propertyGroup caption="Width">
                 <property key="widthUnit" type="enumeration" defaultValue="percentage">
-                    <caption>Unit </caption>
+                    <caption>Width Unit</caption>
                     <description/>
                     <enumerationValues>
                         <enumerationValue key="percentage">Percentage</enumerationValue>
@@ -54,26 +53,34 @@
                     </enumerationValues>
                 </property>
                 <property key="width" type="integer" defaultValue="100">
-                    <caption>Size </caption>
+                    <caption>Width</caption>
                     <description/>
                 </property>
-            </propertyGroup>
-            <propertyGroup caption="Height">
                 <property key="heightUnit" type="enumeration" defaultValue="aspectRatio">
-                    <caption>Unit</caption>
+                    <caption>Height unit</caption>
                     <description>Warning: when "Percentage of parent" is selected, the parent container must have an absolute height, otherwise nothing will be displayed.</description>
                     <enumerationValues>
                         <enumerationValue key="aspectRatio">Aspect ratio</enumerationValue>
+                        <enumerationValue key="percentageOfParent">Percentage of parent</enumerationValue>
                         <enumerationValue key="percentageOfWidth">Percentage of width</enumerationValue>
                         <enumerationValue key="pixels">Pixels</enumerationValue>
-                        <enumerationValue key="percentageOfParent">Percentage of parent</enumerationValue>
+                    </enumerationValues>
+                </property>
+                <property key="heightAspectRatio" type="enumeration" defaultValue="sixteenByNine">
+                    <caption>Aspect ratio</caption>
+                    <description />
+                    <enumerationValues>
+                        <enumerationValue key="oneByOne">1:1</enumerationValue>
+                        <enumerationValue key="fourByThree">4:3</enumerationValue>
+                        <enumerationValue key="threeByTwo">3:2</enumerationValue>
+                        <enumerationValue key="sixteenByNine">16:9</enumerationValue>
+                        <enumerationValue key="TwentyOneByNine">21:9</enumerationValue>
                     </enumerationValues>
                 </property>
                 <property key="height" type="integer" defaultValue="500">
-                    <caption>Size</caption>
-                    <description>If the unit is 'Aspect ratio' the height will be based on the video height.</description>
+                    <caption>Height</caption>
+                    <description />
                 </property>
-            </propertyGroup>
         </propertyGroup>
     </properties>
 </widget>

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
@@ -69,7 +69,7 @@
                 </property>
                 <property key="heightAspectRatio" type="enumeration" defaultValue="sixteenByNine">
                     <caption>Aspect ratio</caption>
-                    <description>16:9 (Widescreen, HD Video), 4:3 (Classic TV, Standard monitor) , 3:2 (Classic film), 21:9 (Cinemascope), 1:1 (Square, Social media).</description>
+                    <description>16:9 (Widescreen, HD Video), 4:3 (Classic TV, Standard monitor), 3:2 (Classic film), 21:9 (Cinemascope), 1:1 (Square, Social media)</description>
                     <enumerationValues>
                         <enumerationValue key="sixteenByNine">16:9</enumerationValue>
                         <enumerationValue key="fourByThree">4:3</enumerationValue>

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
@@ -58,7 +58,7 @@
                 </property>
                 <property key="heightUnit" type="enumeration" defaultValue="aspectRatio">
                     <caption>Height unit</caption>
-                    <description>Warning: when "Percentage of parent" is selected, the parent container must have an absolute height, otherwise nothing will be displayed.</description>
+                    <description>Note: when "Percentage of parent" is selected, the parent container must have a height.</description>
                     <enumerationValues>
                         <enumerationValue key="aspectRatio">Aspect ratio</enumerationValue>
                         <enumerationValue key="percentageOfParent">Percentage of parent</enumerationValue>

--- a/packages/pluggableWidgets/video-player-web/src/components/Dailymotion.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/Dailymotion.tsx
@@ -1,6 +1,5 @@
-import { Component, createElement, createRef } from "react";
-import ReactResizeDetector from "react-resize-detector";
-import { fixHeightWithRatio, getRatio, validateUrl } from "../utils/Utils";
+import { Component, createElement } from "react";
+import { validateUrl } from "../utils/Utils";
 
 export interface DailymotionProps {
     url: string;
@@ -10,17 +9,8 @@ export interface DailymotionProps {
     aspectRatio?: boolean;
 }
 
-export interface DailymotionState {
-    ratio: number;
-}
-
-export class Dailymotion extends Component<DailymotionProps, DailymotionState> {
-    private iframe = createRef<HTMLIFrameElement>();
-    private readonly handleOnResize = this.onResize.bind(this);
+export class Dailymotion extends Component<DailymotionProps> {
     private handleAttributes = this.getUrlAttributes.bind(this);
-    readonly state: DailymotionState = {
-        ratio: 0
-    };
 
     render(): JSX.Element {
         return (
@@ -30,32 +20,8 @@ export class Dailymotion extends Component<DailymotionProps, DailymotionState> {
                 frameBorder="0"
                 allow="autoplay; fullscreen"
                 allowFullScreen
-                ref={this.iframe}
-            >
-                <ReactResizeDetector
-                    handleWidth
-                    handleHeight
-                    onResize={this.handleOnResize}
-                    refreshMode="debounce"
-                    refreshRate={100}
-                />
-            </iframe>
+            />
         );
-    }
-
-    private onResize(): void {
-        if (this.iframe && this.iframe.current && this.props.aspectRatio) {
-            if (this.state.ratio) {
-                fixHeightWithRatio(this.iframe.current, this.state.ratio);
-            } else {
-                getRatio(this.props.url).then(ratio => {
-                    this.setState({ ratio });
-                    if (this.iframe && this.iframe.current) {
-                        fixHeightWithRatio(this.iframe.current, this.state.ratio);
-                    }
-                });
-            }
-        }
     }
 
     private generateUrl(url: string): string {

--- a/packages/pluggableWidgets/video-player-web/src/components/Html5.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/Html5.tsx
@@ -1,5 +1,4 @@
 import { Component, createElement, createRef } from "react";
-import ReactResizeDetector from "react-resize-detector";
 
 export interface Html5PlayerProps {
     url: string;
@@ -15,7 +14,6 @@ export interface Html5PlayerProps {
 export class Html5 extends Component<Html5PlayerProps> {
     private videoElement = createRef<HTMLVideoElement>();
     private errorElement = createRef<HTMLDivElement>();
-    private readonly handleOnResize = this.onResize.bind(this);
     private readonly handleOnSuccess = this.handleSuccess.bind(this);
     private readonly handleOnError = this.handleError.bind(this);
 
@@ -42,13 +40,6 @@ export class Html5 extends Component<Html5PlayerProps> {
                         onError={this.handleOnError}
                         onLoad={this.handleOnSuccess}
                     />
-                    <ReactResizeDetector
-                        handleWidth
-                        handleHeight
-                        onResize={this.handleOnResize}
-                        refreshMode="debounce"
-                        refreshRate={100}
-                    />
                 </video>
             </div>
         );
@@ -68,25 +59,6 @@ export class Html5 extends Component<Html5PlayerProps> {
             this.errorElement.current.classList.remove("hasError");
             if (this.videoElement && this.videoElement.current) {
                 this.videoElement.current.controls = this.props.showControls;
-            }
-        }
-    }
-
-    private onResize(): void {
-        if (this.videoElement && this.videoElement.current && this.props.aspectRatio) {
-            Html5.changeHeight(this.videoElement.current);
-        }
-    }
-
-    private static changeHeight(element: HTMLElement): void {
-        if (element.parentElement) {
-            const height = element.clientHeight + "px";
-            if (element.parentElement.parentElement) {
-                element.parentElement.parentElement.style.height = height;
-
-                if (element.parentElement.parentElement.parentElement) {
-                    element.parentElement.parentElement.parentElement.style.height = height;
-                }
             }
         }
     }

--- a/packages/pluggableWidgets/video-player-web/src/components/SizeContainer.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/SizeContainer.tsx
@@ -21,59 +21,47 @@ export interface SizeProps extends Dimensions {
 
 export class SizeContainer extends Component<SizeProps> {
     render(): JSX.Element {
-        const styleWidth = this.props.widthUnit === "percentage" ? `${this.props.width}%` : `${this.props.width}px`;
-        const relativeStyle: CSSProperties = {
-            position: "relative",
-            width: styleWidth,
-            ...this.getHeight(this.props.heightUnit, this.props.height, this.props.widthUnit, this.props.width),
-            display: "flex",
-            justifyContent: "center",
-            ...this.props.style
-        };
-        const absoluteStyle: CSSProperties = {
-            position: "absolute",
-            top: "0",
-            right: "0",
-            bottom: "0",
-            left: "0",
-            display: "flex",
-            justifyContent: "center"
-        };
-
         return (
             <div
                 className={classNames(this.props.className, "size-box")}
-                style={relativeStyle}
                 tabIndex={this.props.tabIndex}
+                style={this.setDimensions()}
             >
-                <div className={classNames("size-box-inner", this.props.classNameInner)} style={absoluteStyle}>
-                    {this.props.children}
-                </div>
+                <div className={classNames("size-box-inner", this.props.classNameInner)}>{this.props.children}</div>
             </div>
         );
     }
 
-    private getHeight(
-        heightUnit: HeightUnitType,
-        height: number,
-        widthUnit: WidthUnitType,
-        width: number
-    ): CSSProperties {
+    private setDimensions(): CSSProperties {
+        const { heightUnit, height, widthUnit, width } = this.props;
+
         const style: CSSProperties = {};
-        if (heightUnit === "percentageOfWidth") {
-            const ratio = (height / 100) * width;
-            if (widthUnit === "percentage") {
-                style.height = "auto";
-                style.paddingBottom = `${ratio}%`;
-            } else {
-                style.height = `${ratio}px`;
-            }
-        } else if (heightUnit === "pixels") {
-            style.height = `${height}px`;
-        } else if (heightUnit === "percentageOfParent") {
-            style.height = `${height}%`;
-        } else if (heightUnit === "aspectRatio") {
-            style.height = width * 0.5625; // Default is 16:9
+        style.width = widthUnit === "percentage" ? `${width}%` : `${width}px`;
+
+        switch (heightUnit) {
+            case "pixels":
+                style.paddingTop = height;
+                break;
+            case "percentageOfWidth":
+                const actualHeight = (height / 100) * width;
+
+                if (widthUnit === "percentage") {
+                    style.paddingTop = `${actualHeight}%`;
+                } else {
+                    style.paddingTop = actualHeight;
+                }
+                break;
+            case "percentageOfParent":
+                style.paddingTop = 0;
+                style.height = `${height}%`;
+                break;
+            case "aspectRatio":
+                if (widthUnit === "pixels") {
+                    style.paddingTop = width * 0.5625;
+                } else {
+                    style.paddingTop = `${width * 0.5625}%`; // Default is 16:9
+                }
+                break;
         }
 
         return style;

--- a/packages/pluggableWidgets/video-player-web/src/components/SizeContainer.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/SizeContainer.tsx
@@ -27,7 +27,7 @@ export class SizeContainer extends Component<SizeProps> {
             <div
                 className={classNames(this.props.className, "size-box")}
                 tabIndex={this.props.tabIndex}
-                style={this.setDimensions()}
+                style={{ ...this.setDimensions(), ...this.props.style }}
             >
                 <div className={classNames("size-box-inner", this.props.classNameInner)}>{this.props.children}</div>
             </div>

--- a/packages/pluggableWidgets/video-player-web/src/components/SizeContainer.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/SizeContainer.tsx
@@ -2,6 +2,7 @@ import { CSSProperties, Component, createElement } from "react";
 import classNames from "classnames";
 
 export type HeightUnitType = "percentageOfWidth" | "percentageOfParent" | "pixels" | "aspectRatio";
+export type HeightAspectRatioType = "oneByOne" | "fourByThree" | "threeByTwo" | "sixteenByNine" | "TwentyOneByNine";
 
 export type WidthUnitType = "percentage" | "pixels";
 
@@ -9,7 +10,8 @@ export interface Dimensions {
     widthUnit: WidthUnitType;
     width: number;
     heightUnit: HeightUnitType;
-    height: number;
+    height?: number;
+    heightAspectRatio?: HeightAspectRatioType;
     tabIndex?: number;
 }
 
@@ -33,7 +35,7 @@ export class SizeContainer extends Component<SizeProps> {
     }
 
     private setDimensions(): CSSProperties {
-        const { heightUnit, height, widthUnit, width } = this.props;
+        const { widthUnit, width, heightUnit, height, heightAspectRatio } = this.props;
 
         const style: CSSProperties = {};
         style.width = widthUnit === "percentage" ? `${width}%` : `${width}px`;
@@ -43,7 +45,7 @@ export class SizeContainer extends Component<SizeProps> {
                 style.paddingTop = height;
                 break;
             case "percentageOfWidth":
-                const actualHeight = (height / 100) * width;
+                const actualHeight = (height! / 100) * width;
 
                 if (widthUnit === "percentage") {
                     style.paddingTop = `${actualHeight}%`;
@@ -56,10 +58,30 @@ export class SizeContainer extends Component<SizeProps> {
                 style.height = `${height}%`;
                 break;
             case "aspectRatio":
+                let ratioHeightFactor = 0;
+
+                switch (heightAspectRatio) {
+                    case "oneByOne":
+                        ratioHeightFactor = 1;
+                        break;
+                    case "fourByThree":
+                        ratioHeightFactor = 3 / 4;
+                        break;
+                    case "threeByTwo":
+                        ratioHeightFactor = 2 / 3;
+                        break;
+                    case "sixteenByNine":
+                        ratioHeightFactor = 9 / 16;
+                        break;
+                    case "TwentyOneByNine":
+                        ratioHeightFactor = 9 / 21;
+                        break;
+                }
+
                 if (widthUnit === "pixels") {
-                    style.paddingTop = width * 0.5625;
+                    style.paddingTop = width * ratioHeightFactor;
                 } else {
-                    style.paddingTop = `${width * 0.5625}%`; // Default is 16:9
+                    style.paddingTop = `${width * ratioHeightFactor}%`;
                 }
                 break;
         }

--- a/packages/pluggableWidgets/video-player-web/src/components/Vimeo.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/Vimeo.tsx
@@ -1,6 +1,5 @@
-import { Component, createElement, createRef } from "react";
-import ReactResizeDetector from "react-resize-detector";
-import { fixHeightWithRatio, getRatio, validateUrl } from "../utils/Utils";
+import { Component, createElement } from "react";
+import { validateUrl } from "../utils/Utils";
 
 export interface VimeoProps {
     url: string;
@@ -10,17 +9,8 @@ export interface VimeoProps {
     aspectRatio?: boolean;
 }
 
-export interface VimeoState {
-    ratio: number;
-}
-
-export class Vimeo extends Component<VimeoProps, VimeoState> {
-    private iframe = createRef<HTMLIFrameElement>();
-    private readonly handleOnResize = this.onResize.bind(this);
+export class Vimeo extends Component<VimeoProps> {
     private handleAttributes = this.getUrlAttributes.bind(this);
-    readonly state: VimeoState = {
-        ratio: 0
-    };
 
     render(): JSX.Element {
         return (
@@ -30,32 +20,8 @@ export class Vimeo extends Component<VimeoProps, VimeoState> {
                 frameBorder="0"
                 allow="autoplay; fullscreen"
                 allowFullScreen
-                ref={this.iframe}
-            >
-                <ReactResizeDetector
-                    handleWidth
-                    handleHeight
-                    onResize={this.handleOnResize}
-                    refreshMode="debounce"
-                    refreshRate={100}
-                />
-            </iframe>
+            />
         );
-    }
-
-    private onResize(): void {
-        if (this.iframe && this.iframe.current && this.props.aspectRatio) {
-            if (this.state.ratio) {
-                fixHeightWithRatio(this.iframe.current, this.state.ratio);
-            } else {
-                getRatio(this.props.url).then(ratio => {
-                    this.setState({ ratio });
-                    if (this.iframe && this.iframe.current) {
-                        fixHeightWithRatio(this.iframe.current, this.state.ratio);
-                    }
-                });
-            }
-        }
     }
 
     private generateUrl(url: string): string {

--- a/packages/pluggableWidgets/video-player-web/src/components/Youtube.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/Youtube.tsx
@@ -1,6 +1,5 @@
-import { Component, createElement, createRef } from "react";
-import ReactResizeDetector from "react-resize-detector";
-import { fixHeightWithRatio, getRatio, validateUrl } from "../utils/Utils";
+import { Component, createElement } from "react";
+import { validateUrl } from "../utils/Utils";
 
 export interface YoutubeProps {
     url: string;
@@ -11,17 +10,8 @@ export interface YoutubeProps {
     aspectRatio?: boolean;
 }
 
-export interface YoutubeState {
-    ratio: number;
-}
-
-export class Youtube extends Component<YoutubeProps, YoutubeState> {
-    private iframe = createRef<HTMLIFrameElement>();
-    private readonly handleOnResize = this.onResize.bind(this);
+export class Youtube extends Component<YoutubeProps> {
     private handleAttributes = this.getUrlAttributes.bind(this);
-    readonly state: YoutubeState = {
-        ratio: 0
-    };
 
     render(): JSX.Element {
         return (
@@ -31,32 +21,8 @@ export class Youtube extends Component<YoutubeProps, YoutubeState> {
                 frameBorder="0"
                 allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                 allowFullScreen
-                ref={this.iframe}
-            >
-                <ReactResizeDetector
-                    handleWidth
-                    handleHeight
-                    onResize={this.handleOnResize}
-                    refreshMode="debounce"
-                    refreshRate={100}
-                />
-            </iframe>
+            />
         );
-    }
-
-    private onResize(): void {
-        if (this.iframe && this.iframe.current && this.props.aspectRatio) {
-            if (this.state.ratio) {
-                fixHeightWithRatio(this.iframe.current, this.state.ratio);
-            } else {
-                getRatio(this.props.url).then(ratio => {
-                    this.setState({ ratio });
-                    if (this.iframe && this.iframe.current) {
-                        fixHeightWithRatio(this.iframe.current, this.state.ratio);
-                    }
-                });
-            }
-        }
     }
 
     private generateUrl(url: string): string {

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/Dailymotion.spec.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/Dailymotion.spec.tsx
@@ -1,8 +1,7 @@
 import { createElement } from "react";
+import { create } from "react-test-renderer";
 
 import { Dailymotion, DailymotionProps } from "../Dailymotion";
-import { create } from "react-test-renderer";
-import ReactResizeDetector from "react-resize-detector";
 
 describe("Dailymotion Player", () => {
     const defaultProps = {
@@ -37,16 +36,5 @@ describe("Dailymotion Player", () => {
         const player = create(defaulPlayer({ ...defaultProps, showControls: true })).toJSON();
 
         expect(player).toMatchSnapshot();
-    });
-
-    it("should renders correctly with aspectRatio", () => {
-        const player = create(defaulPlayer({ ...defaultProps, aspectRatio: true }));
-        window.dispatchEvent(new Event("resize"));
-        const instance = player.root;
-        const sizeDetector = instance.findByType(ReactResizeDetector);
-
-        expect(player.toJSON).toMatchSnapshot();
-        expect(sizeDetector).not.toBeNull();
-        expect(sizeDetector.props).toHaveProperty("onResize");
     });
 });

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/Html5.spec.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/Html5.spec.tsx
@@ -1,8 +1,7 @@
 import { createElement } from "react";
+import { create } from "react-test-renderer";
 
 import { Html5, Html5PlayerProps } from "../Html5";
-import { create } from "react-test-renderer";
-import ReactResizeDetector from "react-resize-detector";
 
 describe("Html5 Player", () => {
     const defaultProps = {
@@ -56,16 +55,5 @@ describe("Html5 Player", () => {
         ).toJSON();
 
         expect(player).toMatchSnapshot();
-    });
-
-    it("should renders correctly with aspectRatio", () => {
-        const player = create(defaulPlayer({ ...defaultProps, aspectRatio: true }));
-        window.dispatchEvent(new Event("resize"));
-        const instance = player.root;
-        const sizeDetector = instance.findByType(ReactResizeDetector);
-
-        expect(player.toJSON).toMatchSnapshot();
-        expect(sizeDetector).not.toBeNull();
-        expect(sizeDetector.props).toHaveProperty("onResize");
     });
 });

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/SizeContainer.spec.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/SizeContainer.spec.tsx
@@ -28,16 +28,85 @@ describe("Size container", () => {
         expect(sizeContainer).toMatchSnapshot();
     });
 
+    it("renders correctly with pixel width & height unit percentage of width", () => {
+        const sizeContainer = create(
+            <SizeContainer {...defaultProps} widthUnit="pixels" heightUnit="percentageOfWidth" />
+        ).toJSON();
+
+        expect(sizeContainer).toMatchSnapshot();
+    });
+
     it("renders correctly with height unit percentage of parent", () => {
         const sizeContainer = create(<SizeContainer {...defaultProps} heightUnit="percentageOfParent" />).toJSON();
 
         expect(sizeContainer).toMatchSnapshot();
     });
 
-    it("renders correctly with height unit aspect ratio", () => {
+    it("renders correctly with height unit aspect ratio 1:1", () => {
+        const sizeContainer = create(
+            <SizeContainer {...defaultProps} heightUnit="aspectRatio" height={undefined} heightAspectRatio="oneByOne" />
+        ).toJSON();
+
+        expect(sizeContainer).toMatchSnapshot();
+    });
+
+    it("renders correctly with height unit aspect ratio 4:3", () => {
         const sizeContainer = create(
             <SizeContainer
                 {...defaultProps}
+                heightUnit="aspectRatio"
+                height={undefined}
+                heightAspectRatio="fourByThree"
+            />
+        ).toJSON();
+
+        expect(sizeContainer).toMatchSnapshot();
+    });
+
+    it("renders correctly with height unit aspect ratio 3:2", () => {
+        const sizeContainer = create(
+            <SizeContainer
+                {...defaultProps}
+                heightUnit="aspectRatio"
+                height={undefined}
+                heightAspectRatio="threeByTwo"
+            />
+        ).toJSON();
+
+        expect(sizeContainer).toMatchSnapshot();
+    });
+
+    it("renders correctly with height unit aspect ratio 16:9", () => {
+        const sizeContainer = create(
+            <SizeContainer
+                {...defaultProps}
+                heightUnit="aspectRatio"
+                height={undefined}
+                heightAspectRatio="sixteenByNine"
+            />
+        ).toJSON();
+
+        expect(sizeContainer).toMatchSnapshot();
+    });
+
+    it("renders correctly with height unit aspect ratio 21:9", () => {
+        const sizeContainer = create(
+            <SizeContainer
+                {...defaultProps}
+                heightUnit="aspectRatio"
+                height={undefined}
+                heightAspectRatio="TwentyOneByNine"
+            />
+        ).toJSON();
+
+        expect(sizeContainer).toMatchSnapshot();
+    });
+
+    it("renders correctly with pixel width & height unit aspect ratio", () => {
+        const sizeContainer = create(
+            <SizeContainer
+                {...defaultProps}
+                widthUnit="pixels"
                 heightUnit="aspectRatio"
                 height={undefined}
                 heightAspectRatio="TwentyOneByNine"

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/SizeContainer.spec.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/SizeContainer.spec.tsx
@@ -1,0 +1,49 @@
+import { createElement, ReactNode } from "react";
+import { create } from "react-test-renderer";
+
+import { SizeContainer, SizeProps } from "../SizeContainer";
+
+describe("Size container", () => {
+    const defaultProps: SizeProps & { children: ReactNode } = {
+        children: <span>Child</span>,
+        className: "class-name",
+        classNameInner: "class-name-inner",
+        style: { backgroundColor: "aqua" },
+        tabIndex: 1,
+        widthUnit: "percentage",
+        width: 50,
+        heightUnit: "pixels",
+        height: 25
+    };
+
+    it("renders correctly with height unit pixels", () => {
+        const sizeContainer = create(<SizeContainer {...defaultProps} />).toJSON();
+
+        expect(sizeContainer).toMatchSnapshot();
+    });
+
+    it("renders correctly with height unit percentage of width", () => {
+        const sizeContainer = create(<SizeContainer {...defaultProps} heightUnit="percentageOfWidth" />).toJSON();
+
+        expect(sizeContainer).toMatchSnapshot();
+    });
+
+    it("renders correctly with height unit percentage of parent", () => {
+        const sizeContainer = create(<SizeContainer {...defaultProps} heightUnit="percentageOfParent" />).toJSON();
+
+        expect(sizeContainer).toMatchSnapshot();
+    });
+
+    it("renders correctly with height unit aspect ratio", () => {
+        const sizeContainer = create(
+            <SizeContainer
+                {...defaultProps}
+                heightUnit="aspectRatio"
+                height={undefined}
+                heightAspectRatio="TwentyOneByNine"
+            />
+        ).toJSON();
+
+        expect(sizeContainer).toMatchSnapshot();
+    });
+});

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/SizeContainer.spec.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/SizeContainer.spec.tsx
@@ -102,6 +102,20 @@ describe("Size container", () => {
         expect(sizeContainer).toMatchSnapshot();
     });
 
+    it("renders correctly with height unit aspect ratio & any width", () => {
+        const sizeContainer = create(
+            <SizeContainer
+                {...defaultProps}
+                width={68}
+                heightUnit="aspectRatio"
+                height={undefined}
+                heightAspectRatio="TwentyOneByNine"
+            />
+        ).toJSON();
+
+        expect(sizeContainer).toMatchSnapshot();
+    });
+
     it("renders correctly with pixel width & height unit aspect ratio", () => {
         const sizeContainer = create(
             <SizeContainer

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/SizeContainer.spec.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/SizeContainer.spec.tsx
@@ -11,7 +11,7 @@ describe("Size container", () => {
         style: { backgroundColor: "aqua" },
         tabIndex: 1,
         widthUnit: "percentage",
-        width: 50,
+        width: 100,
         heightUnit: "pixels",
         height: 25
     };

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/Utils.spec.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/Utils.spec.tsx
@@ -1,24 +1,6 @@
-import { fixHeightWithRatio, validateUrl } from "../../utils/Utils";
+import { validateUrl } from "../../utils/Utils";
 
 describe("Utils", () => {
-    it("Test fixHeightWithRatio", () => {
-        const test = fixHeightWithRatio(document.createElement("iframe"), 0);
-
-        expect(test).toEqual(undefined);
-    });
-
-    it("Test fixHeightWithRatio with parents", () => {
-        const parentOfParent = document.createElement("div");
-        const parent = document.createElement("div");
-        const child = document.createElement("iframe");
-        parent.style.width = "500px";
-        parent.appendChild(child);
-        parentOfParent.appendChild(parent);
-        const test = fixHeightWithRatio(child, 0.6);
-
-        expect(test).toBe(undefined);
-    });
-
     it("Test valid url", () => {
         const provider = validateUrl("http://youtube.com");
 

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/Vimeo.spec.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/Vimeo.spec.tsx
@@ -2,7 +2,6 @@ import { createElement } from "react";
 import { create } from "react-test-renderer";
 
 import { Vimeo, VimeoProps } from "../Vimeo";
-import ReactResizeDetector from "react-resize-detector";
 
 describe("VimeoPlayer Player", () => {
     const defaultProps = {
@@ -31,16 +30,5 @@ describe("VimeoPlayer Player", () => {
         const player = create(defaulPlayer({ ...defaultProps, muted: true })).toJSON();
 
         expect(player).toMatchSnapshot();
-    });
-
-    it("should renders correctly with aspectRatio", () => {
-        const player = create(defaulPlayer({ ...defaultProps, aspectRatio: true }));
-        window.dispatchEvent(new Event("resize"));
-        const instance = player.root;
-        const sizeDetector = instance.findByType(ReactResizeDetector);
-
-        expect(player.toJSON).toMatchSnapshot();
-        expect(sizeDetector).not.toBeNull();
-        expect(sizeDetector.props).toHaveProperty("onResize");
     });
 });

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/Youtube.spec.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/Youtube.spec.tsx
@@ -1,8 +1,7 @@
 import { createElement } from "react";
+import { create } from "react-test-renderer";
 
 import { Youtube, YoutubeProps } from "../Youtube";
-import { create } from "react-test-renderer";
-import ReactResizeDetector from "react-resize-detector";
 
 describe("YoutubePlayer Player", () => {
     const defaultProps = {
@@ -38,16 +37,5 @@ describe("YoutubePlayer Player", () => {
         const player = create(defaulPlayer({ ...defaultProps, showControls: true })).toJSON();
 
         expect(player).toMatchSnapshot();
-    });
-
-    it("should renders correctly with aspectRatio", () => {
-        const player = create(defaulPlayer({ ...defaultProps, aspectRatio: true }));
-        window.dispatchEvent(new Event("resize"));
-        const instance = player.root;
-        const sizeDetector = instance.findByType(ReactResizeDetector);
-
-        expect(player.toJSON).toMatchSnapshot();
-        expect(sizeDetector).not.toBeNull();
-        expect(sizeDetector.props).toHaveProperty("onResize");
     });
 });

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/Dailymotion.spec.tsx.snap
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/Dailymotion.spec.tsx.snap
@@ -7,12 +7,8 @@ exports[`Dailymotion Player should renders correctly 1`] = `
   className="widget-video-player-iframe"
   frameBorder="0"
   src="https://www.dailymotion.com/embed/video/test?sharing-enable=false&autoplay=false&mute=false&controls=false"
->
-  <div />
-</iframe>
+/>
 `;
-
-exports[`Dailymotion Player should renders correctly with aspectRatio 1`] = `[Function]`;
 
 exports[`Dailymotion Player should renders correctly with autoplay 1`] = `
 <iframe
@@ -21,9 +17,7 @@ exports[`Dailymotion Player should renders correctly with autoplay 1`] = `
   className="widget-video-player-iframe"
   frameBorder="0"
   src="https://www.dailymotion.com/embed/video/test?sharing-enable=false&autoplay=true&mute=false&controls=false"
->
-  <div />
-</iframe>
+/>
 `;
 
 exports[`Dailymotion Player should renders correctly with controls 1`] = `
@@ -33,9 +27,7 @@ exports[`Dailymotion Player should renders correctly with controls 1`] = `
   className="widget-video-player-iframe"
   frameBorder="0"
   src="https://www.dailymotion.com/embed/video/test?sharing-enable=false&autoplay=false&mute=false&controls=true"
->
-  <div />
-</iframe>
+/>
 `;
 
 exports[`Dailymotion Player should renders correctly with muted 1`] = `
@@ -45,7 +37,5 @@ exports[`Dailymotion Player should renders correctly with muted 1`] = `
   className="widget-video-player-iframe"
   frameBorder="0"
   src="https://www.dailymotion.com/embed/video/test?sharing-enable=false&autoplay=false&mute=true&controls=false"
->
-  <div />
-</iframe>
+/>
 `;

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/Html5.spec.tsx.snap
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/Html5.spec.tsx.snap
@@ -25,12 +25,9 @@ exports[`Html5 Player should renders correctly 1`] = `
       src="test"
       type="video/mp4"
     />
-    <div />
   </video>
 </div>
 `;
-
-exports[`Html5 Player should renders correctly with aspectRatio 1`] = `[Function]`;
 
 exports[`Html5 Player should renders correctly with autoplay 1`] = `
 <div
@@ -57,7 +54,6 @@ exports[`Html5 Player should renders correctly with autoplay 1`] = `
       src="test"
       type="video/mp4"
     />
-    <div />
   </video>
 </div>
 `;
@@ -87,7 +83,6 @@ exports[`Html5 Player should renders correctly with controls 1`] = `
       src="test"
       type="video/mp4"
     />
-    <div />
   </video>
 </div>
 `;
@@ -117,7 +112,6 @@ exports[`Html5 Player should renders correctly with loop 1`] = `
       src="test"
       type="video/mp4"
     />
-    <div />
   </video>
 </div>
 `;
@@ -147,7 +141,6 @@ exports[`Html5 Player should renders correctly with muted 1`] = `
       src="test"
       type="video/mp4"
     />
-    <div />
   </video>
 </div>
 `;
@@ -177,7 +170,6 @@ exports[`Html5 Player should renders correctly with poster 1`] = `
       src="test"
       type="video/mp4"
     />
-    <div />
   </video>
 </div>
 `;

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/SizeContainer.spec.tsx.snap
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/SizeContainer.spec.tsx.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Size container renders correctly with height unit aspect ratio & any width 1`] = `
+<div
+  className="class-name size-box"
+  style={
+    Object {
+      "backgroundColor": "aqua",
+      "paddingTop": "29.142857142857142%",
+      "width": "68%",
+    }
+  }
+  tabIndex={1}
+>
+  <div
+    className="size-box-inner class-name-inner"
+  >
+    <span>
+      Child
+    </span>
+  </div>
+</div>
+`;
+
 exports[`Size container renders correctly with height unit aspect ratio 1:1 1`] = `
 <div
   className="class-name size-box"

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/SizeContainer.spec.tsx.snap
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/SizeContainer.spec.tsx.snap
@@ -1,0 +1,90 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Size container renders correctly with height unit aspect ratio 1`] = `
+<div
+  className="class-name size-box"
+  style={
+    Object {
+      "backgroundColor": "aqua",
+      "paddingTop": "21.428571428571427%",
+      "width": "50%",
+    }
+  }
+  tabIndex={1}
+>
+  <div
+    className="size-box-inner class-name-inner"
+  >
+    <span>
+      Child
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Size container renders correctly with height unit percentage of parent 1`] = `
+<div
+  className="class-name size-box"
+  style={
+    Object {
+      "backgroundColor": "aqua",
+      "height": "25%",
+      "paddingTop": 0,
+      "width": "50%",
+    }
+  }
+  tabIndex={1}
+>
+  <div
+    className="size-box-inner class-name-inner"
+  >
+    <span>
+      Child
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Size container renders correctly with height unit percentage of width 1`] = `
+<div
+  className="class-name size-box"
+  style={
+    Object {
+      "backgroundColor": "aqua",
+      "paddingTop": "12.5%",
+      "width": "50%",
+    }
+  }
+  tabIndex={1}
+>
+  <div
+    className="size-box-inner class-name-inner"
+  >
+    <span>
+      Child
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Size container renders correctly with height unit pixels 1`] = `
+<div
+  className="class-name size-box"
+  style={
+    Object {
+      "backgroundColor": "aqua",
+      "paddingTop": 25,
+      "width": "50%",
+    }
+  }
+  tabIndex={1}
+>
+  <div
+    className="size-box-inner class-name-inner"
+  >
+    <span>
+      Child
+    </span>
+  </div>
+</div>
+`;

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/SizeContainer.spec.tsx.snap
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/SizeContainer.spec.tsx.snap
@@ -1,6 +1,94 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Size container renders correctly with height unit aspect ratio 1`] = `
+exports[`Size container renders correctly with height unit aspect ratio 1:1 1`] = `
+<div
+  className="class-name size-box"
+  style={
+    Object {
+      "backgroundColor": "aqua",
+      "paddingTop": "50%",
+      "width": "50%",
+    }
+  }
+  tabIndex={1}
+>
+  <div
+    className="size-box-inner class-name-inner"
+  >
+    <span>
+      Child
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Size container renders correctly with height unit aspect ratio 3:2 1`] = `
+<div
+  className="class-name size-box"
+  style={
+    Object {
+      "backgroundColor": "aqua",
+      "paddingTop": "33.33333333333333%",
+      "width": "50%",
+    }
+  }
+  tabIndex={1}
+>
+  <div
+    className="size-box-inner class-name-inner"
+  >
+    <span>
+      Child
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Size container renders correctly with height unit aspect ratio 4:3 1`] = `
+<div
+  className="class-name size-box"
+  style={
+    Object {
+      "backgroundColor": "aqua",
+      "paddingTop": "37.5%",
+      "width": "50%",
+    }
+  }
+  tabIndex={1}
+>
+  <div
+    className="size-box-inner class-name-inner"
+  >
+    <span>
+      Child
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Size container renders correctly with height unit aspect ratio 16:9 1`] = `
+<div
+  className="class-name size-box"
+  style={
+    Object {
+      "backgroundColor": "aqua",
+      "paddingTop": "28.125%",
+      "width": "50%",
+    }
+  }
+  tabIndex={1}
+>
+  <div
+    className="size-box-inner class-name-inner"
+  >
+    <span>
+      Child
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Size container renders correctly with height unit aspect ratio 21:9 1`] = `
 <div
   className="class-name size-box"
   style={
@@ -75,6 +163,50 @@ exports[`Size container renders correctly with height unit pixels 1`] = `
       "backgroundColor": "aqua",
       "paddingTop": 25,
       "width": "50%",
+    }
+  }
+  tabIndex={1}
+>
+  <div
+    className="size-box-inner class-name-inner"
+  >
+    <span>
+      Child
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Size container renders correctly with pixel width & height unit aspect ratio 1`] = `
+<div
+  className="class-name size-box"
+  style={
+    Object {
+      "backgroundColor": "aqua",
+      "paddingTop": 21.428571428571427,
+      "width": "50px",
+    }
+  }
+  tabIndex={1}
+>
+  <div
+    className="size-box-inner class-name-inner"
+  >
+    <span>
+      Child
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Size container renders correctly with pixel width & height unit percentage of width 1`] = `
+<div
+  className="class-name size-box"
+  style={
+    Object {
+      "backgroundColor": "aqua",
+      "paddingTop": 12.5,
+      "width": "50px",
     }
   }
   tabIndex={1}

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/SizeContainer.spec.tsx.snap
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/SizeContainer.spec.tsx.snap
@@ -6,8 +6,8 @@ exports[`Size container renders correctly with height unit aspect ratio 1:1 1`] 
   style={
     Object {
       "backgroundColor": "aqua",
-      "paddingTop": "50%",
-      "width": "50%",
+      "paddingTop": "100%",
+      "width": "100%",
     }
   }
   tabIndex={1}
@@ -28,8 +28,8 @@ exports[`Size container renders correctly with height unit aspect ratio 3:2 1`] 
   style={
     Object {
       "backgroundColor": "aqua",
-      "paddingTop": "33.33333333333333%",
-      "width": "50%",
+      "paddingTop": "66.66666666666666%",
+      "width": "100%",
     }
   }
   tabIndex={1}
@@ -50,8 +50,8 @@ exports[`Size container renders correctly with height unit aspect ratio 4:3 1`] 
   style={
     Object {
       "backgroundColor": "aqua",
-      "paddingTop": "37.5%",
-      "width": "50%",
+      "paddingTop": "75%",
+      "width": "100%",
     }
   }
   tabIndex={1}
@@ -72,8 +72,8 @@ exports[`Size container renders correctly with height unit aspect ratio 16:9 1`]
   style={
     Object {
       "backgroundColor": "aqua",
-      "paddingTop": "28.125%",
-      "width": "50%",
+      "paddingTop": "56.25%",
+      "width": "100%",
     }
   }
   tabIndex={1}
@@ -94,8 +94,8 @@ exports[`Size container renders correctly with height unit aspect ratio 21:9 1`]
   style={
     Object {
       "backgroundColor": "aqua",
-      "paddingTop": "21.428571428571427%",
-      "width": "50%",
+      "paddingTop": "42.857142857142854%",
+      "width": "100%",
     }
   }
   tabIndex={1}
@@ -118,7 +118,7 @@ exports[`Size container renders correctly with height unit percentage of parent 
       "backgroundColor": "aqua",
       "height": "25%",
       "paddingTop": 0,
-      "width": "50%",
+      "width": "100%",
     }
   }
   tabIndex={1}
@@ -139,8 +139,8 @@ exports[`Size container renders correctly with height unit percentage of width 1
   style={
     Object {
       "backgroundColor": "aqua",
-      "paddingTop": "12.5%",
-      "width": "50%",
+      "paddingTop": "25%",
+      "width": "100%",
     }
   }
   tabIndex={1}
@@ -162,7 +162,7 @@ exports[`Size container renders correctly with height unit pixels 1`] = `
     Object {
       "backgroundColor": "aqua",
       "paddingTop": 25,
-      "width": "50%",
+      "width": "100%",
     }
   }
   tabIndex={1}
@@ -183,8 +183,8 @@ exports[`Size container renders correctly with pixel width & height unit aspect 
   style={
     Object {
       "backgroundColor": "aqua",
-      "paddingTop": 21.428571428571427,
-      "width": "50px",
+      "paddingTop": 42.857142857142854,
+      "width": "100px",
     }
   }
   tabIndex={1}
@@ -205,8 +205,8 @@ exports[`Size container renders correctly with pixel width & height unit percent
   style={
     Object {
       "backgroundColor": "aqua",
-      "paddingTop": 12.5,
-      "width": "50px",
+      "paddingTop": 25,
+      "width": "100px",
     }
   }
   tabIndex={1}

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/Video.spec.tsx.snap
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/Video.spec.tsx.snap
@@ -7,9 +7,7 @@ exports[`Video Player Renders the structure of dailymotion tags 1`] = `
   className="widget-video-player-iframe"
   frameBorder="0"
   src="https://www.dailymotion.com/embed/video/123456?sharing-enable=false&autoplay=false&mute=false&controls=false"
->
-  <div />
-</iframe>
+/>
 `;
 
 exports[`Video Player Renders the structure of html5 player tags 1`] = `
@@ -37,7 +35,6 @@ exports[`Video Player Renders the structure of html5 player tags 1`] = `
       src="http://ext.com/video.mp4"
       type="video/mp4"
     />
-    <div />
   </video>
 </div>
 `;
@@ -49,9 +46,7 @@ exports[`Video Player Renders the structure of vimeo tags 1`] = `
   className="widget-video-player-iframe"
   frameBorder="0"
   src="https://player.vimeo.com/video/123456?dnt=1&autoplay=0&muted=0&loop=0"
->
-  <div />
-</iframe>
+/>
 `;
 
 exports[`Video Player Renders the structure of youtube tags 1`] = `
@@ -61,7 +56,5 @@ exports[`Video Player Renders the structure of youtube tags 1`] = `
   className="widget-video-player-iframe"
   frameBorder="0"
   src="http://youtube.com/video/123456"
->
-  <div />
-</iframe>
+/>
 `;

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/Vimeo.spec.tsx.snap
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/Vimeo.spec.tsx.snap
@@ -7,12 +7,8 @@ exports[`VimeoPlayer Player should renders correctly 1`] = `
   className="widget-video-player-iframe"
   frameBorder="0"
   src="https://player.vimeo.com/video/123456?dnt=1&autoplay=0&muted=0&loop=0"
->
-  <div />
-</iframe>
+/>
 `;
-
-exports[`VimeoPlayer Player should renders correctly with aspectRatio 1`] = `[Function]`;
 
 exports[`VimeoPlayer Player should renders correctly with autoplay 1`] = `
 <iframe
@@ -21,9 +17,7 @@ exports[`VimeoPlayer Player should renders correctly with autoplay 1`] = `
   className="widget-video-player-iframe"
   frameBorder="0"
   src="https://player.vimeo.com/video/123456?dnt=1&autoplay=1&muted=0&loop=0"
->
-  <div />
-</iframe>
+/>
 `;
 
 exports[`VimeoPlayer Player should renders correctly with muted 1`] = `
@@ -33,7 +27,5 @@ exports[`VimeoPlayer Player should renders correctly with muted 1`] = `
   className="widget-video-player-iframe"
   frameBorder="0"
   src="https://player.vimeo.com/video/123456?dnt=1&autoplay=0&muted=1&loop=0"
->
-  <div />
-</iframe>
+/>
 `;

--- a/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/Youtube.spec.tsx.snap
+++ b/packages/pluggableWidgets/video-player-web/src/components/__tests__/__snapshots__/Youtube.spec.tsx.snap
@@ -7,12 +7,8 @@ exports[`YoutubePlayer Player should renders correctly 1`] = `
   className="widget-video-player-iframe"
   frameBorder="0"
   src="https://www.youtube.com/embed/123456?modestbranding=1&rel=0&autoplay=0&controls=0&muted=0&loop=0"
->
-  <div />
-</iframe>
+/>
 `;
-
-exports[`YoutubePlayer Player should renders correctly with aspectRatio 1`] = `[Function]`;
 
 exports[`YoutubePlayer Player should renders correctly with autoplay 1`] = `
 <iframe
@@ -21,9 +17,7 @@ exports[`YoutubePlayer Player should renders correctly with autoplay 1`] = `
   className="widget-video-player-iframe"
   frameBorder="0"
   src="https://www.youtube.com/embed/123456?modestbranding=1&rel=0&autoplay=1&controls=0&muted=0&loop=0"
->
-  <div />
-</iframe>
+/>
 `;
 
 exports[`YoutubePlayer Player should renders correctly with controls 1`] = `
@@ -33,9 +27,7 @@ exports[`YoutubePlayer Player should renders correctly with controls 1`] = `
   className="widget-video-player-iframe"
   frameBorder="0"
   src="https://www.youtube.com/embed/123456?modestbranding=1&rel=0&autoplay=0&controls=1&muted=0&loop=0"
->
-  <div />
-</iframe>
+/>
 `;
 
 exports[`YoutubePlayer Player should renders correctly with muted 1`] = `
@@ -45,7 +37,5 @@ exports[`YoutubePlayer Player should renders correctly with muted 1`] = `
   className="widget-video-player-iframe"
   frameBorder="0"
   src="https://www.youtube.com/embed/123456?modestbranding=1&rel=0&autoplay=0&controls=0&muted=1&loop=0"
->
-  <div />
-</iframe>
+/>
 `;

--- a/packages/pluggableWidgets/video-player-web/src/ui/VideoPlayer.css
+++ b/packages/pluggableWidgets/video-player-web/src/ui/VideoPlayer.css
@@ -2,7 +2,6 @@
     position: relative;
     width: 100%;
     height: 0;
-    padding-top: 400px;
 }
 
 .size-box-inner {

--- a/packages/pluggableWidgets/video-player-web/src/ui/VideoPlayer.css
+++ b/packages/pluggableWidgets/video-player-web/src/ui/VideoPlayer.css
@@ -1,3 +1,18 @@
+.size-box {
+    position: relative;
+    width: 100%;
+    height: 0;
+    padding-top: 400px;
+}
+
+.size-box-inner {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+}
+
 .widget-video-player-iframe {
     position: absolute;
     border: 0px;

--- a/packages/pluggableWidgets/video-player-web/src/ui/VideoPlayer.css
+++ b/packages/pluggableWidgets/video-player-web/src/ui/VideoPlayer.css
@@ -25,6 +25,7 @@
 
 .widget-video-player-html5 {
     width: 100%;
+    height: 100%;
     background-color: #000;
     position: absolute;
 }

--- a/packages/pluggableWidgets/video-player-web/src/utils/Utils.ts
+++ b/packages/pluggableWidgets/video-player-web/src/utils/Utils.ts
@@ -1,25 +1,3 @@
-export const fixHeightWithRatio = (element: HTMLElement, ratio: number): void => {
-    const height = element.parentElement ? element.parentElement.offsetWidth * ratio : 0;
-    if (height > 0 && element.parentElement) {
-        element.style.height = `${height}px`;
-        element.parentElement.style.height = `${height}px`;
-        if (element.parentElement.parentElement) {
-            element.parentElement.parentElement.style.height = `${height}px`;
-        }
-    }
-};
-
-export const getRatio = (url: string): Promise<number> => {
-    return fetch(`https://noembed.com/embed?url=${url}`)
-        .then(response => response.json())
-        .then(properties => {
-            return properties.height / properties.width;
-        })
-        .catch(() => {
-            return 0;
-        });
-};
-
 export const validateUrl = (url: string): string => {
     // eslint-disable-next-line no-useless-escape
     if (/^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/g.test(url)) {

--- a/packages/pluggableWidgets/video-player-web/typings/VideoPlayerProps.d.ts
+++ b/packages/pluggableWidgets/video-player-web/typings/VideoPlayerProps.d.ts
@@ -10,7 +10,7 @@ export type WidthUnitEnum = "percentage" | "pixels";
 
 export type HeightUnitEnum = "aspectRatio" | "percentageOfParent" | "percentageOfWidth" | "pixels";
 
-export type HeightAspectRatioEnum = "oneByOne" | "fourByThree" | "threeByTwo" | "sixteenByNine" | "TwentyOneByNine";
+export type HeightAspectRatioEnum = "sixteenByNine" | "fourByThree" | "threeByTwo" | "TwentyOneByNine" | "oneByOne";
 
 export interface VideoPlayerContainerProps {
     name: string;

--- a/packages/pluggableWidgets/video-player-web/typings/VideoPlayerProps.d.ts
+++ b/packages/pluggableWidgets/video-player-web/typings/VideoPlayerProps.d.ts
@@ -8,7 +8,9 @@ import { DynamicValue } from "mendix";
 
 export type WidthUnitEnum = "percentage" | "pixels";
 
-export type HeightUnitEnum = "aspectRatio" | "percentageOfWidth" | "pixels" | "percentageOfParent";
+export type HeightUnitEnum = "aspectRatio" | "percentageOfParent" | "percentageOfWidth" | "pixels";
+
+export type HeightAspectRatioEnum = "oneByOne" | "fourByThree" | "threeByTwo" | "sixteenByNine" | "TwentyOneByNine";
 
 export interface VideoPlayerContainerProps {
     name: string;
@@ -24,6 +26,7 @@ export interface VideoPlayerContainerProps {
     widthUnit: WidthUnitEnum;
     width: number;
     heightUnit: HeightUnitEnum;
+    heightAspectRatio: HeightAspectRatioEnum;
     height: number;
 }
 
@@ -39,5 +42,6 @@ export interface VideoPlayerPreviewProps {
     widthUnit: WidthUnitEnum;
     width: number | null;
     heightUnit: HeightUnitEnum;
+    heightAspectRatio: HeightAspectRatioEnum;
     height: number | null;
 }


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 7️⃣, 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ✅ 
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
This PR adds an aspect ratio options widget configuration property and improves the way dimensions are enforced on the video element.

## Relevant changes
- Add aspect ratio options widget configuration property.
- Rehaul setting dimensions on video player.
- Remove natural video aspect ratio calculation via third party.

## What should be covered while testing?
Test all dimension options for all video player options as the underlying dimension enforcement has changed.

## TODO
- [x] Add descriptions for widget properties to the dimensions tab.