### PR TITLE
Crafting: Marketplace auto release on tag

### DIFF
--- a/.github/workflows/MarketplaceRelease.yml
+++ b/.github/workflows/MarketplaceRelease.yml
@@ -1,0 +1,30 @@
+name: Marketplace Release
+
+on:
+    push:
+        tags:
+            - "*-web-v*"
+
+jobs:
+    publish:
+          name: "Marketplace Release"
+          runs-on: ubuntu-latest
+
+          steps:
+              - name: "Checking-out code"
+                uses: actions/checkout@v2
+                with:
+                    submodules: false
+              - name: "Defining Environment Variables"
+                id: variables
+                run: echo "::set-output name=tag::$(git tag --points-at HEAD)"
+              - name: "Defining lerna scope"
+                uses: jungwinter/split@v1
+                id: scope
+                with:
+                    msg: ${{ steps.variables.outputs.tag }}
+                    separator: "-v"
+              - name: "Installing dependencies"
+                run: npm install
+              - name: "Check changes and publish widgets"
+                run: TAG=${{ steps.variables.outputs.tag }} npm run releaseMarketplace -- --scope=${{ steps.scope.outputs._1 }}

--- a/.github/workflows/MarketplaceRelease.yml
+++ b/.github/workflows/MarketplaceRelease.yml
@@ -26,5 +26,5 @@ jobs:
                     separator: "-v"
               - name: "Installing dependencies"
                 run: npm install
-              - name: "Check changes and publish widgets"
+              - name: "Check changes and publish widget"
                 run: TAG=${{ steps.variables.outputs.tag }} MARKETPLACE_USERNAME=${{ secrets.MARKETPLACE_USERNAME }} MARKETPLACE_API_KEY=${{ secrets.MARKETPLACE_API_KEY }} npm run release:marketplace -- --scope=${{ steps.scope.outputs._1 }}

--- a/.github/workflows/MarketplaceRelease.yml
+++ b/.github/workflows/MarketplaceRelease.yml
@@ -27,4 +27,4 @@ jobs:
               - name: "Installing dependencies"
                 run: npm install
               - name: "Check changes and publish widgets"
-                run: TAG=${{ steps.variables.outputs.tag }} MARKETPLACE_USERNAME=${{ secrets.MARKETPLACE_USERNAME }} MARKETPLACE_API_KEY=${{ secrets.MARKETPLACE_API_KEY }} npm run releaseMarketplace -- --scope=${{ steps.scope.outputs._1 }}
+                run: TAG=${{ steps.variables.outputs.tag }} MARKETPLACE_USERNAME=${{ secrets.MARKETPLACE_USERNAME }} MARKETPLACE_API_KEY=${{ secrets.MARKETPLACE_API_KEY }} npm run release:marketplace -- --scope=${{ steps.scope.outputs._1 }}

--- a/.github/workflows/MarketplaceRelease.yml
+++ b/.github/workflows/MarketplaceRelease.yml
@@ -27,4 +27,4 @@ jobs:
               - name: "Installing dependencies"
                 run: npm install
               - name: "Check changes and publish widgets"
-                run: TAG=${{ steps.variables.outputs.tag }} npm run releaseMarketplace -- --scope=${{ steps.scope.outputs._1 }}
+                run: TAG=${{ steps.variables.outputs.tag }} MARKETPLACE_USERNAME=${{ secrets.MARKETPLACE_USERNAME }} MARKETPLACE_API_KEY=${{ secrets.MARKETPLACE_API_KEY }} npm run releaseMarketplace -- --scope=${{ steps.scope.outputs._1 }}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "mime": "^2.4.6",
     "mini-css-extract-plugin": "^1.2.1",
     "node-ip": "^0.1.2",
+    "node-fetch": "^2.6.1",
     "prettier": "^2.2.1",
     "pretty-quick": "^3.1.0",
     "react": "~17.0.1",

--- a/packages/customWidgets/calendar-web/package.json
+++ b/packages/customWidgets/calendar-web/package.json
@@ -14,7 +14,7 @@
   },
   "license": "Apache-2.0",
   "marketplace": {
-    "studioProMinimumVersion": "7.14.1",
+    "minimumMXVersion": "7.14.1",
     "marketplaceId": 107954
   },
   "scripts": {

--- a/packages/customWidgets/calendar-web/package.json
+++ b/packages/customWidgets/calendar-web/package.json
@@ -30,7 +30,7 @@
     "lint:fix": "npm run lint -- --fix",
     "build": "utils-react-widgets build",
     "release": "utils-react-widgets release",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "config": {
     "mendixHost": "http://localhost:8080",

--- a/packages/customWidgets/calendar-web/package.json
+++ b/packages/customWidgets/calendar-web/package.json
@@ -13,6 +13,10 @@
     "branchName": "calendar-web"
   },
   "license": "Apache-2.0",
+  "marketplace": {
+    "studioProMinimumVersion": "7.14.1",
+    "marketplaceId": 107954
+  },
   "scripts": {
     "start": "utils-react-widgets start",
     "dev": "utils-react-widgets dev",
@@ -25,7 +29,8 @@
     "lint": "eslint --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",
     "build": "utils-react-widgets build",
-    "release": "utils-react-widgets release"
+    "release": "utils-react-widgets release",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "config": {
     "mendixHost": "http://localhost:8080",

--- a/packages/customWidgets/carousel-web/package.json
+++ b/packages/customWidgets/carousel-web/package.json
@@ -14,7 +14,7 @@
   },
   "license": "Apache-2.0",
   "marketplace": {
-    "studioProMinimumVersion": "7.13.1",
+    "minimumMXVersion": "7.13.1",
     "marketplaceId": 47784
   },
   "scripts": {

--- a/packages/customWidgets/carousel-web/package.json
+++ b/packages/customWidgets/carousel-web/package.json
@@ -29,7 +29,7 @@
     "lint:fix": "npm run lint -- --fix",
     "build": "utils-react-widgets build",
     "release": "utils-react-widgets release",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "config": {
     "mendixHost": "http://localhost:8080",

--- a/packages/customWidgets/carousel-web/package.json
+++ b/packages/customWidgets/carousel-web/package.json
@@ -13,6 +13,10 @@
     "branchName": "carousel-web"
   },
   "license": "Apache-2.0",
+  "marketplace": {
+    "studioProMinimumVersion": "7.13.1",
+    "marketplaceId": 47784
+  },
   "scripts": {
     "start": "utils-react-widgets start",
     "dev": "utils-react-widgets dev",
@@ -24,7 +28,8 @@
     "lint": "eslint --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",
     "build": "utils-react-widgets build",
-    "release": "utils-react-widgets release"
+    "release": "utils-react-widgets release",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "config": {
     "mendixHost": "http://localhost:8080",

--- a/packages/customWidgets/color-picker-web/package.json
+++ b/packages/customWidgets/color-picker-web/package.json
@@ -13,6 +13,10 @@
     "branchName": "color-picker-web"
   },
   "license": "Apache-2.0",
+  "marketplace": {
+    "studioProMinimumVersion": "7.13.1",
+    "marketplaceId": 107044
+  },
   "scripts": {
     "start": "utils-react-widgets start",
     "dev": "utils-react-widgets dev",
@@ -24,7 +28,8 @@
     "lint": "eslint --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",
     "build": "utils-react-widgets build",
-    "release": "utils-react-widgets release"
+    "release": "utils-react-widgets release",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "config": {
     "mendixHost": "http://localhost:8080",

--- a/packages/customWidgets/color-picker-web/package.json
+++ b/packages/customWidgets/color-picker-web/package.json
@@ -29,7 +29,7 @@
     "lint:fix": "npm run lint -- --fix",
     "build": "utils-react-widgets build",
     "release": "utils-react-widgets release",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "config": {
     "mendixHost": "http://localhost:8080",

--- a/packages/customWidgets/color-picker-web/package.json
+++ b/packages/customWidgets/color-picker-web/package.json
@@ -14,7 +14,7 @@
   },
   "license": "Apache-2.0",
   "marketplace": {
-    "studioProMinimumVersion": "7.13.1",
+    "minimumMXVersion": "7.13.1",
     "marketplaceId": 107044
   },
   "scripts": {

--- a/packages/customWidgets/range-slider-web/package.json
+++ b/packages/customWidgets/range-slider-web/package.json
@@ -29,7 +29,7 @@
     "lint:fix": "npm run lint -- --fix",
     "build": "utils-react-widgets build",
     "release": "utils-react-widgets release",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "config": {
     "mendixHost": "http://localhost:8080",

--- a/packages/customWidgets/range-slider-web/package.json
+++ b/packages/customWidgets/range-slider-web/package.json
@@ -14,7 +14,7 @@
   },
   "license": "Apache-2.0",
   "marketplace": {
-    "studioProMinimumVersion": "7.13.1",
+    "minimumMXVersion": "7.13.1",
     "marketplaceId": 52704
   },
   "scripts": {

--- a/packages/customWidgets/range-slider-web/package.json
+++ b/packages/customWidgets/range-slider-web/package.json
@@ -13,6 +13,10 @@
     "branchName": "range-slider-web"
   },
   "license": "Apache-2.0",
+  "marketplace": {
+    "studioProMinimumVersion": "7.13.1",
+    "marketplaceId": 52704
+  },
   "scripts": {
     "start": "utils-react-widgets start",
     "dev": "utils-react-widgets dev",
@@ -24,7 +28,8 @@
     "lint": "eslint --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",
     "build": "utils-react-widgets build",
-    "release": "utils-react-widgets release"
+    "release": "utils-react-widgets release",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "config": {
     "mendixHost": "http://localhost:8080",

--- a/packages/customWidgets/rich-text-web/package.json
+++ b/packages/customWidgets/rich-text-web/package.json
@@ -14,7 +14,7 @@
   },
   "license": "Apache-2.0",
   "marketplace": {
-    "studioProMinimumVersion": "7.13.1",
+    "minimumMXVersion": "7.13.1",
     "marketplaceId": 74889
   },
   "scripts": {

--- a/packages/customWidgets/rich-text-web/package.json
+++ b/packages/customWidgets/rich-text-web/package.json
@@ -29,7 +29,7 @@
     "lint:fix": "npm run lint -- --fix",
     "build": "utils-react-widgets build",
     "release": "utils-react-widgets release",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "config": {
     "mendixHost": "http://localhost:8080",

--- a/packages/customWidgets/rich-text-web/package.json
+++ b/packages/customWidgets/rich-text-web/package.json
@@ -13,6 +13,10 @@
     "branchName": "rich-text-web"
   },
   "license": "Apache-2.0",
+  "marketplace": {
+    "studioProMinimumVersion": "7.13.1",
+    "marketplaceId": 74889
+  },
   "scripts": {
     "start": "utils-react-widgets start",
     "dev": "utils-react-widgets dev",
@@ -24,7 +28,8 @@
     "lint": "eslint --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",
     "build": "utils-react-widgets build",
-    "release": "utils-react-widgets release"
+    "release": "utils-react-widgets release",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "config": {
     "mendixHost": "http://localhost:8080",

--- a/packages/customWidgets/signature-web/package.json
+++ b/packages/customWidgets/signature-web/package.json
@@ -14,7 +14,7 @@
   },
   "license": "Apache-2.0",
   "marketplace": {
-    "studioProMinimumVersion": "7.13.1",
+    "minimumMXVersion": "7.13.1",
     "marketplaceId": 107984
   },
   "scripts": {

--- a/packages/customWidgets/signature-web/package.json
+++ b/packages/customWidgets/signature-web/package.json
@@ -29,7 +29,7 @@
     "lint:fix": "npm run lint -- --fix",
     "build": "utils-react-widgets build",
     "release": "utils-react-widgets release",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "config": {
     "mendixHost": "http://localhost:8080",

--- a/packages/customWidgets/signature-web/package.json
+++ b/packages/customWidgets/signature-web/package.json
@@ -13,6 +13,10 @@
     "branchName": "signature-web"
   },
   "license": "Apache-2.0",
+  "marketplace": {
+    "studioProMinimumVersion": "7.13.1",
+    "marketplaceId": 107984
+  },
   "scripts": {
     "start": "utils-react-widgets start",
     "dev": "utils-react-widgets dev",
@@ -24,7 +28,8 @@
     "lint": "eslint --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",
     "build": "utils-react-widgets build",
-    "release": "utils-react-widgets release"
+    "release": "utils-react-widgets release",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "config": {
     "mendixHost": "http://localhost:8080",

--- a/packages/customWidgets/slider-web/package.json
+++ b/packages/customWidgets/slider-web/package.json
@@ -13,6 +13,10 @@
     "branchName": "slider-web"
   },
   "license": "Apache-2.0",
+  "marketplace": {
+    "studioProMinimumVersion": "7.13.1",
+    "marketplaceId": 48786
+  },
   "scripts": {
     "start": "utils-react-widgets start",
     "dev": "utils-react-widgets dev",
@@ -24,7 +28,8 @@
     "lint": "eslint --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "lint:fix": "npm run lint -- --fix",
     "build": "utils-react-widgets build",
-    "release": "utils-react-widgets release"
+    "release": "utils-react-widgets release",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "config": {
     "mendixHost": "http://localhost:8080",

--- a/packages/customWidgets/slider-web/package.json
+++ b/packages/customWidgets/slider-web/package.json
@@ -29,7 +29,7 @@
     "lint:fix": "npm run lint -- --fix",
     "build": "utils-react-widgets build",
     "release": "utils-react-widgets release",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "config": {
     "mendixHost": "http://localhost:8080",

--- a/packages/customWidgets/slider-web/package.json
+++ b/packages/customWidgets/slider-web/package.json
@@ -14,7 +14,7 @@
   },
   "license": "Apache-2.0",
   "marketplace": {
-    "studioProMinimumVersion": "7.13.1",
+    "minimumMXVersion": "7.13.1",
     "marketplaceId": 48786
   },
   "scripts": {

--- a/packages/pluggableWidgets/accessibility-helper-web/package.json
+++ b/packages/pluggableWidgets/accessibility-helper-web/package.json
@@ -9,6 +9,10 @@
     "mendixHost": "http://localhost:8080",
     "developmentPort": 3000
   },
+  "marketplace": {
+    "studioProMinimumVersion": "9.0.5",
+    "marketplaceId": 114803
+  },
   "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",
     "branchName": "accessibility-helper-web"
@@ -23,7 +27,8 @@
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
-    "release": "pluggable-widgets-tools release:web"
+    "release": "pluggable-widgets-tools release:web",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/packages/pluggableWidgets/accessibility-helper-web/package.json
+++ b/packages/pluggableWidgets/accessibility-helper-web/package.json
@@ -28,7 +28,7 @@
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/packages/pluggableWidgets/accessibility-helper-web/package.json
+++ b/packages/pluggableWidgets/accessibility-helper-web/package.json
@@ -10,7 +10,7 @@
     "developmentPort": 3000
   },
   "marketplace": {
-    "studioProMinimumVersion": "9.0.5",
+    "minimumMXVersion": "9.0.5",
     "marketplaceId": 114803
   },
   "testProject": {

--- a/packages/pluggableWidgets/accordion-web/package.json
+++ b/packages/pluggableWidgets/accordion-web/package.json
@@ -33,7 +33,7 @@
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=9.0.0",

--- a/packages/pluggableWidgets/accordion-web/package.json
+++ b/packages/pluggableWidgets/accordion-web/package.json
@@ -14,7 +14,7 @@
     "developmentPort": 3000
   },
   "marketplace": {
-    "studioProMinimumVersion": "9.0.5",
+    "minimumMXVersion": "9.0.5",
     "marketplaceId": 117895
   },
   "testProject": {

--- a/packages/pluggableWidgets/accordion-web/package.json
+++ b/packages/pluggableWidgets/accordion-web/package.json
@@ -13,6 +13,10 @@
     "mendixHost": "http://localhost:8080",
     "developmentPort": 3000
   },
+  "marketplace": {
+    "studioProMinimumVersion": "9.0.5",
+    "marketplaceId": 117895
+  },
   "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",
     "branchName": "accordion-web"
@@ -28,7 +32,8 @@
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js --latest-atlas",
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
-    "release": "pluggable-widgets-tools release:web"
+    "release": "pluggable-widgets-tools release:web",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=9.0.0",

--- a/packages/pluggableWidgets/badge-button-web/package.json
+++ b/packages/pluggableWidgets/badge-button-web/package.json
@@ -33,7 +33,7 @@
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "cross-env MPKOUTPUT=BadgeButton.mpk pluggable-widgets-tools release:web",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/badge-button-web/package.json
+++ b/packages/pluggableWidgets/badge-button-web/package.json
@@ -13,6 +13,10 @@
     "mendixHost": "http://localhost:8080",
     "developmentPort": 3000
   },
+  "marketplace": {
+    "studioProMinimumVersion": "9.0.5",
+    "marketplaceId": 52705
+  },
   "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",
     "branchName": "badge-button-web"
@@ -28,7 +32,8 @@
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js --latest-atlas",
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
-    "release": "cross-env MPKOUTPUT=BadgeButton.mpk pluggable-widgets-tools release:web"
+    "release": "cross-env MPKOUTPUT=BadgeButton.mpk pluggable-widgets-tools release:web",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/badge-button-web/package.json
+++ b/packages/pluggableWidgets/badge-button-web/package.json
@@ -14,7 +14,7 @@
     "developmentPort": 3000
   },
   "marketplace": {
-    "studioProMinimumVersion": "9.0.5",
+    "minimumMXVersion": "9.0.5",
     "marketplaceId": 52705
   },
   "testProject": {

--- a/packages/pluggableWidgets/badge-web/package.json
+++ b/packages/pluggableWidgets/badge-web/package.json
@@ -13,6 +13,10 @@
     "mendixHost": "http://localhost:8080",
     "developmentPort": 3000
   },
+  "marketplace": {
+    "studioProMinimumVersion": "9.0.5",
+    "marketplaceId": 50325
+  },
   "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",
     "branchName": "badge-web"
@@ -28,7 +32,8 @@
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js --latest-atlas",
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
-    "release": "cross-env MPKOUTPUT=Badge.mpk pluggable-widgets-tools release:web"
+    "release": "cross-env MPKOUTPUT=Badge.mpk pluggable-widgets-tools release:web",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/badge-web/package.json
+++ b/packages/pluggableWidgets/badge-web/package.json
@@ -14,7 +14,7 @@
     "developmentPort": 3000
   },
   "marketplace": {
-    "studioProMinimumVersion": "9.0.5",
+    "minimumMXVersion": "9.0.5",
     "marketplaceId": 50325
   },
   "testProject": {

--- a/packages/pluggableWidgets/badge-web/package.json
+++ b/packages/pluggableWidgets/badge-web/package.json
@@ -33,7 +33,7 @@
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "cross-env MPKOUTPUT=Badge.mpk pluggable-widgets-tools release:web",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/barcode-scanner-web/package.json
+++ b/packages/pluggableWidgets/barcode-scanner-web/package.json
@@ -33,7 +33,7 @@
     "test:e2e": "echo \"Skipping barcode-scanner-web e2e tests\"",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/barcode-scanner-web/package.json
+++ b/packages/pluggableWidgets/barcode-scanner-web/package.json
@@ -13,6 +13,10 @@
     "mendixHost": "http://localhost:8080",
     "developmentPort": 3000
   },
+  "marketplace": {
+    "studioProMinimumVersion": "9.0.5",
+    "marketplaceId": 117627
+  },
   "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",
     "branchName": "barcode-scanner-web"
@@ -28,7 +32,8 @@
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js --latest-atlas",
     "test:e2e": "echo \"Skipping barcode-scanner-web e2e tests\"",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
-    "release": "pluggable-widgets-tools release:web"
+    "release": "pluggable-widgets-tools release:web",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/barcode-scanner-web/package.json
+++ b/packages/pluggableWidgets/barcode-scanner-web/package.json
@@ -14,7 +14,7 @@
     "developmentPort": 3000
   },
   "marketplace": {
-    "studioProMinimumVersion": "9.0.5",
+    "minimumMXVersion": "9.0.5",
     "marketplaceId": 117627
   },
   "testProject": {

--- a/packages/pluggableWidgets/fieldset-web/package.json
+++ b/packages/pluggableWidgets/fieldset-web/package.json
@@ -13,6 +13,10 @@
     "mendixHost": "http://localhost:8080",
     "developmentPort": 3000
   },
+  "marketplace": {
+    "studioProMinimumVersion": "8.3.1",
+    "marketplaceId": 113922
+  },
     "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",
     "branchName": "fieldset-web"
@@ -28,7 +32,8 @@
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
     "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "cross-env DEBUG=true node ../../node_modules/.bin/wdio ../../configs/e2e/wdio.conf.js",
-    "release": "pluggable-widgets-tools release:web"
+    "release": "pluggable-widgets-tools release:web",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "dependencies": {
     "@mendix/piw-utils-internal": "^1.0.0"

--- a/packages/pluggableWidgets/fieldset-web/package.json
+++ b/packages/pluggableWidgets/fieldset-web/package.json
@@ -14,7 +14,7 @@
     "developmentPort": 3000
   },
   "marketplace": {
-    "studioProMinimumVersion": "8.3.1",
+    "minimumMXVersion": "8.3.1",
     "marketplaceId": 113922
   },
     "testProject": {

--- a/packages/pluggableWidgets/fieldset-web/package.json
+++ b/packages/pluggableWidgets/fieldset-web/package.json
@@ -17,7 +17,7 @@
     "minimumMXVersion": "8.3.1",
     "marketplaceId": 113922
   },
-    "testProject": {
+  "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",
     "branchName": "fieldset-web"
   },

--- a/packages/pluggableWidgets/fieldset-web/package.json
+++ b/packages/pluggableWidgets/fieldset-web/package.json
@@ -33,7 +33,7 @@
     "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "cross-env DEBUG=true node ../../node_modules/.bin/wdio ../../configs/e2e/wdio.conf.js",
     "release": "pluggable-widgets-tools release:web",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "dependencies": {
     "@mendix/piw-utils-internal": "^1.0.0"

--- a/packages/pluggableWidgets/image-viewer-web/package.json
+++ b/packages/pluggableWidgets/image-viewer-web/package.json
@@ -33,7 +33,7 @@
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "cross-env MPKOUTPUT=ImageViewer.mpk pluggable-widgets-tools release:web",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/image-viewer-web/package.json
+++ b/packages/pluggableWidgets/image-viewer-web/package.json
@@ -13,6 +13,10 @@
     "mendixHost": "http://localhost:8080",
     "developmentPort": 3000
   },
+  "marketplace": {
+    "studioProMinimumVersion": "9.0.5",
+    "marketplaceId": 65122
+  },
   "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",
     "branchName": "image-viewer-web"
@@ -28,7 +32,8 @@
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js --latest-atlas",
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
-    "release": "cross-env MPKOUTPUT=ImageViewer.mpk pluggable-widgets-tools release:web"
+    "release": "cross-env MPKOUTPUT=ImageViewer.mpk pluggable-widgets-tools release:web",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/image-viewer-web/package.json
+++ b/packages/pluggableWidgets/image-viewer-web/package.json
@@ -14,7 +14,7 @@
     "developmentPort": 3000
   },
   "marketplace": {
-    "studioProMinimumVersion": "9.0.5",
+    "minimumMXVersion": "9.0.5",
     "marketplaceId": 65122
   },
   "testProject": {

--- a/packages/pluggableWidgets/maps-web/package.json
+++ b/packages/pluggableWidgets/maps-web/package.json
@@ -14,7 +14,7 @@
     "developmentPort": 3000
   },
   "marketplace": {
-    "studioProMinimumVersion": "9.0.5",
+    "minimumMXVersion": "9.0.5",
     "marketplaceId": 108261
   },
   "testProject": {

--- a/packages/pluggableWidgets/maps-web/package.json
+++ b/packages/pluggableWidgets/maps-web/package.json
@@ -33,7 +33,7 @@
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "cross-env MPKOUTPUT=Maps.mpk pluggable-widgets-tools release:web",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@googlemaps/jest-mocks": "^0.0.3",

--- a/packages/pluggableWidgets/maps-web/package.json
+++ b/packages/pluggableWidgets/maps-web/package.json
@@ -13,6 +13,10 @@
     "mendixHost": "http://localhost:8080",
     "developmentPort": 3000
   },
+  "marketplace": {
+    "studioProMinimumVersion": "9.0.5",
+    "marketplaceId": 108261
+  },
   "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",
     "branchName": "maps-web"
@@ -28,7 +32,8 @@
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js && rm tests/testProject/widgets/Maps.mpk",
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
-    "release": "cross-env MPKOUTPUT=Maps.mpk pluggable-widgets-tools release:web"
+    "release": "cross-env MPKOUTPUT=Maps.mpk pluggable-widgets-tools release:web",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@googlemaps/jest-mocks": "^0.0.3",

--- a/packages/pluggableWidgets/popup-menu-web/package.json
+++ b/packages/pluggableWidgets/popup-menu-web/package.json
@@ -12,6 +12,10 @@
     "mendixHost": "http://localhost:8080",
     "developmentPort": 3000
   },
+  "marketplace": {
+    "studioProMinimumVersion": "9.0.5",
+    "marketplaceId": 115826
+  },
   "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",
     "branchName": "popupmenu-web"
@@ -27,7 +31,8 @@
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
     "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
-    "release": "pluggable-widgets-tools release:web"
+    "release": "pluggable-widgets-tools release:web",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/popup-menu-web/package.json
+++ b/packages/pluggableWidgets/popup-menu-web/package.json
@@ -32,7 +32,7 @@
     "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/popup-menu-web/package.json
+++ b/packages/pluggableWidgets/popup-menu-web/package.json
@@ -13,7 +13,7 @@
     "developmentPort": 3000
   },
   "marketplace": {
-    "studioProMinimumVersion": "9.0.5",
+    "minimumMXVersion": "9.0.5",
     "marketplaceId": 115826
   },
   "testProject": {

--- a/packages/pluggableWidgets/progress-bar-web/package.json
+++ b/packages/pluggableWidgets/progress-bar-web/package.json
@@ -33,7 +33,7 @@
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "cross-env MPKOUTPUT=ProgressBar.mpk pluggable-widgets-tools release:web",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/progress-bar-web/package.json
+++ b/packages/pluggableWidgets/progress-bar-web/package.json
@@ -14,7 +14,7 @@
     "developmentPort": 3000
   },
   "marketplace": {
-    "studioProMinimumVersion": "9.0.5",
+    "minimumMXVersion": "9.0.5",
     "marketplaceId": 48910
   },
   "testProject": {

--- a/packages/pluggableWidgets/progress-bar-web/package.json
+++ b/packages/pluggableWidgets/progress-bar-web/package.json
@@ -13,6 +13,10 @@
     "mendixHost": "http://localhost:8080",
     "developmentPort": 3000
   },
+  "marketplace": {
+    "studioProMinimumVersion": "9.0.5",
+    "marketplaceId": 48910
+  },
   "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",
     "branchName": "progress-bar-web"
@@ -28,7 +32,8 @@
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js --latest-atlas",
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
-    "release": "cross-env MPKOUTPUT=ProgressBar.mpk pluggable-widgets-tools release:web"
+    "release": "cross-env MPKOUTPUT=ProgressBar.mpk pluggable-widgets-tools release:web",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/progress-circle-web/package.json
+++ b/packages/pluggableWidgets/progress-circle-web/package.json
@@ -33,7 +33,7 @@
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "cross-env MPKOUTPUT=ProgressCircle.mpk pluggable-widgets-tools release:web",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/progress-circle-web/package.json
+++ b/packages/pluggableWidgets/progress-circle-web/package.json
@@ -14,7 +14,7 @@
     "developmentPort": 3000
   },
   "marketplace": {
-    "studioProMinimumVersion": "9.0.5",
+    "minimumMXVersion": "9.0.5",
     "marketplaceId": 47783
   },
   "testProject": {

--- a/packages/pluggableWidgets/progress-circle-web/package.json
+++ b/packages/pluggableWidgets/progress-circle-web/package.json
@@ -13,6 +13,10 @@
     "mendixHost": "http://localhost:8080",
     "developmentPort": 3000
   },
+  "marketplace": {
+    "studioProMinimumVersion": "9.0.5",
+    "marketplaceId": 47783
+  },
   "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",
     "branchName": "progress-circle-web"
@@ -28,7 +32,8 @@
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js --latest-atlas",
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
-    "release": "cross-env MPKOUTPUT=ProgressCircle.mpk pluggable-widgets-tools release:web"
+    "release": "cross-env MPKOUTPUT=ProgressCircle.mpk pluggable-widgets-tools release:web",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/rating-web/package.json
+++ b/packages/pluggableWidgets/rating-web/package.json
@@ -13,6 +13,10 @@
     "mendixHost": "http://localhost:8080",
     "developmentPort": 3000
   },
+  "marketplace": {
+    "studioProMinimumVersion": "9.0.5",
+    "marketplaceId": 54611
+  },
   "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",
     "branchName": "star-rating-web"
@@ -28,7 +32,8 @@
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js --latest-atlas",
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
-    "release": "cross-env MPKOUTPUT=StarRating.mpk pluggable-widgets-tools release:web"
+    "release": "cross-env MPKOUTPUT=StarRating.mpk pluggable-widgets-tools release:web",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/rating-web/package.json
+++ b/packages/pluggableWidgets/rating-web/package.json
@@ -14,7 +14,7 @@
     "developmentPort": 3000
   },
   "marketplace": {
-    "studioProMinimumVersion": "9.0.5",
+    "minimumMXVersion": "9.0.5",
     "marketplaceId": 54611
   },
   "testProject": {

--- a/packages/pluggableWidgets/rating-web/package.json
+++ b/packages/pluggableWidgets/rating-web/package.json
@@ -33,7 +33,7 @@
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "cross-env MPKOUTPUT=StarRating.mpk pluggable-widgets-tools release:web",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/switch-web/package.json
+++ b/packages/pluggableWidgets/switch-web/package.json
@@ -33,7 +33,7 @@
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "cross-env MPKOUTPUT=Switch.mpk pluggable-widgets-tools release:web",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/switch-web/package.json
+++ b/packages/pluggableWidgets/switch-web/package.json
@@ -14,7 +14,7 @@
     "developmentPort": 3000
   },
   "marketplace": {
-    "studioProMinimumVersion": "9.0.5",
+    "minimumMXVersion": "9.0.5",
     "marketplaceId": 50324
   },
   "testProject": {

--- a/packages/pluggableWidgets/switch-web/package.json
+++ b/packages/pluggableWidgets/switch-web/package.json
@@ -13,6 +13,10 @@
     "mendixHost": "http://localhost:8080",
     "developmentPort": 3000
   },
+  "marketplace": {
+    "studioProMinimumVersion": "9.0.5",
+    "marketplaceId": 50324
+  },
   "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",
     "branchName": "switch-web"
@@ -28,7 +32,8 @@
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js --latest-atlas",
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
-    "release": "cross-env MPKOUTPUT=Switch.mpk pluggable-widgets-tools release:web"
+    "release": "cross-env MPKOUTPUT=Switch.mpk pluggable-widgets-tools release:web",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/timeline-web/package.json
+++ b/packages/pluggableWidgets/timeline-web/package.json
@@ -9,6 +9,10 @@
     "mendixHost": "http://localhost:8080",
     "developmentPort": 3000
   },
+  "marketplace": {
+    "studioProMinimumVersion": "9.0.5",
+    "marketplaceId": 115852
+  },
   "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",
     "branchName": "timeline-web"
@@ -24,7 +28,8 @@
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
-    "release": "pluggable-widgets-tools release:web"
+    "release": "pluggable-widgets-tools release:web",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/pluggableWidgets/timeline-web/package.json
+++ b/packages/pluggableWidgets/timeline-web/package.json
@@ -29,7 +29,7 @@
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/packages/pluggableWidgets/timeline-web/package.json
+++ b/packages/pluggableWidgets/timeline-web/package.json
@@ -10,7 +10,7 @@
     "developmentPort": 3000
   },
   "marketplace": {
-    "studioProMinimumVersion": "9.0.5",
+    "minimumMXVersion": "9.0.5",
     "marketplaceId": 115852
   },
   "testProject": {

--- a/packages/pluggableWidgets/video-player-web/package.json
+++ b/packages/pluggableWidgets/video-player-web/package.json
@@ -33,7 +33,7 @@
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web",
-    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
+    "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/video-player-web/package.json
+++ b/packages/pluggableWidgets/video-player-web/package.json
@@ -13,6 +13,10 @@
     "mendixHost": "http://localhost:8080/",
     "developmentPort": "3000"
   },
+  "marketplace": {
+    "studioProMinimumVersion": "8.0.0",
+    "marketplaceId": 110700
+  },
   "testProject": {
     "githubUrl": "https://github.com/mendix/testProjects",
     "branchName": "video-player-web"
@@ -28,7 +32,8 @@
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
     "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
-    "release": "pluggable-widgets-tools release:web"
+    "release": "pluggable-widgets-tools release:web",
+    "releaseMarketplace": "node ../../../scripts/release/marketplaceRelease.js"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/video-player-web/package.json
+++ b/packages/pluggableWidgets/video-player-web/package.json
@@ -14,7 +14,7 @@
     "developmentPort": "3000"
   },
   "marketplace": {
-    "studioProMinimumVersion": "8.0.0",
+    "minimumMXVersion": "8.0.0",
     "marketplaceId": 110700
   },
   "testProject": {

--- a/scripts/release/marketplaceRelease.js
+++ b/scripts/release/marketplaceRelease.js
@@ -14,19 +14,19 @@ async function main() {
     const {
         widgetName,
         version,
-        marketplace: { studioProMinimumVersion, marketplaceId }
+        marketplace: { minimumMXVersion, marketplaceId }
     } = require(join(process.cwd(), "package.json"));
 
-    if (!widgetName || !version || !studioProMinimumVersion || !marketplaceId || !version.includes(".")) {
+    if (!widgetName || !version || !minimumMXVersion || !marketplaceId || !version.includes(".")) {
         throw new Error("Widget does not define expected keys in its package.json");
     }
 
-    await uploadModuleToAppStore(widgetName, marketplaceId, version, studioProMinimumVersion);
+    await uploadModuleToAppStore(widgetName, marketplaceId, version, minimumMXVersion);
 }
 
-async function uploadModuleToAppStore(widgetName, marketplaceId, version, studioProMinimumVersion) {
+async function uploadModuleToAppStore(widgetName, marketplaceId, version, minimumMXVersion) {
     try {
-        const postResponse = await createDraft(marketplaceId, version, studioProMinimumVersion);
+        const postResponse = await createDraft(marketplaceId, version, minimumMXVersion);
         await publishDraft(postResponse.Version.VersionUUID);
         console.log(`Successfully uploaded ${widgetName} to the Mendix Marketplace.`);
     } catch (error) {
@@ -58,7 +58,7 @@ async function getGithubAssetUrl() {
     }
 }
 
-async function createDraft(marketplaceId, version, studioProMinimumVersion) {
+async function createDraft(marketplaceId, version, minimumMXVersion) {
     console.log(`Creating draft in the Mendix Marketplace..`);
     const url = `${config.appStoreUrl}/packages/${marketplaceId}/version`;
     try {
@@ -68,7 +68,7 @@ async function createDraft(marketplaceId, version, studioProMinimumVersion) {
             VersionMajor: major ?? 1,
             VersionMinor: minor ?? 0,
             VersionPatch: patch ?? 0,
-            StudioProVersion: studioProMinimumVersion,
+            StudioProVersion: minimumMXVersion,
             IsSourceGitHub: "true",
             GithubRepo: {
                 UseReadmeForDoc: false,

--- a/scripts/release/marketplaceRelease.js
+++ b/scripts/release/marketplaceRelease.js
@@ -17,6 +17,8 @@ async function main() {
         marketplace: { minimumMXVersion, marketplaceId }
     } = require(join(process.cwd(), "package.json"));
 
+    console.log(`Starting release process for tag ${process.env.TAG}`);
+
     if (!widgetName || !version || !minimumMXVersion || !marketplaceId || !version.includes(".")) {
         throw new Error("Widget does not define expected keys in its package.json");
     }

--- a/scripts/release/marketplaceRelease.js
+++ b/scripts/release/marketplaceRelease.js
@@ -120,7 +120,7 @@ async function fetch(method, url, body) {
     try {
         response = await nodefetch(url, httpsOptions);
     } catch (error) {
-        throw new Error(`An error occurred while retrieving data from ${url}`);
+        throw new Error(`An error occurred while retrieving data from ${url}. Technical error: ${error.message}`);
     }
     console.log(`Response status Code ${response.status}`);
     if (response.status === 409) {

--- a/scripts/release/marketplaceRelease.js
+++ b/scripts/release/marketplaceRelease.js
@@ -1,0 +1,135 @@
+const nodefetch = require("node-fetch");
+const { join } = require("path");
+
+const config = {
+    appStoreUrl: "https://appstore.home.mendix.com/rest/packagesapi/v2"
+};
+
+main().catch(e => {
+    console.error(e);
+    process.exit(-1);
+});
+
+async function main() {
+    const {
+        widgetName,
+        version,
+        marketplace: { studioProMinimumVersion, marketplaceId }
+    } = require(join(process.cwd(), "package.json"));
+
+    if (!widgetName || !version || !studioProMinimumVersion || !marketplaceId || !version.includes(".")) {
+        throw new Error("Widget does not define expected keys in its package.json");
+    }
+
+    await uploadModuleToAppStore(widgetName, marketplaceId, version, studioProMinimumVersion);
+}
+
+async function uploadModuleToAppStore(widgetName, marketplaceId, version, studioProMinimumVersion) {
+    try {
+        const postResponse = await createDraft(marketplaceId, version, studioProMinimumVersion);
+        await publishDraft(postResponse.Version.VersionUUID);
+        console.log(`Successfully uploaded ${widgetName} to the Mendix Marketplace.`);
+    } catch (error) {
+        error.message = `Failed uploading module to appstore with error: ${error.message}`;
+        throw error;
+    }
+}
+
+async function getGithubAssetUrl() {
+    console.log("Retrieving informations from Github Tag");
+    const request = await nodefetch("https://api.github.com/repos/mendix/widgets-resources/releases?per_page=5", {
+        method: "GET"
+    });
+    const data = (await request.json()) ?? [];
+    const releaseId = data.filter(info => info.tag_name === process.env.TAG)?.pop()?.id;
+    if (releaseId) {
+        const assetsRequest = await nodefetch(
+            `https://api.github.com/repos/mendix/widgets-resources/releases/${releaseId}/assets`,
+            { method: "GET" }
+        );
+        const assetsData = (await assetsRequest.json()) ?? [];
+        const downloadUrl = assetsData.filter(asset => asset.name.endsWith(".mpk"))?.pop()?.browser_download_url;
+        if (!downloadUrl) {
+            throw new Error("Could not retrieve MPK url from GitHub tag");
+        }
+        return downloadUrl;
+    } else {
+        throw new Error("Could not retrieve release tag information from GitHub");
+    }
+}
+
+async function createDraft(marketplaceId, version, studioProMinimumVersion) {
+    console.log(`Creating draft in the Mendix Marketplace..`);
+    const url = `${config.appStoreUrl}/packages/${marketplaceId}/version`;
+    try {
+        const [major, minor, patch] = version.split(".");
+        const assetUrl = await getGithubAssetUrl();
+        const body = {
+            VersionMajor: major ?? 1,
+            VersionMinor: minor ?? 0,
+            VersionPatch: patch ?? 0,
+            StudioProVersion: studioProMinimumVersion,
+            IsSourceGitHub: "true",
+            GithubRepo: {
+                UseReadmeForDoc: false,
+                ArtifactURL: assetUrl
+            }
+        };
+
+        return fetch("POST", url, JSON.stringify(body));
+    } catch (error) {
+        error.message = `Failed creating draft in the appstore with error: ${error.message}`;
+        throw error;
+    }
+}
+
+function publishDraft(UUID) {
+    console.log(`Publishing draft in the Mendix Marketplace..`);
+    const url = `${config.appStoreUrl}/version/${UUID}/publish`;
+    try {
+        return fetch("PUT", url);
+    } catch (error) {
+        error.message = `Failed publishing draft in the appstore with error: ${error.message}`;
+        throw error;
+    }
+}
+
+async function fetch(method, url, body) {
+    let response;
+    const httpsOptions = {
+        method,
+        redirect: "follow",
+        headers: {
+            Accept: "application/json",
+            "Mendix-Username": process.env.MARKETPLACE_USERNAME,
+            "Mendix-ApiKey": process.env.MARKETPLACE_API_KEY
+        },
+        body: undefined
+    };
+
+    if (body) {
+        httpsOptions.body = body;
+        httpsOptions.headers["Content-Type"] = "application/json";
+    }
+
+    console.log(`Fetching URL (${method}): ${url}`);
+    try {
+        response = await nodefetch(url, httpsOptions);
+    } catch (error) {
+        console.error(error);
+    }
+    console.log(`Response status Code ${response.status}`);
+    if (response.status === 409) {
+        throw new Error(
+            `Fetching Failed (Code ${response.status}). Possible solution: Check & delete drafts in Mendix Marketplace.`
+        );
+    } else if (response.status === 503) {
+        throw new Error(`Fetching Failed. "${url}" is unreachable (Code ${response.status}).`);
+    } else if (response.status !== 200 && response.status !== 201) {
+        throw new Error(`Fetching Failed (Code ${response.status}). ${response.statusText}`);
+    } else if (response.ok) {
+        return response.json();
+    } else {
+        throw new Error(`Fetching Failed. Unhandled status code: ${response.status}`);
+    }
+}


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 7️⃣, 8️⃣, 9️⃣

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Release a widget is always painful, as we do 2 releases, one via our release tags and another one via Marketplace. It is also very painful to keep tracking the correct version that a widget has as minimum version. This PR introduces the minimum version for each widget as well as auto publish them to the Marketplace as soon as a tag is created.

## Relevant changes
The following variables needs to be created in order to make it work on GH Actions:
- TAG (only running locally)
- MARKETPLACE_USERNAME
- MARKETPLACE_API_KEY

## What should be covered while testing?
-
