### PR TITLE
[WC-402 ] Accordion web - Add remaining advanced mode features

### DIFF
--- a/packages/pluggableWidgets/accordion-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/accordion-web/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - We added a widget property to configure the render mode of the header text.
 - We added widget properties to influence the initial collapsed state for a group.
-- We added a widget property to trigger an action when the widget collapse state changes.
+- We added a widget properties to control the collapse state of a group via an entity attribute.
 
 ## [1.0.0] - 2021-06-29
 ### Added

--- a/packages/pluggableWidgets/accordion-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/accordion-web/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this widget will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Added
+- We added a widget property to configure the render mode of the header text.
+- We added widget properties to influence the initial collapsed state for a group.
+- We added a widget property to trigger an action when the widget collapse state changes.
+
 ## [1.0.0] - 2021-06-29
 ### Added
 -   We added configuration of groups with composable content for header & body.

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
@@ -22,6 +22,10 @@ export function getProperties(
         if (!values.advancedMode || group.initialCollapsedState !== "dynamic") {
             hidePropertyIn(defaultProperties, values, "groups", index, "initiallyCollapsed");
         }
+
+        if (!values.advancedMode) {
+            hidePropertyIn(defaultProperties, values, "groups", index, "onToggleCollapsed");
+        }
     });
 
     if (!values.collapsible) {

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
@@ -99,7 +99,7 @@ export function check(values: AccordionPreviewProps): Problem[] {
         errors.push({
             property: "expandBehavior",
             severity: "error",
-            message: `There are ${amountOfGroupsStartingExpanded} groups configured to start expanded. Change the configuration to have just one group starting expanded or switch the "Expanded groups" property to "Multiple".`
+            message: `The 'Expanded groups' property is set to 'Single', but there are ${amountOfGroupsStartingExpanded} group items configured to be shown as expanded. Either change the configuration to have just one group to start as expanded or switch the 'Expanded groups' property to 'Multiple'.`
         });
     }
 

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
@@ -25,6 +25,7 @@ export function getProperties(
 
         if (!values.advancedMode) {
             hidePropertyIn(defaultProperties, values, "groups", index, "onToggleCollapsed");
+            hidePropertyIn(defaultProperties, values, "groups", index, "collapsed");
         }
     });
 

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
@@ -30,16 +30,7 @@ export function getProperties(
             hidePropertyIn(defaultProperties, values, "groups", index, "initiallyCollapsed");
         }
 
-        if (!values.advancedMode) {
-            hideNestedPropertiesIn(defaultProperties, values, "groups", index, [
-                "collapsed",
-                "onToggleCollapsed",
-                "initialCollapsedState",
-                "initiallyCollapsed"
-            ]);
-        }
-
-        if (!values.collapsible) {
+        if (!values.advancedMode || !values.collapsible) {
             hideNestedPropertiesIn(defaultProperties, values, "groups", index, [
                 "collapsed",
                 "onToggleCollapsed",

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
@@ -1,4 +1,10 @@
-import { hidePropertiesIn, hidePropertyIn, Properties, transformGroupsIntoTabs } from "@mendix/piw-utils-internal";
+import {
+    hideNestedPropertiesIn,
+    hidePropertiesIn,
+    hidePropertyIn,
+    Properties,
+    transformGroupsIntoTabs
+} from "@mendix/piw-utils-internal";
 
 import { AccordionContainerProps } from "../typings/AccordionProps";
 
@@ -19,13 +25,26 @@ export function getProperties(
             hidePropertyIn(defaultProperties, values, "groups", index, "headerHeading");
         }
 
-        if (!values.advancedMode || group.initialCollapsedState !== "dynamic") {
+        if (group.initialCollapsedState !== "dynamic") {
             hidePropertyIn(defaultProperties, values, "groups", index, "initiallyCollapsed");
         }
 
         if (!values.advancedMode) {
-            hidePropertyIn(defaultProperties, values, "groups", index, "onToggleCollapsed");
-            hidePropertyIn(defaultProperties, values, "groups", index, "collapsed");
+            hideNestedPropertiesIn(defaultProperties, values, "groups", index, [
+                "collapsed",
+                "onToggleCollapsed",
+                "initialCollapsedState",
+                "initiallyCollapsed"
+            ]);
+        }
+
+        if (!values.collapsible) {
+            hideNestedPropertiesIn(defaultProperties, values, "groups", index, [
+                "collapsed",
+                "onToggleCollapsed",
+                "initialCollapsedState",
+                "initiallyCollapsed"
+            ]);
         }
     });
 

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
@@ -2,11 +2,12 @@ import {
     hideNestedPropertiesIn,
     hidePropertiesIn,
     hidePropertyIn,
+    Problem,
     Properties,
     transformGroupsIntoTabs
 } from "@mendix/piw-utils-internal";
 
-import { AccordionContainerProps } from "../typings/AccordionProps";
+import { AccordionContainerProps, AccordionPreviewProps } from "../typings/AccordionProps";
 
 export function getProperties(
     values: AccordionContainerProps,
@@ -86,4 +87,21 @@ export function getProperties(
     }
 
     return defaultProperties;
+}
+
+export function check(values: AccordionPreviewProps): Problem[] {
+    const errors: Problem[] = [];
+
+    const amountOfGroupsStartingExpanded = values.groups.filter(group => group.initialCollapsedState === "expanded")
+        .length;
+
+    if (values.expandBehavior === "singleExpanded" && amountOfGroupsStartingExpanded > 1) {
+        errors.push({
+            property: "expandBehavior",
+            severity: "error",
+            message: `There are ${amountOfGroupsStartingExpanded} groups configured to start expanded. Change the configuration to have just one group starting expanded or switch the "Expanded groups" property to "Multiple".`
+        });
+    }
+
+    return errors;
 }

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
@@ -10,8 +10,13 @@ export function getProperties(
     values.groups.forEach((group, index) => {
         if (group.headerRenderMode === "text") {
             hidePropertyIn(defaultProperties, values, "groups", index, "headerContent");
+
+            if (!values.advancedMode) {
+                hidePropertyIn(defaultProperties, values, "groups", index, "headerHeading");
+            }
         } else {
             hidePropertyIn(defaultProperties, values, "groups", index, "headerText");
+            hidePropertyIn(defaultProperties, values, "groups", index, "headerHeading");
         }
     });
 

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
@@ -18,6 +18,10 @@ export function getProperties(
             hidePropertyIn(defaultProperties, values, "groups", index, "headerText");
             hidePropertyIn(defaultProperties, values, "groups", index, "headerHeading");
         }
+
+        if (!values.advancedMode || group.initialCollapsedState !== "dynamic") {
+            hidePropertyIn(defaultProperties, values, "groups", index, "initiallyCollapsed");
+        }
     });
 
     if (!values.collapsible) {

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
@@ -9,7 +9,14 @@ import { Header } from "./components/Header";
 
 export function Accordion(props: AccordionContainerProps): ReactElement | null {
     const accordionGroups: AccordionGroups | undefined = useMemo(() => {
-        if (props.groups.some(group => group.visible.value === undefined || group.headerText.value === undefined)) {
+        if (
+            props.groups.some(
+                group =>
+                    group.visible.value === undefined ||
+                    group.headerText.value === undefined ||
+                    group.initiallyCollapsed.value === undefined
+            )
+        ) {
             return undefined;
         }
 
@@ -23,7 +30,10 @@ export function Accordion(props: AccordionContainerProps): ReactElement | null {
             return {
                 header,
                 content: group.content,
-                initiallyCollapsed: group.initialCollapsedState === "collapsed",
+                initiallyCollapsed:
+                    group.initialCollapsedState === "dynamic"
+                        ? group.initiallyCollapsed.value
+                        : group.initialCollapsedState === "collapsed",
                 visible: group.visible.value!,
                 dynamicClassName: group.dynamicClass?.value
             };

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
@@ -2,46 +2,13 @@ import { createElement, ReactElement, useMemo } from "react";
 import { ValueStatus } from "mendix";
 
 import { Accordion as AccordionComponent, AccordionGroups } from "./components/Accordion";
+import { Header } from "./components/Header";
 import { useIconGenerator } from "./utils/iconGenerator";
 
 import { AccordionContainerProps } from "../typings/AccordionProps";
-import { Header } from "./components/Header";
 
 export function Accordion(props: AccordionContainerProps): ReactElement | null {
-    const accordionGroups: AccordionGroups | undefined = useMemo(() => {
-        if (
-            props.groups.some(
-                group =>
-                    group.visible.value === undefined ||
-                    group.headerText.value === undefined ||
-                    group.initiallyCollapsed.value === undefined ||
-                    (group.collapsed && group.collapsed.value === undefined)
-            )
-        ) {
-            return undefined;
-        }
-
-        return props.groups.map(group => {
-            let header = group.headerContent;
-
-            if (group.headerRenderMode === "text") {
-                header = <Header heading={group.headerHeading} text={group.headerText.value} />;
-            }
-
-            return {
-                header,
-                content: group.content,
-                collapsed: group.collapsed?.value,
-                initiallyCollapsed:
-                    group.initialCollapsedState === "dynamic"
-                        ? group.initiallyCollapsed.value
-                        : group.initialCollapsedState === "collapsed",
-                visible: group.visible.value!,
-                dynamicClassName: group.dynamicClass?.value,
-                onToggleCompletion: group.collapsed?.setValue
-            };
-        });
-    }, [props.groups]);
+    const groups: AccordionGroups | undefined = useMemo(() => translateGroups(props.groups), [props.groups]);
 
     const generateIcon = useIconGenerator(
         props.advancedMode,
@@ -51,7 +18,7 @@ export function Accordion(props: AccordionContainerProps): ReactElement | null {
         { data: props.collapseIcon?.value, loading: props.collapseIcon?.status === ValueStatus.Loading }
     );
 
-    if (!accordionGroups) {
+    if (!groups) {
         return null;
     }
 
@@ -61,7 +28,7 @@ export function Accordion(props: AccordionContainerProps): ReactElement | null {
             class={props.class}
             style={props.style}
             tabIndex={props.tabIndex}
-            groups={accordionGroups}
+            groups={groups}
             collapsible={props.collapsible}
             animateContent={props.animate}
             singleExpandedGroup={props.collapsible ? props.expandBehavior === "singleExpanded" : undefined}
@@ -69,4 +36,39 @@ export function Accordion(props: AccordionContainerProps): ReactElement | null {
             showGroupHeaderIcon={props.showIcon}
         />
     );
+}
+
+function translateGroups(groups: AccordionContainerProps["groups"]): AccordionGroups | undefined {
+    if (
+        groups.some(
+            group =>
+                group.visible.value === undefined ||
+                group.headerText.value === undefined ||
+                group.initiallyCollapsed.value === undefined ||
+                (group.collapsed && group.collapsed.value === undefined)
+        )
+    ) {
+        return undefined;
+    }
+
+    return groups.map(group => {
+        let header = group.headerContent;
+
+        if (group.headerRenderMode === "text") {
+            header = <Header heading={group.headerHeading} text={group.headerText.value} />;
+        }
+
+        return {
+            header,
+            content: group.content,
+            collapsed: group.collapsed?.value,
+            initiallyCollapsed:
+                group.initialCollapsedState === "dynamic"
+                    ? group.initiallyCollapsed.value
+                    : group.initialCollapsedState === "collapsed",
+            visible: group.visible.value!,
+            dynamicClassName: group.dynamicClass?.value,
+            onToggleCompletion: group.collapsed?.setValue
+        };
+    });
 }

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
@@ -35,7 +35,8 @@ export function Accordion(props: AccordionContainerProps): ReactElement | null {
                         ? group.initiallyCollapsed.value
                         : group.initialCollapsedState === "collapsed",
                 visible: group.visible.value!,
-                dynamicClassName: group.dynamicClass?.value
+                dynamicClassName: group.dynamicClass?.value,
+                onToggleCompletion: group.onToggleCollapsed?.execute
             };
         });
     }, [props.groups]);

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
@@ -55,7 +55,7 @@ function translateGroups(groups: AccordionContainerProps["groups"]): AccordionGr
         let header = group.headerContent;
 
         if (group.headerRenderMode === "text") {
-            header = <Header heading={group.headerHeading} text={group.headerText.value} />;
+            header = <Header heading={group.headerHeading}>{group.headerText.value}</Header>;
         }
 
         return {

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
@@ -5,7 +5,7 @@ import { Accordion as AccordionComponent, AccordionGroups } from "./components/A
 import { Header } from "./components/Header";
 import { useIconGenerator } from "./utils/iconGenerator";
 
-import { AccordionContainerProps } from "../typings/AccordionProps";
+import { AccordionContainerProps, GroupsType } from "../typings/AccordionProps";
 
 export function Accordion(props: AccordionContainerProps): ReactElement | null {
     const groups: AccordionGroups | undefined = useMemo(() => translateGroups(props.groups), [props.groups]);
@@ -39,15 +39,7 @@ export function Accordion(props: AccordionContainerProps): ReactElement | null {
 }
 
 function translateGroups(groups: AccordionContainerProps["groups"]): AccordionGroups | undefined {
-    if (
-        groups.some(
-            group =>
-                group.visible.value === undefined ||
-                group.headerText.value === undefined ||
-                group.initiallyCollapsed.value === undefined ||
-                (group.collapsed && group.collapsed.value === undefined)
-        )
-    ) {
+    if (someGroupMissingData(groups)) {
         return undefined;
     }
 
@@ -71,4 +63,14 @@ function translateGroups(groups: AccordionContainerProps["groups"]): AccordionGr
             onToggleCompletion: group.collapsed?.setValue
         };
     });
+}
+
+function someGroupMissingData(groups: GroupsType[]): boolean {
+    return groups.some(
+        group =>
+            group.visible.value === undefined ||
+            group.headerText.value === undefined ||
+            group.initiallyCollapsed.value === undefined ||
+            (group.collapsed && group.collapsed.value === undefined)
+    );
 }

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
@@ -14,7 +14,8 @@ export function Accordion(props: AccordionContainerProps): ReactElement | null {
                 group =>
                     group.visible.value === undefined ||
                     group.headerText.value === undefined ||
-                    group.initiallyCollapsed.value === undefined
+                    group.initiallyCollapsed.value === undefined ||
+                    (group.collapsed && group.collapsed.value === undefined)
             )
         ) {
             return undefined;
@@ -30,6 +31,7 @@ export function Accordion(props: AccordionContainerProps): ReactElement | null {
             return {
                 header,
                 content: group.content,
+                collapsed: group.collapsed?.value,
                 initiallyCollapsed:
                     group.initialCollapsedState === "dynamic"
                         ? group.initiallyCollapsed.value

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
@@ -23,6 +23,7 @@ export function Accordion(props: AccordionContainerProps): ReactElement | null {
             return {
                 header,
                 content: group.content,
+                initiallyCollapsed: group.initialCollapsedState === "collapsed",
                 visible: group.visible.value!,
                 dynamicClassName: group.dynamicClass?.value
             };

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
@@ -38,7 +38,7 @@ export function Accordion(props: AccordionContainerProps): ReactElement | null {
                         : group.initialCollapsedState === "collapsed",
                 visible: group.visible.value!,
                 dynamicClassName: group.dynamicClass?.value,
-                onToggleCompletion: group.onToggleCollapsed?.execute
+                onToggleCompletion: group.collapsed?.setValue
             };
         });
     }, [props.groups]);

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
@@ -5,6 +5,7 @@ import { Accordion as AccordionComponent, AccordionGroups } from "./components/A
 import { useIconGenerator } from "./utils/iconGenerator";
 
 import { AccordionContainerProps } from "../typings/AccordionProps";
+import { Header } from "./components/Header";
 
 export function Accordion(props: AccordionContainerProps): ReactElement | null {
     const accordionGroups: AccordionGroups | undefined = useMemo(() => {
@@ -12,12 +13,20 @@ export function Accordion(props: AccordionContainerProps): ReactElement | null {
             return undefined;
         }
 
-        return props.groups.map(group => ({
-            header: group.headerRenderMode === "text" ? <h3>{group.headerText.value}</h3> : group.headerContent,
-            content: group.content,
-            visible: group.visible.value!,
-            dynamicClassName: group.dynamicClass?.value
-        }));
+        return props.groups.map(group => {
+            let header = group.headerContent;
+
+            if (group.headerRenderMode === "text") {
+                header = <Header heading={group.headerHeading} text={group.headerText.value} />;
+            }
+
+            return {
+                header,
+                content: group.content,
+                visible: group.visible.value!,
+                dynamicClassName: group.dynamicClass?.value
+            };
+        });
     }, [props.groups]);
 
     const generateIcon = useIconGenerator(

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.xml
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.xml
@@ -52,6 +52,14 @@
                                 <caption>Content</caption>
                                 <description/>
                             </property>
+                            <property key="initialCollapsedState" type="enumeration" defaultValue="expanded">
+                                <caption>Start as</caption>
+                                <description />
+                                <enumerationValues>
+                                    <enumerationValue key="expanded">Expanded</enumerationValue>
+                                    <enumerationValue key="collapsed">Collapsed</enumerationValue>
+                                </enumerationValues>
+                            </property>
                             <property key="visible" type="expression" defaultValue="true">
                                 <caption>Visible</caption>
                                 <description/>

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.xml
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.xml
@@ -58,7 +58,13 @@
                                 <enumerationValues>
                                     <enumerationValue key="expanded">Expanded</enumerationValue>
                                     <enumerationValue key="collapsed">Collapsed</enumerationValue>
+                                    <enumerationValue key="dynamic">Dynamic</enumerationValue>
                                 </enumerationValues>
+                            </property>
+                            <property key="initiallyCollapsed" type="expression" defaultValue="false">
+                                <caption>Collapsed</caption>
+                                <description/>
+                                <returnType type="Boolean"/>
                             </property>
                             <property key="visible" type="expression" defaultValue="true">
                                 <caption>Visible</caption>

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.xml
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.xml
@@ -32,6 +32,18 @@
                                     <translation lang="nl_NL">Koptekst</translation>
                                 </translations>
                             </property>
+                            <property key="headerHeading" type="enumeration" defaultValue="headingThree">
+                                <caption>Render mode</caption>
+                                <description />
+                                <enumerationValues>
+                                    <enumerationValue key="headingOne">Heading 1</enumerationValue>
+                                    <enumerationValue key="headingTwo">Heading 2</enumerationValue>
+                                    <enumerationValue key="headingThree">Heading 3</enumerationValue>
+                                    <enumerationValue key="headingFour">Heading 4</enumerationValue>
+                                    <enumerationValue key="headingFive">Heading 5</enumerationValue>
+                                    <enumerationValue key="headingSix">Heading 6</enumerationValue>
+                                </enumerationValues>
+                            </property>
                             <property key="headerContent" type="widgets" required="false">
                                 <caption>Header</caption>
                                 <description/>

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.xml
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.xml
@@ -77,6 +77,12 @@
                                 <returnType type="String"/>
                             </property>
                         </propertyGroup>
+                        <propertyGroup caption="Events">
+                            <property key="onToggleCollapsed" type="action">
+                                <caption>On change</caption>
+                                <description />
+                            </property>
+                        </propertyGroup>
                     </properties>
                 </property>
             </propertyGroup>

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.xml
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.xml
@@ -78,6 +78,13 @@
                             </property>
                         </propertyGroup>
                         <propertyGroup caption="Events">
+                            <property key="collapsed" type="attribute" required="false" onChange="onToggleCollapsed">
+                                <caption>Attribute</caption>
+                                <description />
+                                <attributeTypes>
+                                    <attributeType name="Boolean"/>
+                                </attributeTypes>
+                            </property>
                             <property key="onToggleCollapsed" type="action">
                                 <caption>On change</caption>
                                 <description />

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.xml
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.xml
@@ -52,20 +52,6 @@
                                 <caption>Content</caption>
                                 <description/>
                             </property>
-                            <property key="initialCollapsedState" type="enumeration" defaultValue="expanded">
-                                <caption>Start as</caption>
-                                <description />
-                                <enumerationValues>
-                                    <enumerationValue key="expanded">Expanded</enumerationValue>
-                                    <enumerationValue key="collapsed">Collapsed</enumerationValue>
-                                    <enumerationValue key="dynamic">Dynamic</enumerationValue>
-                                </enumerationValues>
-                            </property>
-                            <property key="initiallyCollapsed" type="expression" defaultValue="false">
-                                <caption>Collapsed</caption>
-                                <description/>
-                                <returnType type="Boolean"/>
-                            </property>
                             <property key="visible" type="expression" defaultValue="true">
                                 <caption>Visible</caption>
                                 <description/>
@@ -77,17 +63,31 @@
                                 <returnType type="String"/>
                             </property>
                         </propertyGroup>
-                        <propertyGroup caption="Events">
-                            <property key="collapsed" type="attribute" required="false" onChange="onToggleCollapsed">
-                                <caption>Attribute</caption>
+                        <propertyGroup caption="State">
+                            <property key="initialCollapsedState" type="enumeration" defaultValue="expanded">
+                                <caption>Start as</caption>
                                 <description />
+                                <enumerationValues>
+                                    <enumerationValue key="expanded">Expanded</enumerationValue>
+                                    <enumerationValue key="collapsed">Collapsed</enumerationValue>
+                                    <enumerationValue key="dynamic">Dynamic</enumerationValue>
+                                </enumerationValues>
+                            </property>
+                            <property key="initiallyCollapsed" type="expression" defaultValue="false">
+                                <caption>Start as collapsed</caption>
+                                <description/>
+                                <returnType type="Boolean"/>
+                            </property>
+                            <property key="collapsed" type="attribute" required="false" onChange="onToggleCollapsed">
+                                <caption>Collapsed</caption>
+                                <description>Determines whether the group is collapsed or expanded. The 'Start as' properties override the attribute value for the initial state.</description>
                                 <attributeTypes>
                                     <attributeType name="Boolean"/>
                                 </attributeTypes>
                             </property>
                             <property key="onToggleCollapsed" type="action">
                                 <caption>On change</caption>
-                                <description />
+                                <description>Executes an action when the 'Collapsed' attribute value changes. Note: the 'Start as' properties can prevent execution of this action when the initial state changes.</description>
                             </property>
                         </propertyGroup>
                     </properties>

--- a/packages/pluggableWidgets/accordion-web/src/components/Accordion.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/Accordion.tsx
@@ -133,6 +133,7 @@ function AccordionGroupWrapper(props: AccordionGroupWrapperProps): ReactElement 
             dynamicClassName={props.dynamicClassName}
             collapsible={props.collapsible}
             toggleCollapsed={toggleCollapsedState}
+            onToggleCompletion={props.onToggleCompletion}
             changeFocus={focusAccordionGroupHeaderElement}
             animateContent={props.animateContent}
             generateHeaderIcon={props.generateHeaderIcon}

--- a/packages/pluggableWidgets/accordion-web/src/components/Accordion.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/Accordion.tsx
@@ -5,7 +5,9 @@ import { CollapsedAccordionGroupsReducerAction, getCollapsedAccordionGroupsReduc
 import { AccordionContainerProps } from "../../typings/AccordionProps";
 import classNames from "classnames";
 
-export type AccordionGroups = Array<Pick<AccordionGroupProps, "header" | "content" | "visible" | "dynamicClassName">>;
+export type AccordionGroups = Array<
+    Pick<AccordionGroupProps, "header" | "content" | "visible" | "dynamicClassName"> & { initiallyCollapsed?: boolean }
+>;
 
 export interface AccordionProps extends Pick<AccordionContainerProps, "class" | "style" | "tabIndex"> {
     id: string;
@@ -23,7 +25,20 @@ export function Accordion(props: AccordionProps): ReactElement | null {
 
     const [collapsedAccordionGroups, collapsedAccordionGroupsDispatch] = useReducer(
         reducer.current,
-        props.groups.map(() => !props.previewMode && props.collapsible)
+        props.groups.reduce<boolean[]>((accumulator, group) => {
+            let result;
+            const collapsed = !props.previewMode && props.collapsible && !!group.initiallyCollapsed;
+
+            if (!collapsed && props.singleExpandedGroup) {
+                result = accumulator.map(() => true);
+            } else {
+                result = [...accumulator];
+            }
+
+            result.push(collapsed);
+
+            return result;
+        }, [])
     );
 
     const containerRef = useRef<HTMLDivElement | null>(null);

--- a/packages/pluggableWidgets/accordion-web/src/components/Accordion.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/Accordion.tsx
@@ -60,17 +60,11 @@ export function Accordion(props: AccordionProps): ReactElement | null {
     const previousGroupCollapsedValues = useRef(props.groups.map(group => group.collapsed));
 
     useMemo(() => {
-        const changes: Array<{ index: number; value: boolean }> = [];
-
         props.groups.forEach((group, index) => {
             if (group.collapsed !== undefined && group.collapsed !== previousGroupCollapsedValues.current[index]) {
-                changes.push({ index, value: group.collapsed });
                 previousGroupCollapsedValues.current[index] = group.collapsed;
+                accordionGroupCollapsedStateDispatch({ type: group.collapsed ? "collapse" : "expand", index });
             }
-        });
-
-        changes.forEach(change => {
-            accordionGroupCollapsedStateDispatch({ type: change.value ? "collapse" : "expand", index: change.index });
         });
     }, [props.groups]);
 

--- a/packages/pluggableWidgets/accordion-web/src/components/AccordionGroup.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/AccordionGroup.tsx
@@ -22,7 +22,7 @@ export interface AccordionGroupProps {
     dynamicClassName?: string;
     collapsible: boolean;
     toggleCollapsed?: () => void;
-    onToggleCompletion?: () => void;
+    onToggleCompletion?: (collapsed: boolean) => void;
     changeFocus?: (focusedGroupHeader: EventTarget | null, focusTargetGroupHeader: Target) => void;
     animateContent?: boolean;
     generateHeaderIcon?: (collapsed: boolean) => ReactElement;
@@ -94,9 +94,9 @@ export function AccordionGroup(props: AccordionGroupProps): ReactElement | null 
     useEffect(() => {
         if (previousCollapsedValue !== previousPreviousCollapsedValue.current) {
             previousPreviousCollapsedValue.current = previousCollapsedValue;
-            onToggleCompletion?.();
+            onToggleCompletion?.(props.collapsed);
         }
-    }, [onToggleCompletion, previousCollapsedValue, previousPreviousCollapsedValue]);
+    }, [props.collapsed, onToggleCompletion, previousCollapsedValue, previousPreviousCollapsedValue]);
 
     const onKeydownHandler = useCallback(
         (event: KeyboardEvent<HTMLDivElement>) => {

--- a/packages/pluggableWidgets/accordion-web/src/components/AccordionGroup.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/AccordionGroup.tsx
@@ -32,8 +32,8 @@ export interface AccordionGroupProps {
 export function AccordionGroup(props: AccordionGroupProps): ReactElement | null {
     const { animateContent, changeFocus, showHeaderIcon, toggleCollapsed, onToggleCompletion } = props;
 
-    const [previousCollapsedValue, setPreviousCollapsedValue] = useState(props.collapsed);
-    const previousPreviousCollapsedValue = useRef(previousCollapsedValue);
+    const [renderCollapsed, setRenderCollapsed] = useState(props.collapsed);
+    const previousRenderCollapsed = useRef(renderCollapsed);
     const animatingContent = useRef<boolean>(false);
 
     const rootRef = useRef<HTMLDivElement>(null);
@@ -42,23 +42,23 @@ export function AccordionGroup(props: AccordionGroupProps): ReactElement | null 
 
     const completeTransitioning = useCallback((): void => {
         if (contentWrapperRef.current && rootRef.current && animatingContent.current) {
-            if (!previousCollapsedValue) {
+            if (!renderCollapsed) {
                 rootRef.current.classList.add("widget-accordion-group-collapsed");
                 rootRef.current.classList.remove("widget-accordion-group-collapsing");
-                setPreviousCollapsedValue(true);
+                setRenderCollapsed(true);
             } else {
                 rootRef.current.classList.remove("widget-accordion-group-expanding");
                 contentWrapperRef.current.style.height = "";
-                setPreviousCollapsedValue(false);
+                setRenderCollapsed(false);
             }
 
             animatingContent.current = false;
         }
-    }, [previousCollapsedValue]);
+    }, [renderCollapsed]);
 
     useEffect(() => {
         if (
-            props.collapsed !== previousCollapsedValue &&
+            props.collapsed !== renderCollapsed &&
             rootRef.current &&
             contentWrapperRef.current &&
             contentRef.current &&
@@ -86,17 +86,17 @@ export function AccordionGroup(props: AccordionGroupProps): ReactElement | null 
                     }
                 }, 50);
             }
-        } else if (props.collapsed !== previousCollapsedValue && (!animateContent || !props.visible)) {
-            setPreviousCollapsedValue(props.collapsed);
+        } else if (props.collapsed !== renderCollapsed && (!animateContent || !props.visible)) {
+            setRenderCollapsed(props.collapsed);
         }
-    }, [props.collapsed, props.visible, previousCollapsedValue, animateContent]);
+    }, [props.collapsed, props.visible, renderCollapsed, animateContent]);
 
     useEffect(() => {
-        if (previousCollapsedValue !== previousPreviousCollapsedValue.current) {
-            previousPreviousCollapsedValue.current = previousCollapsedValue;
+        if (renderCollapsed !== previousRenderCollapsed.current) {
+            previousRenderCollapsed.current = renderCollapsed;
             onToggleCompletion?.(props.collapsed);
         }
-    }, [props.collapsed, onToggleCompletion, previousCollapsedValue, previousPreviousCollapsedValue]);
+    }, [props.collapsed, onToggleCompletion, renderCollapsed]);
 
     const onKeydownHandler = useCallback(
         (event: KeyboardEvent<HTMLDivElement>) => {
@@ -139,7 +139,7 @@ export function AccordionGroup(props: AccordionGroupProps): ReactElement | null 
             className={classNames(
                 "widget-accordion-group",
                 {
-                    "widget-accordion-group-collapsed": previousCollapsedValue
+                    "widget-accordion-group-collapsed": renderCollapsed
                 },
                 props.dynamicClassName
             )}
@@ -159,13 +159,13 @@ export function AccordionGroup(props: AccordionGroupProps): ReactElement | null 
                     role="button"
                     onClick={props.collapsible ? toggleCollapsed : undefined}
                     onKeyDown={props.collapsible ? onKeydownHandler : undefined}
-                    aria-expanded={!previousCollapsedValue}
+                    aria-expanded={!renderCollapsed}
                     aria-disabled={!props.collapsible}
                     aria-controls={`${props.id}ContentWrapper`}
                 >
                     {props.header}
                     {props.collapsible && (showHeaderIcon === "left" || showHeaderIcon === "right")
-                        ? props.generateHeaderIcon?.(previousCollapsedValue ?? false)
+                        ? props.generateHeaderIcon?.(renderCollapsed ?? false)
                         : null}
                 </div>
             </header>

--- a/packages/pluggableWidgets/accordion-web/src/components/AccordionGroup.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/AccordionGroup.tsx
@@ -22,6 +22,7 @@ export interface AccordionGroupProps {
     dynamicClassName?: string;
     collapsible: boolean;
     toggleCollapsed?: () => void;
+    onToggleCompletion?: () => void;
     changeFocus?: (focusedGroupHeader: EventTarget | null, focusTargetGroupHeader: Target) => void;
     animateContent?: boolean;
     generateHeaderIcon?: (collapsed: boolean) => ReactElement;
@@ -29,9 +30,10 @@ export interface AccordionGroupProps {
 }
 
 export function AccordionGroup(props: AccordionGroupProps): ReactElement | null {
-    const { animateContent, changeFocus, showHeaderIcon, toggleCollapsed } = props;
+    const { animateContent, changeFocus, showHeaderIcon, toggleCollapsed, onToggleCompletion } = props;
 
     const [previousCollapsedValue, setPreviousCollapsedValue] = useState(props.collapsed);
+    const previousPreviousCollapsedValue = useRef(previousCollapsedValue);
     const animatingContent = useRef<boolean>(false);
 
     const rootRef = useRef<HTMLDivElement>(null);
@@ -88,6 +90,13 @@ export function AccordionGroup(props: AccordionGroupProps): ReactElement | null 
             setPreviousCollapsedValue(props.collapsed);
         }
     }, [props.collapsed, props.visible, previousCollapsedValue, animateContent]);
+
+    useEffect(() => {
+        if (previousCollapsedValue !== previousPreviousCollapsedValue.current) {
+            previousPreviousCollapsedValue.current = previousCollapsedValue;
+            onToggleCompletion?.();
+        }
+    }, [onToggleCompletion, previousCollapsedValue, previousPreviousCollapsedValue]);
 
     const onKeydownHandler = useCallback(
         (event: KeyboardEvent<HTMLDivElement>) => {

--- a/packages/pluggableWidgets/accordion-web/src/components/Header.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/Header.tsx
@@ -6,28 +6,25 @@ export interface HeaderProps {
 }
 
 export function Header(props: HeaderProps): ReactElement {
-    let header;
+    let Header: keyof JSX.IntrinsicElements = "h1";
 
     switch (props.heading) {
-        case "headingOne":
-            header = <h1>{props.text}</h1>;
-            break;
         case "headingTwo":
-            header = <h2>{props.text}</h2>;
+            Header = "h2";
             break;
         case "headingThree":
-            header = <h3>{props.text}</h3>;
+            Header = "h3";
             break;
         case "headingFour":
-            header = <h4>{props.text}</h4>;
+            Header = "h4";
             break;
         case "headingFive":
-            header = <h5>{props.text}</h5>;
+            Header = "h5";
             break;
         case "headingSix":
-            header = <h6>{props.text}</h6>;
+            Header = "h6";
             break;
     }
 
-    return header;
+    return <Header>{props.text}</Header>;
 }

--- a/packages/pluggableWidgets/accordion-web/src/components/Header.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/Header.tsx
@@ -1,11 +1,10 @@
-import { createElement, ReactElement } from "react";
+import { createElement, PropsWithChildren, ReactElement } from "react";
 
 export interface HeaderProps {
     heading: "headingOne" | "headingTwo" | "headingThree" | "headingFour" | "headingFive" | "headingSix";
-    text?: string;
 }
 
-export function Header(props: HeaderProps): ReactElement {
+export function Header(props: PropsWithChildren<HeaderProps>): ReactElement {
     let Header: keyof JSX.IntrinsicElements = "h1";
 
     switch (props.heading) {
@@ -26,5 +25,5 @@ export function Header(props: HeaderProps): ReactElement {
             break;
     }
 
-    return <Header>{props.text}</Header>;
+    return <Header>{props.children}</Header>;
 }

--- a/packages/pluggableWidgets/accordion-web/src/components/Header.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/Header.tsx
@@ -1,0 +1,33 @@
+import { createElement, ReactElement } from "react";
+
+export interface HeaderProps {
+    heading: "headingOne" | "headingTwo" | "headingThree" | "headingFour" | "headingFive" | "headingSix";
+    text?: string;
+}
+
+export function Header(props: HeaderProps): ReactElement {
+    let header;
+
+    switch (props.heading) {
+        case "headingOne":
+            header = <h1>{props.text}</h1>;
+            break;
+        case "headingTwo":
+            header = <h2>{props.text}</h2>;
+            break;
+        case "headingThree":
+            header = <h3>{props.text}</h3>;
+            break;
+        case "headingFour":
+            header = <h4>{props.text}</h4>;
+            break;
+        case "headingFive":
+            header = <h5>{props.text}</h5>;
+            break;
+        case "headingSix":
+            header = <h6>{props.text}</h6>;
+            break;
+    }
+
+    return header;
+}

--- a/packages/pluggableWidgets/accordion-web/src/components/__tests__/Accordion.spec.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/__tests__/Accordion.spec.tsx
@@ -12,8 +12,8 @@ describe("Accordion", () => {
             style: { height: "500px" },
             tabIndex: 1,
             groups: [
-                { header: "header", content: <span>content</span>, visible: true },
-                { header: "header2", content: <span>content2</span>, visible: false }
+                { header: "header", content: <span>content</span>, initiallyCollapsed: true, visible: true },
+                { header: "header2", content: <span>content2</span>, initiallyCollapsed: true, visible: false }
             ],
             collapsible,
             singleExpandedGroup,
@@ -195,6 +195,21 @@ describe("Accordion", () => {
             accordion.find(".widget-accordion-group-header-button").first().simulate("click");
             expect(accordion).toMatchSnapshot();
         });
+
+        it("inits with group initially collapsed settings", () => {
+            const groups = [...defaultProps.groups];
+            groups[0].initiallyCollapsed = false;
+
+            const accordion = shallow(<Accordion {...defaultProps} groups={groups} />);
+            expect(accordion).toMatchSnapshot();
+        });
+
+        it("inits with not more than one group expanded", () => {
+            const groups = [...defaultProps.groups].map(group => ({ ...group, initiallyCollapsed: false }));
+
+            const accordion = shallow(<Accordion {...defaultProps} groups={groups} />);
+            expect(accordion).toMatchSnapshot();
+        });
     });
 
     describe("in collapsible & multiple expanded group mode", () => {
@@ -233,6 +248,14 @@ describe("Accordion", () => {
             accordion.find(".widget-accordion-group-header-button").first().simulate("click");
             accordion.find(".widget-accordion-group-header-button").last().simulate("click");
             accordion.find(".widget-accordion-group-header-button").first().simulate("click");
+            expect(accordion).toMatchSnapshot();
+        });
+
+        it("inits with group initially collapsed settings", () => {
+            const groups = [...defaultProps.groups].map(group => ({ ...group, initiallyCollapsed: false }));
+            groups.push({ header: "header3", content: <span>content3</span>, initiallyCollapsed: true, visible: true });
+
+            const accordion = shallow(<Accordion {...defaultProps} groups={groups} />);
             expect(accordion).toMatchSnapshot();
         });
     });

--- a/packages/pluggableWidgets/accordion-web/src/components/__tests__/Accordion.spec.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/__tests__/Accordion.spec.tsx
@@ -258,6 +258,15 @@ describe("Accordion", () => {
             const accordion = shallow(<Accordion {...defaultProps} groups={groups} />);
             expect(accordion).toMatchSnapshot();
         });
+
+        it("applies group collapsed value changes", () => {
+            const accordion = shallow(<Accordion {...defaultProps} />);
+            const newGroups = [...defaultProps.groups];
+            newGroups[1].collapsed = false;
+            accordion.setProps({ groups: newGroups });
+
+            expect(accordion).toMatchSnapshot();
+        });
     });
 
     describe("not collapsible", () => {

--- a/packages/pluggableWidgets/accordion-web/src/components/__tests__/AccordionGroup.spec.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/__tests__/AccordionGroup.spec.tsx
@@ -243,6 +243,7 @@ describe("AccordionGroup", () => {
 
                 accordionGroup.setProps({ collapsed: false });
                 expect(onToggleCompletionMock).toHaveBeenCalledTimes(1);
+                expect(onToggleCompletionMock).toHaveBeenCalledWith(false);
             });
 
             it("applies the correct class when the header icon is aligned right", () => {

--- a/packages/pluggableWidgets/accordion-web/src/components/__tests__/AccordionGroup.spec.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/__tests__/AccordionGroup.spec.tsx
@@ -1,5 +1,5 @@
 import { createElement } from "react";
-import { shallow, ShallowWrapper } from "enzyme";
+import { mount, shallow, ShallowWrapper } from "enzyme";
 import { AccordionGroup, AccordionGroupProps, Target } from "../AccordionGroup";
 
 describe("AccordionGroup", () => {
@@ -228,6 +228,21 @@ describe("AccordionGroup", () => {
                 expect(keyboardEvent.preventDefault).toHaveBeenCalledTimes(1);
                 expect(changeFocusMock).toHaveBeenCalledTimes(1);
                 expect(changeFocusMock).toHaveBeenCalledWith(keyboardEvent.currentTarget, Target.LAST);
+            });
+
+            it("calls onToggleCompletion", () => {
+                const onToggleCompletionMock = jest.fn();
+
+                const accordionGroup = mount(
+                    <AccordionGroup
+                        {...defaultAccordionGroupProps}
+                        collapsible
+                        onToggleCompletion={onToggleCompletionMock}
+                    />
+                );
+
+                accordionGroup.setProps({ collapsed: false });
+                expect(onToggleCompletionMock).toHaveBeenCalledTimes(1);
             });
 
             it("applies the correct class when the header icon is aligned right", () => {

--- a/packages/pluggableWidgets/accordion-web/src/components/__tests__/Header.spec.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/__tests__/Header.spec.tsx
@@ -1,15 +1,15 @@
-import { createElement } from "react";
+import { createElement, PropsWithChildren } from "react";
 import { shallow } from "enzyme";
 
 import { Header, HeaderProps } from "../Header";
 
 describe("Header", () => {
-    let defaultHeaderProps: HeaderProps;
+    let defaultHeaderProps: PropsWithChildren<HeaderProps>;
 
     beforeEach(() => {
         defaultHeaderProps = {
             heading: "headingThree",
-            text: "Text"
+            children: "Text"
         };
     });
 

--- a/packages/pluggableWidgets/accordion-web/src/components/__tests__/Header.spec.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/components/__tests__/Header.spec.tsx
@@ -1,0 +1,51 @@
+import { createElement } from "react";
+import { shallow } from "enzyme";
+
+import { Header, HeaderProps } from "../Header";
+
+describe("Header", () => {
+    let defaultHeaderProps: HeaderProps;
+
+    beforeEach(() => {
+        defaultHeaderProps = {
+            heading: "headingThree",
+            text: "Text"
+        };
+    });
+
+    it("renders h1", () => {
+        const headerWrapper = shallow(<Header {...defaultHeaderProps} heading="headingOne" />);
+
+        expect(headerWrapper).toMatchSnapshot();
+    });
+
+    it("renders h2", () => {
+        const headerWrapper = shallow(<Header {...defaultHeaderProps} heading="headingTwo" />);
+
+        expect(headerWrapper).toMatchSnapshot();
+    });
+
+    it("renders h3", () => {
+        const headerWrapper = shallow(<Header {...defaultHeaderProps} />);
+
+        expect(headerWrapper).toMatchSnapshot();
+    });
+
+    it("renders h4", () => {
+        const headerWrapper = shallow(<Header {...defaultHeaderProps} heading="headingFour" />);
+
+        expect(headerWrapper).toMatchSnapshot();
+    });
+
+    it("renders h5", () => {
+        const headerWrapper = shallow(<Header {...defaultHeaderProps} heading="headingFive" />);
+
+        expect(headerWrapper).toMatchSnapshot();
+    });
+
+    it("renders h6", () => {
+        const headerWrapper = shallow(<Header {...defaultHeaderProps} heading="headingSix" />);
+
+        expect(headerWrapper).toMatchSnapshot();
+    });
+});

--- a/packages/pluggableWidgets/accordion-web/src/components/__tests__/__snapshots__/Accordion.spec.tsx.snap
+++ b/packages/pluggableWidgets/accordion-web/src/components/__tests__/__snapshots__/Accordion.spec.tsx.snap
@@ -75,6 +75,7 @@ exports[`Accordion in collapsible & multiple expanded group mode allows multiple
           content
         </span>,
         "header": "header",
+        "initiallyCollapsed": true,
         "visible": true,
       },
       Object {
@@ -82,6 +83,7 @@ exports[`Accordion in collapsible & multiple expanded group mode allows multiple
           content2
         </span>,
         "header": "header2",
+        "initiallyCollapsed": true,
         "visible": true,
       },
     ]
@@ -182,6 +184,7 @@ exports[`Accordion in collapsible & multiple expanded group mode allows multiple
       header="header"
       id="idAccordionGroup0"
       index={0}
+      initiallyCollapsed={true}
       key="0"
       parent={
         Object {
@@ -463,6 +466,7 @@ exports[`Accordion in collapsible & multiple expanded group mode allows multiple
       header="header2"
       id="idAccordionGroup1"
       index={1}
+      initiallyCollapsed={true}
       key="1"
       parent={
         Object {
@@ -768,6 +772,7 @@ exports[`Accordion in collapsible & multiple expanded group mode collapses a gro
           content
         </span>,
         "header": "header",
+        "initiallyCollapsed": true,
         "visible": true,
       },
       Object {
@@ -775,6 +780,7 @@ exports[`Accordion in collapsible & multiple expanded group mode collapses a gro
           content2
         </span>,
         "header": "header2",
+        "initiallyCollapsed": true,
         "visible": true,
       },
     ]
@@ -896,6 +902,7 @@ exports[`Accordion in collapsible & multiple expanded group mode collapses a gro
       header="header"
       id="idAccordionGroup0"
       index={0}
+      initiallyCollapsed={true}
       key="0"
       parent={
         Object {
@@ -1219,6 +1226,7 @@ exports[`Accordion in collapsible & multiple expanded group mode collapses a gro
       header="header2"
       id="idAccordionGroup1"
       index={1}
+      initiallyCollapsed={true}
       key="1"
       parent={
         Object {
@@ -1489,6 +1497,7 @@ exports[`Accordion in collapsible & multiple expanded group mode expands a group
           content
         </span>,
         "header": "header",
+        "initiallyCollapsed": true,
         "visible": true,
       },
       Object {
@@ -1496,6 +1505,7 @@ exports[`Accordion in collapsible & multiple expanded group mode expands a group
           content2
         </span>,
         "header": "header2",
+        "initiallyCollapsed": true,
         "visible": false,
       },
     ]
@@ -1561,6 +1571,7 @@ exports[`Accordion in collapsible & multiple expanded group mode expands a group
       header="header"
       id="idAccordionGroup0"
       index={0}
+      initiallyCollapsed={true}
       key="0"
       parent={
         Object {
@@ -1737,6 +1748,7 @@ exports[`Accordion in collapsible & multiple expanded group mode expands a group
       header="header2"
       id="idAccordionGroup1"
       index={1}
+      initiallyCollapsed={true}
       key="1"
       parent={
         Object {
@@ -1837,6 +1849,89 @@ exports[`Accordion in collapsible & multiple expanded group mode expands a group
 </Accordion>
 `;
 
+exports[`Accordion in collapsible & multiple expanded group mode inits with group initially collapsed settings 1`] = `
+<div
+  className="widget-accordion"
+  data-focusindex={1}
+  id="id"
+  style={
+    Object {
+      "height": "500px",
+    }
+  }
+>
+  <AccordionGroupWrapper
+    collapsed={false}
+    collapsedAccordionGroupsDispatch={[Function]}
+    collapsible={true}
+    content={
+      <span>
+        content
+      </span>
+    }
+    generateHeaderIcon={[MockFunction]}
+    header="header"
+    id="idAccordionGroup0"
+    index={0}
+    initiallyCollapsed={false}
+    key="0"
+    parent={
+      Object {
+        "current": null,
+      }
+    }
+    showHeaderIcon="right"
+    visible={true}
+  />
+  <AccordionGroupWrapper
+    collapsed={false}
+    collapsedAccordionGroupsDispatch={[Function]}
+    collapsible={true}
+    content={
+      <span>
+        content2
+      </span>
+    }
+    generateHeaderIcon={[MockFunction]}
+    header="header2"
+    id="idAccordionGroup1"
+    index={1}
+    initiallyCollapsed={false}
+    key="1"
+    parent={
+      Object {
+        "current": null,
+      }
+    }
+    showHeaderIcon="right"
+    visible={false}
+  />
+  <AccordionGroupWrapper
+    collapsed={true}
+    collapsedAccordionGroupsDispatch={[Function]}
+    collapsible={true}
+    content={
+      <span>
+        content3
+      </span>
+    }
+    generateHeaderIcon={[MockFunction]}
+    header="header3"
+    id="idAccordionGroup2"
+    index={2}
+    initiallyCollapsed={true}
+    key="2"
+    parent={
+      Object {
+        "current": null,
+      }
+    }
+    showHeaderIcon="right"
+    visible={true}
+  />
+</div>
+`;
+
 exports[`Accordion in collapsible & multiple expanded group mode renders correctly 1`] = `
 <Accordion
   class=""
@@ -1863,6 +1958,7 @@ exports[`Accordion in collapsible & multiple expanded group mode renders correct
           content
         </span>,
         "header": "header",
+        "initiallyCollapsed": true,
         "visible": true,
       },
       Object {
@@ -1870,6 +1966,7 @@ exports[`Accordion in collapsible & multiple expanded group mode renders correct
           content2
         </span>,
         "header": "header2",
+        "initiallyCollapsed": true,
         "visible": false,
       },
     ]
@@ -1921,6 +2018,7 @@ exports[`Accordion in collapsible & multiple expanded group mode renders correct
       header="header"
       id="idAccordionGroup0"
       index={0}
+      initiallyCollapsed={true}
       key="0"
       parent={
         Object {
@@ -2069,6 +2167,7 @@ exports[`Accordion in collapsible & multiple expanded group mode renders correct
       header="header2"
       id="idAccordionGroup1"
       index={1}
+      initiallyCollapsed={true}
       key="1"
       parent={
         Object {
@@ -2237,6 +2336,7 @@ exports[`Accordion in collapsible & single expanded group mode allows one group 
           content
         </span>,
         "header": "header",
+        "initiallyCollapsed": true,
         "visible": true,
       },
       Object {
@@ -2244,6 +2344,7 @@ exports[`Accordion in collapsible & single expanded group mode allows one group 
           content2
         </span>,
         "header": "header2",
+        "initiallyCollapsed": true,
         "visible": true,
       },
     ]
@@ -2351,6 +2452,7 @@ exports[`Accordion in collapsible & single expanded group mode allows one group 
       header="header"
       id="idAccordionGroup0"
       index={0}
+      initiallyCollapsed={true}
       key="0"
       parent={
         Object {
@@ -2646,6 +2748,7 @@ exports[`Accordion in collapsible & single expanded group mode allows one group 
       header="header2"
       id="idAccordionGroup1"
       index={1}
+      initiallyCollapsed={true}
       key="1"
       parent={
         Object {
@@ -2916,6 +3019,7 @@ exports[`Accordion in collapsible & single expanded group mode collapses a group
           content
         </span>,
         "header": "header",
+        "initiallyCollapsed": true,
         "visible": true,
       },
       Object {
@@ -2923,6 +3027,7 @@ exports[`Accordion in collapsible & single expanded group mode collapses a group
           content2
         </span>,
         "header": "header2",
+        "initiallyCollapsed": true,
         "visible": false,
       },
     ]
@@ -3002,6 +3107,7 @@ exports[`Accordion in collapsible & single expanded group mode collapses a group
       header="header"
       id="idAccordionGroup0"
       index={0}
+      initiallyCollapsed={true}
       key="0"
       parent={
         Object {
@@ -3206,6 +3312,7 @@ exports[`Accordion in collapsible & single expanded group mode collapses a group
       header="header2"
       id="idAccordionGroup1"
       index={1}
+      initiallyCollapsed={true}
       key="1"
       parent={
         Object {
@@ -3360,6 +3467,7 @@ exports[`Accordion in collapsible & single expanded group mode expands a group 1
           content
         </span>,
         "header": "header",
+        "initiallyCollapsed": true,
         "visible": true,
       },
       Object {
@@ -3367,6 +3475,7 @@ exports[`Accordion in collapsible & single expanded group mode expands a group 1
           content2
         </span>,
         "header": "header2",
+        "initiallyCollapsed": true,
         "visible": false,
       },
     ]
@@ -3432,6 +3541,7 @@ exports[`Accordion in collapsible & single expanded group mode expands a group 1
       header="header"
       id="idAccordionGroup0"
       index={0}
+      initiallyCollapsed={true}
       key="0"
       parent={
         Object {
@@ -3608,6 +3718,7 @@ exports[`Accordion in collapsible & single expanded group mode expands a group 1
       header="header2"
       id="idAccordionGroup1"
       index={1}
+      initiallyCollapsed={true}
       key="1"
       parent={
         Object {
@@ -3708,6 +3819,126 @@ exports[`Accordion in collapsible & single expanded group mode expands a group 1
 </Accordion>
 `;
 
+exports[`Accordion in collapsible & single expanded group mode inits with group initially collapsed settings 1`] = `
+<div
+  className="widget-accordion"
+  data-focusindex={1}
+  id="id"
+  style={
+    Object {
+      "height": "500px",
+    }
+  }
+>
+  <AccordionGroupWrapper
+    collapsed={false}
+    collapsedAccordionGroupsDispatch={[Function]}
+    collapsible={true}
+    content={
+      <span>
+        content
+      </span>
+    }
+    generateHeaderIcon={[MockFunction]}
+    header="header"
+    id="idAccordionGroup0"
+    index={0}
+    initiallyCollapsed={false}
+    key="0"
+    parent={
+      Object {
+        "current": null,
+      }
+    }
+    showHeaderIcon="right"
+    visible={true}
+  />
+  <AccordionGroupWrapper
+    collapsed={true}
+    collapsedAccordionGroupsDispatch={[Function]}
+    collapsible={true}
+    content={
+      <span>
+        content2
+      </span>
+    }
+    generateHeaderIcon={[MockFunction]}
+    header="header2"
+    id="idAccordionGroup1"
+    index={1}
+    initiallyCollapsed={true}
+    key="1"
+    parent={
+      Object {
+        "current": null,
+      }
+    }
+    showHeaderIcon="right"
+    visible={false}
+  />
+</div>
+`;
+
+exports[`Accordion in collapsible & single expanded group mode inits with not more than one group expanded 1`] = `
+<div
+  className="widget-accordion"
+  data-focusindex={1}
+  id="id"
+  style={
+    Object {
+      "height": "500px",
+    }
+  }
+>
+  <AccordionGroupWrapper
+    collapsed={true}
+    collapsedAccordionGroupsDispatch={[Function]}
+    collapsible={true}
+    content={
+      <span>
+        content
+      </span>
+    }
+    generateHeaderIcon={[MockFunction]}
+    header="header"
+    id="idAccordionGroup0"
+    index={0}
+    initiallyCollapsed={false}
+    key="0"
+    parent={
+      Object {
+        "current": null,
+      }
+    }
+    showHeaderIcon="right"
+    visible={true}
+  />
+  <AccordionGroupWrapper
+    collapsed={false}
+    collapsedAccordionGroupsDispatch={[Function]}
+    collapsible={true}
+    content={
+      <span>
+        content2
+      </span>
+    }
+    generateHeaderIcon={[MockFunction]}
+    header="header2"
+    id="idAccordionGroup1"
+    index={1}
+    initiallyCollapsed={false}
+    key="1"
+    parent={
+      Object {
+        "current": null,
+      }
+    }
+    showHeaderIcon="right"
+    visible={false}
+  />
+</div>
+`;
+
 exports[`Accordion in collapsible & single expanded group mode renders correctly 1`] = `
 <Accordion
   class=""
@@ -3734,6 +3965,7 @@ exports[`Accordion in collapsible & single expanded group mode renders correctly
           content
         </span>,
         "header": "header",
+        "initiallyCollapsed": true,
         "visible": true,
       },
       Object {
@@ -3741,6 +3973,7 @@ exports[`Accordion in collapsible & single expanded group mode renders correctly
           content2
         </span>,
         "header": "header2",
+        "initiallyCollapsed": true,
         "visible": false,
       },
     ]
@@ -3792,6 +4025,7 @@ exports[`Accordion in collapsible & single expanded group mode renders correctly
       header="header"
       id="idAccordionGroup0"
       index={0}
+      initiallyCollapsed={true}
       key="0"
       parent={
         Object {
@@ -3940,6 +4174,7 @@ exports[`Accordion in collapsible & single expanded group mode renders correctly
       header="header2"
       id="idAccordionGroup1"
       index={1}
+      initiallyCollapsed={true}
       key="1"
       parent={
         Object {
@@ -4038,6 +4273,7 @@ exports[`Accordion not collapsible renders correctly 1`] = `
           content
         </span>,
         "header": "header",
+        "initiallyCollapsed": true,
         "visible": true,
       },
       Object {
@@ -4045,6 +4281,7 @@ exports[`Accordion not collapsible renders correctly 1`] = `
           content2
         </span>,
         "header": "header2",
+        "initiallyCollapsed": true,
         "visible": false,
       },
     ]
@@ -4081,6 +4318,7 @@ exports[`Accordion not collapsible renders correctly 1`] = `
       header="header"
       id="idAccordionGroup0"
       index={0}
+      initiallyCollapsed={true}
       key="0"
       parent={
         Object {
@@ -4197,6 +4435,7 @@ exports[`Accordion not collapsible renders correctly 1`] = `
       header="header2"
       id="idAccordionGroup1"
       index={1}
+      initiallyCollapsed={true}
       key="1"
       parent={
         Object {
@@ -4292,6 +4531,7 @@ exports[`Accordion renders correctly without tabindex 1`] = `
     header="header"
     id="idAccordionGroup0"
     index={0}
+    initiallyCollapsed={true}
     key="0"
     parent={
       Object {
@@ -4314,6 +4554,7 @@ exports[`Accordion renders correctly without tabindex 1`] = `
     header="header2"
     id="idAccordionGroup1"
     index={1}
+    initiallyCollapsed={true}
     key="1"
     parent={
       Object {

--- a/packages/pluggableWidgets/accordion-web/src/components/__tests__/__snapshots__/Accordion.spec.tsx.snap
+++ b/packages/pluggableWidgets/accordion-web/src/components/__tests__/__snapshots__/Accordion.spec.tsx.snap
@@ -109,8 +109,8 @@ exports[`Accordion in collapsible & multiple expanded group mode allows multiple
     }
   >
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={false}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={true}
       content={
         <span>
@@ -391,8 +391,8 @@ exports[`Accordion in collapsible & multiple expanded group mode allows multiple
       </AccordionGroup>
     </AccordionGroupWrapper>
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={false}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={true}
       content={
         <span>
@@ -688,8 +688,8 @@ exports[`Accordion in collapsible & multiple expanded group mode applies group c
   }
 >
   <AccordionGroupWrapper
+    accordionGroupCollapsedStateDispatch={[Function]}
     collapsed={true}
-    collapsedAccordionGroupsDispatch={[Function]}
     collapsible={true}
     content={
       <span>
@@ -711,8 +711,8 @@ exports[`Accordion in collapsible & multiple expanded group mode applies group c
     visible={true}
   />
   <AccordionGroupWrapper
+    accordionGroupCollapsedStateDispatch={[Function]}
     collapsed={false}
-    collapsedAccordionGroupsDispatch={[Function]}
     collapsible={true}
     content={
       <span>
@@ -866,8 +866,8 @@ exports[`Accordion in collapsible & multiple expanded group mode collapses a gro
     }
   >
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={true}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={true}
       content={
         <span>
@@ -1190,8 +1190,8 @@ exports[`Accordion in collapsible & multiple expanded group mode collapses a gro
       </AccordionGroup>
     </AccordionGroupWrapper>
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={false}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={true}
       content={
         <span>
@@ -1591,8 +1591,8 @@ exports[`Accordion in collapsible & multiple expanded group mode expands a group
     }
   >
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={false}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={true}
       content={
         <span>
@@ -1768,8 +1768,8 @@ exports[`Accordion in collapsible & multiple expanded group mode expands a group
       </AccordionGroup>
     </AccordionGroupWrapper>
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={true}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={true}
       content={
         <span>
@@ -1921,8 +1921,8 @@ exports[`Accordion in collapsible & multiple expanded group mode inits with grou
   }
 >
   <AccordionGroupWrapper
+    accordionGroupCollapsedStateDispatch={[Function]}
     collapsed={false}
-    collapsedAccordionGroupsDispatch={[Function]}
     collapsible={true}
     content={
       <span>
@@ -1944,8 +1944,8 @@ exports[`Accordion in collapsible & multiple expanded group mode inits with grou
     visible={true}
   />
   <AccordionGroupWrapper
+    accordionGroupCollapsedStateDispatch={[Function]}
     collapsed={false}
-    collapsedAccordionGroupsDispatch={[Function]}
     collapsible={true}
     content={
       <span>
@@ -1967,8 +1967,8 @@ exports[`Accordion in collapsible & multiple expanded group mode inits with grou
     visible={false}
   />
   <AccordionGroupWrapper
+    accordionGroupCollapsedStateDispatch={[Function]}
     collapsed={true}
-    collapsedAccordionGroupsDispatch={[Function]}
     collapsible={true}
     content={
       <span>
@@ -2052,8 +2052,8 @@ exports[`Accordion in collapsible & multiple expanded group mode renders correct
     }
   >
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={true}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={true}
       content={
         <span>
@@ -2201,8 +2201,8 @@ exports[`Accordion in collapsible & multiple expanded group mode renders correct
       </AccordionGroup>
     </AccordionGroupWrapper>
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={true}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={true}
       content={
         <span>
@@ -2430,8 +2430,8 @@ exports[`Accordion in collapsible & single expanded group mode allows one group 
     }
   >
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={true}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={true}
       content={
         <span>
@@ -2726,8 +2726,8 @@ exports[`Accordion in collapsible & single expanded group mode allows one group 
       </AccordionGroup>
     </AccordionGroupWrapper>
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={false}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={true}
       content={
         <span>
@@ -3113,8 +3113,8 @@ exports[`Accordion in collapsible & single expanded group mode collapses a group
     }
   >
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={true}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={true}
       content={
         <span>
@@ -3318,8 +3318,8 @@ exports[`Accordion in collapsible & single expanded group mode collapses a group
       </AccordionGroup>
     </AccordionGroupWrapper>
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={true}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={true}
       content={
         <span>
@@ -3561,8 +3561,8 @@ exports[`Accordion in collapsible & single expanded group mode expands a group 1
     }
   >
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={false}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={true}
       content={
         <span>
@@ -3738,8 +3738,8 @@ exports[`Accordion in collapsible & single expanded group mode expands a group 1
       </AccordionGroup>
     </AccordionGroupWrapper>
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={true}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={true}
       content={
         <span>
@@ -3891,8 +3891,8 @@ exports[`Accordion in collapsible & single expanded group mode inits with group 
   }
 >
   <AccordionGroupWrapper
+    accordionGroupCollapsedStateDispatch={[Function]}
     collapsed={false}
-    collapsedAccordionGroupsDispatch={[Function]}
     collapsible={true}
     content={
       <span>
@@ -3914,8 +3914,8 @@ exports[`Accordion in collapsible & single expanded group mode inits with group 
     visible={true}
   />
   <AccordionGroupWrapper
+    accordionGroupCollapsedStateDispatch={[Function]}
     collapsed={true}
-    collapsedAccordionGroupsDispatch={[Function]}
     collapsible={true}
     content={
       <span>
@@ -3951,8 +3951,8 @@ exports[`Accordion in collapsible & single expanded group mode inits with not mo
   }
 >
   <AccordionGroupWrapper
+    accordionGroupCollapsedStateDispatch={[Function]}
     collapsed={true}
-    collapsedAccordionGroupsDispatch={[Function]}
     collapsible={true}
     content={
       <span>
@@ -3974,8 +3974,8 @@ exports[`Accordion in collapsible & single expanded group mode inits with not mo
     visible={true}
   />
   <AccordionGroupWrapper
+    accordionGroupCollapsedStateDispatch={[Function]}
     collapsed={false}
-    collapsedAccordionGroupsDispatch={[Function]}
     collapsible={true}
     content={
       <span>
@@ -4059,8 +4059,8 @@ exports[`Accordion in collapsible & single expanded group mode renders correctly
     }
   >
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={true}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={true}
       content={
         <span>
@@ -4208,8 +4208,8 @@ exports[`Accordion in collapsible & single expanded group mode renders correctly
       </AccordionGroup>
     </AccordionGroupWrapper>
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={true}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={true}
       content={
         <span>
@@ -4366,8 +4366,8 @@ exports[`Accordion not collapsible renders correctly 1`] = `
     }
   >
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={false}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={false}
       content={
         <span>
@@ -4483,8 +4483,8 @@ exports[`Accordion not collapsible renders correctly 1`] = `
       </AccordionGroup>
     </AccordionGroupWrapper>
     <AccordionGroupWrapper
+      accordionGroupCollapsedStateDispatch={[Function]}
       collapsed={false}
-      collapsedAccordionGroupsDispatch={[Function]}
       collapsible={false}
       content={
         <span>
@@ -4579,8 +4579,8 @@ exports[`Accordion renders correctly without tabindex 1`] = `
   }
 >
   <AccordionGroupWrapper
+    accordionGroupCollapsedStateDispatch={[Function]}
     collapsed={true}
-    collapsedAccordionGroupsDispatch={[Function]}
     collapsible={true}
     content={
       <span>
@@ -4602,8 +4602,8 @@ exports[`Accordion renders correctly without tabindex 1`] = `
     visible={true}
   />
   <AccordionGroupWrapper
+    accordionGroupCollapsedStateDispatch={[Function]}
     collapsed={true}
-    collapsedAccordionGroupsDispatch={[Function]}
     collapsible={true}
     content={
       <span>

--- a/packages/pluggableWidgets/accordion-web/src/components/__tests__/__snapshots__/Accordion.spec.tsx.snap
+++ b/packages/pluggableWidgets/accordion-web/src/components/__tests__/__snapshots__/Accordion.spec.tsx.snap
@@ -676,6 +676,66 @@ exports[`Accordion in collapsible & multiple expanded group mode allows multiple
 </Accordion>
 `;
 
+exports[`Accordion in collapsible & multiple expanded group mode applies group collapsed value changes 1`] = `
+<div
+  className="widget-accordion"
+  data-focusindex={1}
+  id="id"
+  style={
+    Object {
+      "height": "500px",
+    }
+  }
+>
+  <AccordionGroupWrapper
+    collapsed={true}
+    collapsedAccordionGroupsDispatch={[Function]}
+    collapsible={true}
+    content={
+      <span>
+        content
+      </span>
+    }
+    generateHeaderIcon={[MockFunction]}
+    header="header"
+    id="idAccordionGroup0"
+    index={0}
+    initiallyCollapsed={true}
+    key="0"
+    parent={
+      Object {
+        "current": null,
+      }
+    }
+    showHeaderIcon="right"
+    visible={true}
+  />
+  <AccordionGroupWrapper
+    collapsed={false}
+    collapsedAccordionGroupsDispatch={[Function]}
+    collapsible={true}
+    content={
+      <span>
+        content2
+      </span>
+    }
+    generateHeaderIcon={[MockFunction]}
+    header="header2"
+    id="idAccordionGroup1"
+    index={1}
+    initiallyCollapsed={true}
+    key="1"
+    parent={
+      Object {
+        "current": null,
+      }
+    }
+    showHeaderIcon="right"
+    visible={false}
+  />
+</div>
+`;
+
 exports[`Accordion in collapsible & multiple expanded group mode collapses a group 1`] = `
 <Accordion
   class=""

--- a/packages/pluggableWidgets/accordion-web/src/components/__tests__/__snapshots__/Header.spec.tsx.snap
+++ b/packages/pluggableWidgets/accordion-web/src/components/__tests__/__snapshots__/Header.spec.tsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Header renders h1 1`] = `
+<h1>
+  Text
+</h1>
+`;
+
+exports[`Header renders h2 1`] = `
+<h2>
+  Text
+</h2>
+`;
+
+exports[`Header renders h3 1`] = `
+<h3>
+  Text
+</h3>
+`;
+
+exports[`Header renders h4 1`] = `
+<h4>
+  Text
+</h4>
+`;
+
+exports[`Header renders h5 1`] = `
+<h5>
+  Text
+</h5>
+`;
+
+exports[`Header renders h6 1`] = `
+<h6>
+  Text
+</h6>
+`;

--- a/packages/pluggableWidgets/accordion-web/typings/AccordionProps.d.ts
+++ b/packages/pluggableWidgets/accordion-web/typings/AccordionProps.d.ts
@@ -18,10 +18,10 @@ export interface GroupsType {
     headerHeading: HeaderHeadingEnum;
     headerContent?: ReactNode;
     content?: ReactNode;
-    initialCollapsedState: InitialCollapsedStateEnum;
-    initiallyCollapsed: DynamicValue<boolean>;
     visible: DynamicValue<boolean>;
     dynamicClass?: DynamicValue<string>;
+    initialCollapsedState: InitialCollapsedStateEnum;
+    initiallyCollapsed: DynamicValue<boolean>;
     collapsed?: EditableValue<boolean>;
     onToggleCollapsed?: ActionValue;
 }
@@ -36,10 +36,10 @@ export interface GroupsPreviewType {
     headerHeading: HeaderHeadingEnum;
     headerContent: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     content: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
-    initialCollapsedState: InitialCollapsedStateEnum;
-    initiallyCollapsed: string;
     visible: string;
     dynamicClass: string;
+    initialCollapsedState: InitialCollapsedStateEnum;
+    initiallyCollapsed: string;
     collapsed: string;
     onToggleCollapsed: {} | null;
 }

--- a/packages/pluggableWidgets/accordion-web/typings/AccordionProps.d.ts
+++ b/packages/pluggableWidgets/accordion-web/typings/AccordionProps.d.ts
@@ -10,12 +10,15 @@ export type HeaderRenderModeEnum = "text" | "custom";
 
 export type HeaderHeadingEnum = "headingOne" | "headingTwo" | "headingThree" | "headingFour" | "headingFive" | "headingSix";
 
+export type InitialCollapsedStateEnum = "expanded" | "collapsed";
+
 export interface GroupsType {
     headerRenderMode: HeaderRenderModeEnum;
     headerText: DynamicValue<string>;
     headerHeading: HeaderHeadingEnum;
     headerContent?: ReactNode;
     content?: ReactNode;
+    initialCollapsedState: InitialCollapsedStateEnum;
     visible: DynamicValue<boolean>;
     dynamicClass?: DynamicValue<string>;
 }
@@ -30,6 +33,7 @@ export interface GroupsPreviewType {
     headerHeading: HeaderHeadingEnum;
     headerContent: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     content: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
+    initialCollapsedState: InitialCollapsedStateEnum;
     visible: string;
     dynamicClass: string;
 }

--- a/packages/pluggableWidgets/accordion-web/typings/AccordionProps.d.ts
+++ b/packages/pluggableWidgets/accordion-web/typings/AccordionProps.d.ts
@@ -4,7 +4,7 @@
  * @author Mendix UI Content Team
  */
 import { ComponentType, CSSProperties, ReactNode } from "react";
-import { ActionValue, DynamicValue, WebIcon } from "mendix";
+import { ActionValue, DynamicValue, EditableValue, WebIcon } from "mendix";
 
 export type HeaderRenderModeEnum = "text" | "custom";
 
@@ -22,6 +22,7 @@ export interface GroupsType {
     initiallyCollapsed: DynamicValue<boolean>;
     visible: DynamicValue<boolean>;
     dynamicClass?: DynamicValue<string>;
+    collapsed?: EditableValue<boolean>;
     onToggleCollapsed?: ActionValue;
 }
 
@@ -39,6 +40,7 @@ export interface GroupsPreviewType {
     initiallyCollapsed: string;
     visible: string;
     dynamicClass: string;
+    collapsed: string;
     onToggleCollapsed: {} | null;
 }
 

--- a/packages/pluggableWidgets/accordion-web/typings/AccordionProps.d.ts
+++ b/packages/pluggableWidgets/accordion-web/typings/AccordionProps.d.ts
@@ -4,7 +4,7 @@
  * @author Mendix UI Content Team
  */
 import { ComponentType, CSSProperties, ReactNode } from "react";
-import { DynamicValue, WebIcon } from "mendix";
+import { ActionValue, DynamicValue, WebIcon } from "mendix";
 
 export type HeaderRenderModeEnum = "text" | "custom";
 
@@ -22,6 +22,7 @@ export interface GroupsType {
     initiallyCollapsed: DynamicValue<boolean>;
     visible: DynamicValue<boolean>;
     dynamicClass?: DynamicValue<string>;
+    onToggleCollapsed?: ActionValue;
 }
 
 export type ExpandBehaviorEnum = "singleExpanded" | "multipleExpanded";
@@ -38,6 +39,7 @@ export interface GroupsPreviewType {
     initiallyCollapsed: string;
     visible: string;
     dynamicClass: string;
+    onToggleCollapsed: {} | null;
 }
 
 export interface AccordionContainerProps {

--- a/packages/pluggableWidgets/accordion-web/typings/AccordionProps.d.ts
+++ b/packages/pluggableWidgets/accordion-web/typings/AccordionProps.d.ts
@@ -10,7 +10,7 @@ export type HeaderRenderModeEnum = "text" | "custom";
 
 export type HeaderHeadingEnum = "headingOne" | "headingTwo" | "headingThree" | "headingFour" | "headingFive" | "headingSix";
 
-export type InitialCollapsedStateEnum = "expanded" | "collapsed";
+export type InitialCollapsedStateEnum = "expanded" | "collapsed" | "dynamic";
 
 export interface GroupsType {
     headerRenderMode: HeaderRenderModeEnum;
@@ -19,6 +19,7 @@ export interface GroupsType {
     headerContent?: ReactNode;
     content?: ReactNode;
     initialCollapsedState: InitialCollapsedStateEnum;
+    initiallyCollapsed: DynamicValue<boolean>;
     visible: DynamicValue<boolean>;
     dynamicClass?: DynamicValue<string>;
 }
@@ -34,6 +35,7 @@ export interface GroupsPreviewType {
     headerContent: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     content: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     initialCollapsedState: InitialCollapsedStateEnum;
+    initiallyCollapsed: string;
     visible: string;
     dynamicClass: string;
 }

--- a/packages/pluggableWidgets/accordion-web/typings/AccordionProps.d.ts
+++ b/packages/pluggableWidgets/accordion-web/typings/AccordionProps.d.ts
@@ -8,9 +8,12 @@ import { DynamicValue, WebIcon } from "mendix";
 
 export type HeaderRenderModeEnum = "text" | "custom";
 
+export type HeaderHeadingEnum = "headingOne" | "headingTwo" | "headingThree" | "headingFour" | "headingFive" | "headingSix";
+
 export interface GroupsType {
     headerRenderMode: HeaderRenderModeEnum;
     headerText: DynamicValue<string>;
+    headerHeading: HeaderHeadingEnum;
     headerContent?: ReactNode;
     content?: ReactNode;
     visible: DynamicValue<boolean>;
@@ -24,6 +27,7 @@ export type ShowIconEnum = "right" | "left" | "no";
 export interface GroupsPreviewType {
     headerRenderMode: HeaderRenderModeEnum;
     headerText: string;
+    headerHeading: HeaderHeadingEnum;
     headerContent: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     content: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     visible: string;


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅ 
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with designs ✅ ❌
- Comply with PM's requirements ✅ ❌

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Introduce the remainder of advanced mode features of accordion web.

## Relevant changes
- Add a widget property to configure the render mode of the header text.
- Add widget properties to influence the initial collapsed state for a group.
- Add a widget property to trigger an action when the widget collapse state changes.
- Add consistency check for single expanded mode & multiple start expanded configuration.

## What should be covered while testing?
Test the new properties.
