### PR TITLE
[WC-256] Fix datasource preview typings

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
@@ -82,7 +82,7 @@ export interface DatagridContainerProps {
 export interface DatagridPreviewProps {
     class: string;
     style: string;
-    datasource: {} | null;
+    datasource: {} | { type: string } | null;
     columns: ColumnsPreviewType[];
     columnsFilterable: boolean;
     pageSize: number | null;

--- a/packages/pluggableWidgets/maps-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/maps-web/CHANGELOG.md
@@ -3,7 +3,9 @@ All notable changes to this widget will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 2.0.2 - 2021-07-12
+### Fixed
+- We have fixed the dynamic marker data source consistency check for MX 9.2 and above.
 
 ## 2.0.1 - 2021-04-26
 

--- a/packages/pluggableWidgets/maps-web/package.json
+++ b/packages/pluggableWidgets/maps-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maps-web",
   "widgetName": "Maps",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Show locations on Maps",
   "copyright": "Mendix Technology B.V.",
   "license": "Apache-2.0",

--- a/packages/pluggableWidgets/maps-web/src/Maps.editorConfig.ts
+++ b/packages/pluggableWidgets/maps-web/src/Maps.editorConfig.ts
@@ -147,8 +147,7 @@ export function check(values: MapsPreviewProps): Problem[] {
     });
 
     values.dynamicMarkers.forEach((marker, index) => {
-        // @ts-ignore
-        if (marker.markersDS.type === "null") {
+        if (!marker.markersDS || ("type" in marker.markersDS && marker.markersDS.type === "null")) {
             errors.push({
                 property: `dynamicMarkers/${index + 1}/markersDS`,
                 message: "A data source should be selected in order to retrieve a list of markers"

--- a/packages/pluggableWidgets/maps-web/typings/MapsProps.d.ts
+++ b/packages/pluggableWidgets/maps-web/typings/MapsProps.d.ts
@@ -58,7 +58,7 @@ export interface MarkersPreviewType {
 }
 
 export interface DynamicMarkersPreviewType {
-    markersDS: {} | null;
+    markersDS: {} | { type: string } | null;
     locationType: LocationTypeEnum;
     address: string;
     latitude: string;

--- a/packages/pluggableWidgets/tree-view-web/typings/TreeViewProps.d.ts
+++ b/packages/pluggableWidgets/tree-view-web/typings/TreeViewProps.d.ts
@@ -21,7 +21,7 @@ export interface TreeViewContainerProps {
 export interface TreeViewPreviewProps {
     class: string;
     style: string;
-    datasource: {} | null;
+    datasource: {} | { type: string } | null;
     caption: string;
     hasChildren: boolean;
     startExpanded: boolean;

--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this tool will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 9.3.1 - 2021-07-12
+### Fixed
+We fixed the preview prop typing generation for data sources.
+
 ## 9.3.0 - 2021-07-02
 ### Added
 - We added support for testing components that make use of SVG images.

--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -3,9 +3,12 @@ All notable changes to this tool will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 9.3.1 - 2021-07-12
+## 9.3.1 - 2021-07-13
+### Added
+- We added support to download a Mendix test project from a GitHub repository branch.
+
 ### Fixed
-We fixed the preview prop typing generation for data sources.
+- We fixed the preview prop typing generation for data sources.
 
 ## 9.3.0 - 2021-07-02
 ### Added

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "description": "Mendix Pluggable Widgets Tools",
   "license": "Apache-2.0",
   "copyright": "2020 Mendix Technology BV",

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
@@ -39,7 +39,7 @@ export interface MyWidgetContainerProps {
 export interface MyWidgetPreviewProps {
     class: string;
     style: string;
-    contentSource: {} | null;
+    contentSource: {} | { type: string } | null;
     content: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     markerDataAttribute: string;
     actionAttribute: {} | null;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
@@ -35,7 +35,8 @@ function toPreviewPropType(prop: Property, generatedTypes: string[]): string {
         case "file":
             return "string";
         case "datasource":
-            return "{} | null";
+            // { type: string } is included here due to an incorrect API output before 9.2 (PAG-1400)
+            return "{} | { type: string } | null";
         case "attribute":
         case "expression":
             return "string";


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fix datasource preview typings and related code due to datasource preview api change in MX 9.2 (PAG-1400).

## Relevant changes
- Adjust datasource preview typings in pluggable widgets tools.
- Fix maps consistency check.
- Update prop typings of other web widgets with datasources (no release required).

## What should be covered while testing?
Maps dynamic marker datasource consistency check before and from MX 9.2.
