### PR TITLE
[WTF-841] Do not export PiW properties if the linked data source is empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21813,9 +21813,9 @@
 			}
 		},
 		"mendix": {
-			"version": "9.2.20531",
-			"resolved": "https://registry.npmjs.org/mendix/-/mendix-9.2.20531.tgz",
-			"integrity": "sha512-RocAX9YVKiacJbYBYnFU2zauCecPOmpu0Oz+TovNlCjmD5d1yfSHs1vCNASy2aaBk8LYPWmQm9PMif6B/oGbkA==",
+			"version": "9.4.24572",
+			"resolved": "https://registry.npmjs.org/mendix/-/mendix-9.4.24572.tgz",
+			"integrity": "sha512-1+rkdRhDDl9nR9BZKFSdIMHO+kTtMTgvQYqLHlrI2ogHw/y5UJOqoMC+vgEzp9F7FHf7E/uxphicBJX3frp9OA==",
 			"requires": {
 				"@types/big.js": "^6.0.0",
 				"@types/react": "~17.0.0",

--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+- Updated Mendix package to 9.4.
+- If a datasource property is optional and has not been configured by the user, any properties that are linked to that datasource property are automatically omitted from the props passed to the client component (even if they are marked as required). The generated typings have been updated to reflect this, marking such properties as optional.
+
 ## [9.3.1] - 2021-07-13
 
 ### Added

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -82,7 +82,7 @@
     "jest-junit": "^12.0.0",
     "jest-react-hooks-shallow": "^1.4.1",
     "jest-svg-transformer": "^1.0.0",
-    "mendix": "^9.4.24302",
+    "mendix": "^9.4.24572",
     "metro-react-native-babel-preset": "~0.63.0",
     "node-fetch": "^2.6.1",
     "postcss": "^8.1.10",

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.3.1",
+  "version": "9.4.0",
   "description": "Mendix Pluggable Widgets Tools",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2021. All rights reserved.",
@@ -82,7 +82,7 @@
     "jest-junit": "^12.0.0",
     "jest-react-hooks-shallow": "^1.4.1",
     "jest-svg-transformer": "^1.0.0",
-    "mendix": "^9.2.20531",
+    "mendix": "^9.4.24302",
     "metro-react-native-babel-preset": "~0.63.0",
     "node-fetch": "^2.6.1",
     "postcss": "^8.1.10",

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/datasource.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/datasource.ts
@@ -8,6 +8,10 @@ export const datasourceInput = `<?xml version="1.0" encoding="utf-8"?>
                 <caption>Content data source</caption>
                 <description />
             </property>
+            <property key="optionalSource" type="datasource" isList="true" required="false">
+                <caption>Optional data source</caption>
+                <description />
+            </property>
             <property key="content" type="widgets" dataSource="contentSource">
                 <caption>Content</caption>
                 <description />
@@ -34,6 +38,32 @@ export const datasourceInput = `<?xml version="1.0" encoding="utf-8"?>
                 <description />
                 <returnType type="Decimal"/>
             </property>
+            <property key="optionalDSAttribute" type="attribute" dataSource="optionalSource">
+                <caption>Marker attribute</caption>
+                <description />
+                <attributeTypes>
+                    <attributeType name="String"/>
+                    <attributeType name="Boolean"/>
+                    <attributeType name="Decimal"/>
+                </attributeTypes>
+            </property>
+            <property key="optionalDSAction" type="action" dataSource="optionalSource">
+                <caption>Action</caption>
+                <description />
+            </property>
+            <property key="optionalDSTextTemplate" type="textTemplate" dataSource="optionalSource">
+                <caption>Text Template</caption>
+                <description />
+            </property>
+            <property key="optionalDSExpression" type="expression" dataSource="optionalSource">
+                <caption>Expression</caption>
+                <description />
+                <returnType type="Decimal"/>
+            </property>
+            <property key="optionalContent" type="widgets" dataSource="optionalSource">
+                <caption>Content</caption>
+                <description />
+            </property>
             <property key="datasourceProperties" type="object" isList="true">
                 <caption>Data source properties</caption>
                 <description />
@@ -54,6 +84,32 @@ export const datasourceInput = `<?xml version="1.0" encoding="utf-8"?>
                         </property>
                         <property key="actionAttribute" type="action" dataSource="../contentSource">
                             <caption>Action</caption>
+                            <description />
+                        </property>
+                        <property key="optionalDSAttribute" type="attribute" dataSource="../optionalSource">
+                            <caption>Marker attribute</caption>
+                            <description />
+                            <attributeTypes>
+                                <attributeType name="String"/>
+                                <attributeType name="Boolean"/>
+                                <attributeType name="Decimal"/>
+                            </attributeTypes>
+                        </property>
+                        <property key="optionalDSAction" type="action" dataSource="../optionalSource">
+                            <caption>Action</caption>
+                            <description />
+                        </property>
+                        <property key="optionalDSTextTemplate" type="textTemplate" dataSource="../optionalSource">
+                            <caption>Text Template</caption>
+                            <description />
+                        </property>
+                        <property key="optionalDSExpression" type="expression" dataSource="../optionalSource">
+                            <caption>Expression</caption>
+                            <description />
+                            <returnType type="Decimal"/>
+                        </property>
+                        <property key="optionalContent" type="widgets" dataSource="../optionalSource">
+                            <caption>Content</caption>
                             <description />
                         </property>
                     </propertyGroup>

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
@@ -56,7 +56,7 @@ export interface MyWidgetPreviewProps {
     class: string;
     style: string;
     contentSource: {} | { type: string } | null;
-    optionalSource: {} | null;
+    optionalSource: {} | { type: string } | null;
     content: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     markerDataAttribute: string;
     actionAttribute: {} | null;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
@@ -11,12 +11,22 @@ export interface DatasourcePropertiesType {
     contentAttribute: ListWidgetValue;
     markerAttribute: ListAttributeValue<string | boolean | Big>;
     actionAttribute?: ListActionValue;
+    optionalDSAttribute?: ListAttributeValue<string | boolean | Big>;
+    optionalDSAction?: ListActionValue;
+    optionalDSTextTemplate?: ListExpressionValue<string>;
+    optionalDSExpression?: ListExpressionValue<Big>;
+    optionalContent?: ListWidgetValue;
 }
 
 export interface DatasourcePropertiesPreviewType {
     contentAttribute: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     markerAttribute: string;
     actionAttribute: {} | null;
+    optionalDSAttribute: string;
+    optionalDSAction: {} | null;
+    optionalDSTextTemplate: string;
+    optionalDSExpression: string;
+    optionalContent: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
 }
 
 export interface MyWidgetContainerProps {
@@ -26,11 +36,17 @@ export interface MyWidgetContainerProps {
     tabIndex?: number;
     id: string;
     contentSource: ListValue;
+    optionalSource?: ListValue;
     content: ListWidgetValue;
     markerDataAttribute: ListAttributeValue<string | boolean | Big>;
     actionAttribute?: ListActionValue;
     textTemplateAttribute: ListExpressionValue<string>;
     expressionAttribute: ListExpressionValue<Big>;
+    optionalDSAttribute?: ListAttributeValue<string | boolean | Big>;
+    optionalDSAction?: ListActionValue;
+    optionalDSTextTemplate?: ListExpressionValue<string>;
+    optionalDSExpression?: ListExpressionValue<Big>;
+    optionalContent?: ListWidgetValue;
     datasourceProperties: DatasourcePropertiesType[];
     description: EditableValue<string>;
     action?: ActionValue;
@@ -40,11 +56,17 @@ export interface MyWidgetPreviewProps {
     class: string;
     style: string;
     contentSource: {} | { type: string } | null;
+    optionalSource: {} | null;
     content: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     markerDataAttribute: string;
     actionAttribute: {} | null;
     textTemplateAttribute: string;
     expressionAttribute: string;
+    optionalDSAttribute: string;
+    optionalDSAction: {} | null;
+    optionalDSTextTemplate: string;
+    optionalDSExpression: string;
+    optionalContent: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     datasourceProperties: DatasourcePropertiesPreviewType[];
     description: string;
     action: {} | null;


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (describe)

## What is the purpose of this PR?
Update the typings generator to match the behaviour of properties that are linked to an optional data source property in Mendix 9.4.

## Relevant changes
Properties that are linked to a data source property which is marked as optional (required="false") are now hidden and not exported if the data source is left empty. To reflect this, they should also be marked as optional in the typings, even if the property itself is required (which is now only enforced if a data source has been configured).

This is technically a breaking change, as properties may now be exported as optional that weren't optional before. However, the old behaviour of these properties made very little sense and was not reflected in the typings either, so it is very unlikely that existing widgets were using them that way. (The Charts widgets, for example, simply ignore such properties if their linked data source is empty.)

## What should be covered while testing?
The updated unit tests should already cover everything, so only smoke testing should be required.