### PR TITLE
[WC-624] Add data source sorting order test in datagrid 2

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/tests/e2e/specs/DataGrid.spec.ts
+++ b/packages/pluggableWidgets/datagrid-web/tests/e2e/specs/DataGrid.spec.ts
@@ -7,7 +7,7 @@ describe("datagrid-web", () => {
     });
 
     describe("capabilities: sorting", () => {
-        it("changes order of data to ASC when clicking sort option", () => {
+        it("applies the default sort order from the data source option", () => {
             const grid = page.getWidget("datagrid1");
             const column = page.waitForElement(".column-header*=First Name", grid);
             const icon = page.waitForElement("svg", column);
@@ -16,19 +16,28 @@ describe("datagrid-web", () => {
             expect(icon.getAttribute("data-icon")).toContain("arrows-alt-v");
 
             expect(datagrid.getAllRows(items)).toEqual([
-                "10",
-                "test",
-                "test",
+                "12",
+                "test3",
+                "test3",
                 "",
                 "11",
                 "test2",
                 "test2",
                 "",
-                "12",
-                "test3",
-                "test3",
+                "10",
+                "test",
+                "test",
                 ""
             ]);
+        });
+
+        it("changes order of data to ASC when clicking sort option", () => {
+            const grid = page.getWidget("datagrid1");
+            const column = page.waitForElement(".column-header*=First Name", grid);
+            const icon = page.waitForElement("svg", column);
+            const items = page.waitForElements(".td", grid);
+
+            expect(icon.getAttribute("data-icon")).toContain("arrows-alt-v");
 
             column.click();
 


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX  9️⃣

#### Web specific
- Contains e2e tests ✅ 
- Is accessible ✅ ❌
- Compatible with Studio ❌
- Cross-browser compatible ✅ ❌

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (test)

## What is the purpose of this PR?
Add data source sorting order test to verify the expected behavior when you're using this option in a datagrid 2 widget.

## Relevant changes
Test project has been changed to enable this option.

## What should be covered while testing?
Automation should pass.
