### PR TITLE
[WC-623] Fix datagrid 2 default sorting issue

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -5,7 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## 1.2.0 - Unreleased
+## 1.2.1 - 2021-07-01
+
+### Changed
+- We fixed an issue with data source default sorting wasn't being applied correctly.
+
+## 1.2.0 - 2021-06-29
 
 ### Added
 - We implemented lazy filtering and sorting. Now Data Grid v2 will not load all the data if you have sorting or filtering enabled.

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datagrid-web",
   "widgetName": "Datagrid",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "copyright": "Mendix B.V.",
   "repository": {

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -67,7 +67,7 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
             [props.columns[sortParameters.columnIndex].attribute!.id, sortParameters.desc ? "desc" : "asc"]
         ]);
     } else {
-        props.datasource.setSortOrder([]);
+        props.datasource.setSortOrder(undefined);
     }
 
     const columns = useMemo(() => transformColumnProps(props.columns), [props.columns]);

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="1.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="1.2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Datagrid.xml"/>
         </widgetFiles>


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌ 
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX  9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ❌
- Compatible with Studio ❌
- Cross-browser compatible  ❌

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
This PR fix the default sort order not being applied.

## What should be covered while testing?
Test using the sort order in the data source.

