### PR TITLE
[WC-529] add text template properties for urls

### DIFF
--- a/packages/pluggableWidgets/video-player-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/video-player-web/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## 1.2.0 - [Unreleased]
+
+### Changed
+-   We changed the property type of Video link and Poster link to text template.
+
 ## 1.1.0 - 2021-07-02
 
 ### Added

--- a/packages/pluggableWidgets/video-player-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/video-player-web/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## 1.2.0 - [Unreleased]
+
+### Added
+-   We added the option to configure Video link and Poster link with text templates.
+
 ## 1.1.0 - 2021-07-02
 
 ### Added

--- a/packages/pluggableWidgets/video-player-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/video-player-web/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this widget will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## 1.1.0 - 2021-07-02
 
 ### Added

--- a/packages/pluggableWidgets/video-player-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/video-player-web/CHANGELOG.md
@@ -6,11 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## 1.2.0 - [Unreleased]
-
-### Changed
--   We changed the property type of Video link and Poster link to text template.
-
 ## 1.1.0 - 2021-07-02
 
 ### Added

--- a/packages/pluggableWidgets/video-player-web/package.json
+++ b/packages/pluggableWidgets/video-player-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "video-player-web",
   "widgetName": "VideoPlayer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Player for YouTube, Dailymotion, Vimeo and Mp4 videos",
   "copyright": "Mendix BV",
   "repository": {

--- a/packages/pluggableWidgets/video-player-web/package.json
+++ b/packages/pluggableWidgets/video-player-web/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "node ../../../scripts/test/updateAtlas.js",
-    "test:e2e": "pluggable-widgets-tools test:e2e:web --mx-version 8",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "pluggable-widgets-tools release:web"
   },

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.editorConfig.ts
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.editorConfig.ts
@@ -1,6 +1,12 @@
-import { hidePropertyIn, Properties, transformGroupsIntoTabs } from "@mendix/piw-utils-internal";
+import {
+    hidePropertiesIn,
+    hidePropertyIn,
+    Problem,
+    Properties,
+    transformGroupsIntoTabs
+} from "@mendix/piw-utils-internal";
 
-import { VideoPlayerContainerProps } from "../typings/VideoPlayerProps";
+import { VideoPlayerContainerProps, VideoPlayerPreviewProps } from "../typings/VideoPlayerProps";
 
 export function getProperties(
     values: VideoPlayerContainerProps,
@@ -13,9 +19,33 @@ export function getProperties(
         hidePropertyIn(defaultProperties, values, "heightAspectRatio");
     }
 
+    if (values.type === "dynamic") {
+        hidePropertiesIn(defaultProperties, values, ["urlExpression", "posterExpression"]);
+    }
+    if (values.type === "expression") {
+        hidePropertiesIn(defaultProperties, values, ["videoUrl", "posterUrl"]);
+    }
+
     if (platform === "web") {
         transformGroupsIntoTabs(defaultProperties);
     }
 
     return defaultProperties;
+}
+
+export function check(values: VideoPlayerPreviewProps): Problem[] {
+    const errors: Problem[] = [];
+    if (values.type === "dynamic" && !values.videoUrl) {
+        errors.push({
+            property: "videoUrl",
+            message: "Providing a video link is required"
+        });
+    }
+    if (values.type === "expression" && !values.urlExpression) {
+        errors.push({
+            property: "urlExpression",
+            message: "Providing a video link is required"
+        });
+    }
+    return errors;
 }

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.tsx
@@ -9,6 +9,9 @@ import "./ui/VideoPlayer.css";
 
 export default class VideoPlayer extends Component<VideoPlayerContainerProps> {
     render(): JSX.Element {
+        const useExpressionForLinks = this.props.type === "expression";
+        const url = useExpressionForLinks ? this.props.urlExpression?.value : this.props.videoUrl?.value;
+        const poster = useExpressionForLinks ? this.props.posterExpression?.value : this.props.posterUrl?.value;
         return (
             <SizeContainer
                 className={classNames("widget-video-player widget-video-player-container", this.props.class)}
@@ -21,8 +24,8 @@ export default class VideoPlayer extends Component<VideoPlayerContainerProps> {
                 tabIndex={this.props.tabIndex}
             >
                 <Video
-                    url={this.props.urlExpression && this.props.urlExpression.value}
-                    poster={this.props.posterExpression && this.props.posterExpression.value}
+                    url={url}
+                    poster={poster}
                     autoStart={this.props.autoStart}
                     showControls={this.props.showControls}
                     loop={this.props.loop}

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.tsx
@@ -21,8 +21,8 @@ export default class VideoPlayer extends Component<VideoPlayerContainerProps> {
                 tabIndex={this.props.tabIndex}
             >
                 <Video
-                    url={this.props.urlExpression && this.props.urlExpression.value}
-                    poster={this.props.posterExpression && this.props.posterExpression.value}
+                    url={this.props.videoUrl && this.props.videoUrl.value}
+                    poster={this.props.posterUrl && this.props.posterUrl.value}
                     autoStart={this.props.autoStart}
                     showControls={this.props.showControls}
                     loop={this.props.loop}

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.tsx
@@ -21,8 +21,8 @@ export default class VideoPlayer extends Component<VideoPlayerContainerProps> {
                 tabIndex={this.props.tabIndex}
             >
                 <Video
-                    url={this.props.videoUrl && this.props.videoUrl.value}
-                    poster={this.props.posterUrl && this.props.posterUrl.value}
+                    url={this.props.urlExpression && this.props.urlExpression.value}
+                    poster={this.props.posterExpression && this.props.posterExpression.value}
                     autoStart={this.props.autoStart}
                     showControls={this.props.showControls}
                     loop={this.props.loop}

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
@@ -8,7 +8,7 @@
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="Data source">
-                <property key="type" type="enumeration" defaultValue="dynamic">
+                <property key="type" type="enumeration" defaultValue="expression">
                     <caption>Type</caption>
                     <description />
                     <enumerationValues>

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
@@ -8,13 +8,15 @@
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="Data source">
-                <property key="videoUrl" type="textTemplate">
+                <property key="urlExpression" type="expression">
                     <caption>Video link</caption>
                     <description>The web address of the video: YouTube, Vimeo, Dailymotion or MP4.</description>
+                    <returnType type="String"/>
                 </property>
-                <property key="posterUrl" type="textTemplate" required="false">
+                <property key="posterExpression" type="expression" required="false">
                     <caption>Poster link</caption>
                     <description>The web address of the poster image. A poster image is a custom preview image that will be shown in the player until the user starts the video.</description>
+                    <returnType type="String"/>
                 </property>
             </propertyGroup>
             <propertyGroup caption="Common">

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
@@ -8,15 +8,13 @@
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="Data source">
-                <property key="urlExpression" type="expression">
+                <property key="videoUrl" type="textTemplate">
                     <caption>Video link</caption>
                     <description>The web address of the video: YouTube, Vimeo, Dailymotion or MP4.</description>
-                    <returnType type="String"/>
                 </property>
-                <property key="posterExpression" type="expression" required="false">
+                <property key="posterUrl" type="textTemplate" required="false">
                     <caption>Poster link</caption>
                     <description>The web address of the poster image. A poster image is a custom preview image that will be shown in the player until the user starts the video.</description>
-                    <returnType type="String"/>
                 </property>
             </propertyGroup>
             <propertyGroup caption="Common">

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
@@ -8,7 +8,15 @@
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="Data source">
-                <property key="urlExpression" type="expression">
+                <property key="type" type="enumeration" defaultValue="dynamic">
+                    <caption>Type</caption>
+                    <description />
+                    <enumerationValues>
+                        <enumerationValue key="dynamic">Dynamic</enumerationValue>
+                        <enumerationValue key="expression">Expression</enumerationValue>
+                    </enumerationValues>
+                </property>
+                <property key="urlExpression" type="expression" required="false">
                     <caption>Video link</caption>
                     <description>The web address of the video: YouTube, Vimeo, Dailymotion or MP4.</description>
                     <returnType type="String"/>
@@ -17,6 +25,14 @@
                     <caption>Poster link</caption>
                     <description>The web address of the poster image. A poster image is a custom preview image that will be shown in the player until the user starts the video.</description>
                     <returnType type="String"/>
+                </property>
+                <property key="videoUrl" type="textTemplate" required="false">
+                    <caption>Video link</caption>
+                    <description>The web address of the video: YouTube, Vimeo, Dailymotion or MP4.</description>
+                </property>
+                <property key="posterUrl" type="textTemplate" required="false">
+                    <caption>Poster link</caption>
+                    <description>The web address of the poster image. A poster image is a custom preview image that will be shown in the player until the user starts the video.</description>
                 </property>
             </propertyGroup>
             <propertyGroup caption="Common">

--- a/packages/pluggableWidgets/video-player-web/src/package.xml
+++ b/packages/pluggableWidgets/video-player-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="VideoPlayer" version="1.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="VideoPlayer" version="1.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="VideoPlayer.xml"/>
         </widgetFiles>

--- a/packages/pluggableWidgets/video-player-web/tests/e2e/specs/VideoPlayer.spec.ts
+++ b/packages/pluggableWidgets/video-player-web/tests/e2e/specs/VideoPlayer.spec.ts
@@ -6,12 +6,10 @@ describe("Grid page", () => {
     it("should render youtube iframe", () => {
         gridpage.open();
         gridpage.youtube.waitForDisplayed();
-        // @ts-ignore
         const youtubePlayer = gridpage.youtube.getHTML();
-        // prettier-ignore
-        expect(youtubePlayer).toContain("class=\"widget-video-player-iframe\"");
-        // prettier-ignore
-        expect(youtubePlayer).toContain("src=\"https://www.youtube.com");
+
+        expect(youtubePlayer).toContain('class="widget-video-player-iframe"');
+        expect(youtubePlayer).toContain('src="https://www.youtube.com');
         expect(youtubePlayer).toContain("&amp;autoplay=1");
         expect(youtubePlayer).toContain("&amp;controls=0");
         expect(youtubePlayer).toContain("&amp;muted=0");
@@ -19,14 +17,11 @@ describe("Grid page", () => {
     });
 
     it("should render vimeo iframe", () => {
-        // @ts-ignore
         gridpage.vimeo.waitForDisplayed();
-        // @ts-ignore
         const youtubePlayer = gridpage.vimeo.getHTML();
-        // prettier-ignore
-        expect(youtubePlayer).toContain("class=\"widget-video-player-iframe\"");
-        // prettier-ignore
-        expect(youtubePlayer).toContain("src=\"https://player.vimeo.com");
+
+        expect(youtubePlayer).toContain('class="widget-video-player-iframe"');
+        expect(youtubePlayer).toContain('src="https://player.vimeo.com');
         expect(youtubePlayer).toContain("&amp;autoplay=1");
         expect(youtubePlayer).toContain("&amp;muted=0");
         expect(youtubePlayer).toContain("&amp;loop=0");
@@ -40,10 +35,9 @@ describe("Tab page", () => {
         tabpage.youtubeTab.click();
         tabpage.youtube.waitForDisplayed();
         const youtubePlayer = tabpage.youtube.getHTML();
-        // prettier-ignore
-        expect(youtubePlayer).toContain("class=\"widget-video-player-iframe\"");
-        // prettier-ignore
-        expect(youtubePlayer).toContain("src=\"https://www.youtube.com");
+
+        expect(youtubePlayer).toContain('class="widget-video-player-iframe"');
+        expect(youtubePlayer).toContain('src="https://www.youtube.com');
     });
 
     it("should render vimeo tab", () => {
@@ -51,10 +45,9 @@ describe("Tab page", () => {
         tabpage.vimeoTab.click();
         tabpage.vimeo.waitForDisplayed();
         const vimeoPlayer = tabpage.vimeo.getHTML();
-        // prettier-ignore
-        expect(vimeoPlayer).toContain("class=\"widget-video-player-iframe\"");
-        // prettier-ignore
-        expect(vimeoPlayer).toContain("src=\"https://player.vimeo.com");
+
+        expect(vimeoPlayer).toContain('class="widget-video-player-iframe"');
+        expect(vimeoPlayer).toContain('src="https://player.vimeo.com');
     });
 
     it("should render dailymotion tab", () => {
@@ -62,10 +55,9 @@ describe("Tab page", () => {
         tabpage.dailymotionTab.click();
         tabpage.dailymotion.waitForDisplayed();
         const dailymotionPlayer = tabpage.dailymotion.getHTML();
-        // prettier-ignore
-        expect(dailymotionPlayer).toContain("class=\"widget-video-player-iframe\"");
-        // prettier-ignore
-        expect(dailymotionPlayer).toContain("src=\"https://www.dailymotion.com");
+
+        expect(dailymotionPlayer).toContain('class="widget-video-player-iframe"');
+        expect(dailymotionPlayer).toContain('src="https://www.dailymotion.com');
     });
 
     it("should render html5 video tab", () => {
@@ -73,10 +65,10 @@ describe("Tab page", () => {
         tabpage.html5Tab.click();
         tabpage.html5.waitForDisplayed();
         const html5Player = tabpage.html5.getHTML();
-        // prettier-ignore
-        expect(html5Player).toContain("class=\"widget-video-player-html5\"");
+
+        expect(html5Player).toContain('class="widget-video-player-html5"');
         expect(html5Player).toContain("<source src=");
-        expect(html5Player).toContain("ElephantsDream.mp4");
+        expect(html5Player).toContain("file_example_MP4_640_3MG.mp4");
     });
 });
 

--- a/packages/pluggableWidgets/video-player-web/tests/e2e/specs/VideoPlayer.spec.ts
+++ b/packages/pluggableWidgets/video-player-web/tests/e2e/specs/VideoPlayer.spec.ts
@@ -68,7 +68,7 @@ describe("Tab page", () => {
 
         expect(html5Player).toContain('class="widget-video-player-html5"');
         expect(html5Player).toContain("<source src=");
-        expect(html5Player).toContain("file_example_MP4_640_3MG.mp4");
+        expect(html5Player).toContain("ElephantsDream.mp4");
     });
 });
 

--- a/packages/pluggableWidgets/video-player-web/typings/VideoPlayerProps.d.ts
+++ b/packages/pluggableWidgets/video-player-web/typings/VideoPlayerProps.d.ts
@@ -17,8 +17,8 @@ export interface VideoPlayerContainerProps {
     class: string;
     style?: CSSProperties;
     tabIndex?: number;
-    videoUrl: DynamicValue<string>;
-    posterUrl?: DynamicValue<string>;
+    urlExpression: DynamicValue<string>;
+    posterExpression?: DynamicValue<string>;
     autoStart: boolean;
     showControls: boolean;
     muted: boolean;
@@ -33,8 +33,8 @@ export interface VideoPlayerContainerProps {
 export interface VideoPlayerPreviewProps {
     class: string;
     style: string;
-    videoUrl: string;
-    posterUrl: string;
+    urlExpression: string;
+    posterExpression: string;
     autoStart: boolean;
     showControls: boolean;
     muted: boolean;

--- a/packages/pluggableWidgets/video-player-web/typings/VideoPlayerProps.d.ts
+++ b/packages/pluggableWidgets/video-player-web/typings/VideoPlayerProps.d.ts
@@ -6,6 +6,8 @@
 import { CSSProperties } from "react";
 import { DynamicValue } from "mendix";
 
+export type TypeEnum = "dynamic" | "expression";
+
 export type WidthUnitEnum = "percentage" | "pixels";
 
 export type HeightUnitEnum = "aspectRatio" | "percentageOfParent" | "percentageOfWidth" | "pixels";
@@ -17,8 +19,11 @@ export interface VideoPlayerContainerProps {
     class: string;
     style?: CSSProperties;
     tabIndex?: number;
-    urlExpression: DynamicValue<string>;
+    type: TypeEnum;
+    urlExpression?: DynamicValue<string>;
     posterExpression?: DynamicValue<string>;
+    videoUrl?: DynamicValue<string>;
+    posterUrl?: DynamicValue<string>;
     autoStart: boolean;
     showControls: boolean;
     muted: boolean;
@@ -33,8 +38,11 @@ export interface VideoPlayerContainerProps {
 export interface VideoPlayerPreviewProps {
     class: string;
     style: string;
+    type: TypeEnum;
     urlExpression: string;
     posterExpression: string;
+    videoUrl: string;
+    posterUrl: string;
     autoStart: boolean;
     showControls: boolean;
     muted: boolean;

--- a/packages/pluggableWidgets/video-player-web/typings/VideoPlayerProps.d.ts
+++ b/packages/pluggableWidgets/video-player-web/typings/VideoPlayerProps.d.ts
@@ -17,8 +17,8 @@ export interface VideoPlayerContainerProps {
     class: string;
     style?: CSSProperties;
     tabIndex?: number;
-    urlExpression: DynamicValue<string>;
-    posterExpression?: DynamicValue<string>;
+    videoUrl: DynamicValue<string>;
+    posterUrl?: DynamicValue<string>;
     autoStart: boolean;
     showControls: boolean;
     muted: boolean;
@@ -33,8 +33,8 @@ export interface VideoPlayerContainerProps {
 export interface VideoPlayerPreviewProps {
     class: string;
     style: string;
-    urlExpression: string;
-    posterExpression: string;
+    videoUrl: string;
+    posterUrl: string;
     autoStart: boolean;
     showControls: boolean;
     muted: boolean;


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ✅ 
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
~Prepare a major release 2.0.0 for video web.~
This will now only be a minor where we add options to configure links through text templates.
- ~Structure preview~
- ~move video URL and poster URL to string templates~
- add options to configure video URL and poster URL with text templates

## What should be covered while testing?
- I assume the text templates should not change the e2e specs too much except maybe that the widgets need to be configured again. But the result should be the same.
- Structure preview is showing up appropriately.