### PR TITLE
Fix native widgets datasource preview typings & usage

### DIFF
--- a/packages/pluggableWidgets/bar-chart-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/bar-chart-native/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+All notable changes to this widget will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Fixed
+- We have fixed the data source consistency check for MX 9.2 and above.

--- a/packages/pluggableWidgets/bar-chart-native/package.json
+++ b/packages/pluggableWidgets/bar-chart-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bar-chart-native",
   "widgetName": "BarChart",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "Apache-2.0",
   "copyright": "Mendix Technology BV",
   "repository": {

--- a/packages/pluggableWidgets/bar-chart-native/src/BarChart.editorConfig.ts
+++ b/packages/pluggableWidgets/bar-chart-native/src/BarChart.editorConfig.ts
@@ -32,8 +32,10 @@ export function check(values: BarChartPreviewProps): Problem[] {
 
     values.barSeries.forEach((series, index) => {
         if (series.dataSet === "static") {
-            // @ts-ignore
-            if (series.staticDataSource.type === "null") {
+            if (
+                !series.staticDataSource ||
+                ("type" in series.staticDataSource && series.staticDataSource.type === "null")
+            ) {
                 errors.push({
                     property: `barSeries/${index + 1}/staticDataSource`,
                     severity: "error",
@@ -57,8 +59,10 @@ export function check(values: BarChartPreviewProps): Problem[] {
                 });
             }
         } else {
-            // @ts-ignore
-            if (series.dynamicDataSource.type === "null") {
+            if (
+                !series.dynamicDataSource ||
+                ("type" in series.dynamicDataSource && series.dynamicDataSource.type === "null")
+            ) {
                 errors.push({
                     property: `barSeries/${index + 1}/dynamicDataSource`,
                     severity: "error",

--- a/packages/pluggableWidgets/bar-chart-native/src/package.xml
+++ b/packages/pluggableWidgets/bar-chart-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="BarChart" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="BarChart" version="1.0.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="BarChart.xml"/>
         </widgetFiles>

--- a/packages/pluggableWidgets/bar-chart-native/typings/BarChartProps.d.ts
+++ b/packages/pluggableWidgets/bar-chart-native/typings/BarChartProps.d.ts
@@ -29,8 +29,8 @@ export type SortOrderEnum = "ascending" | "descending";
 
 export interface BarSeriesPreviewType {
     dataSet: DataSetEnum;
-    staticDataSource: {} | null;
-    dynamicDataSource: {} | null;
+    staticDataSource: {} | { type: string } | null;
+    dynamicDataSource: {} | { type: string } | null;
     groupByAttribute: string;
     staticSeriesName: string;
     dynamicSeriesName: string;

--- a/packages/pluggableWidgets/carousel-native/typings/CarouselProps.d.ts
+++ b/packages/pluggableWidgets/carousel-native/typings/CarouselProps.d.ts
@@ -23,8 +23,8 @@ export interface CarouselProps<Style> {
 export interface CarouselPreviewProps {
     class: string;
     style: string;
-    contentSource: {} | null;
-    content: { widgetCount: number; renderer: ComponentType };
+    contentSource: {} | { type: string } | null;
+    content: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     layout: LayoutEnum;
     showPagination: boolean;
     activeSlideAlignment: ActiveSlideAlignmentEnum;

--- a/packages/pluggableWidgets/line-chart-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/line-chart-native/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+All notable changes to this widget will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Fixed
+- We have fixed the data source consistency check for MX 9.2 and above.

--- a/packages/pluggableWidgets/line-chart-native/package.json
+++ b/packages/pluggableWidgets/line-chart-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "line-chart-native",
   "widgetName": "LineChart",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/pluggableWidgets/line-chart-native/src/LineChart.editorConfig.ts
+++ b/packages/pluggableWidgets/line-chart-native/src/LineChart.editorConfig.ts
@@ -33,8 +33,10 @@ export function check(values: LineChartPreviewProps): Problem[] {
 
     values.lines.forEach((lines, index) => {
         if (lines.dataSet === "static") {
-            // @ts-ignore
-            if (lines.staticDataSource.type === "null") {
+            if (
+                !lines.staticDataSource ||
+                ("type" in lines.staticDataSource && lines.staticDataSource.type === "null")
+            ) {
                 errors.push({
                     property: `lines/${index + 1}/staticDataSource`,
                     severity: "error",
@@ -58,8 +60,10 @@ export function check(values: LineChartPreviewProps): Problem[] {
                 });
             }
         } else {
-            // @ts-ignore
-            if (lines.dynamicDataSource.type === "null") {
+            if (
+                !lines.dynamicDataSource ||
+                ("type" in lines.dynamicDataSource && lines.dynamicDataSource.type === "null")
+            ) {
                 errors.push({
                     property: `lines/${index + 1}/dynamicDataSource`,
                     severity: "error",

--- a/packages/pluggableWidgets/line-chart-native/src/package.xml
+++ b/packages/pluggableWidgets/line-chart-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="LineChart" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="LineChart" version="1.0.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="LineChart.xml"/>
         </widgetFiles>

--- a/packages/pluggableWidgets/line-chart-native/typings/LineChartProps.d.ts
+++ b/packages/pluggableWidgets/line-chart-native/typings/LineChartProps.d.ts
@@ -34,8 +34,8 @@ export interface LinesType {
 
 export interface LinesPreviewType {
     dataSet: DataSetEnum;
-    staticDataSource: {} | null;
-    dynamicDataSource: {} | null;
+    staticDataSource: {} | { type: string } | null;
+    dynamicDataSource: {} | { type: string } | null;
     groupByAttribute: string;
     staticName: string;
     dynamicName: string;

--- a/packages/pluggableWidgets/maps-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/maps-native/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this widget will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- We have fixed the dynamic marker data source consistency check for MX 9.2 and above.
 
 ### Added
 - Structure preview for maps

--- a/packages/pluggableWidgets/maps-native/package.json
+++ b/packages/pluggableWidgets/maps-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maps-native",
   "widgetName": "Maps",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
+++ b/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
@@ -128,7 +128,7 @@ export function check(values: MapsPreviewProps): Problem[] {
     });
 
     values.dynamicMarkers.forEach((marker, index) => {
-        if (marker.markersDS === {} || marker.markersDS === null) {
+        if (!marker.markersDS || ("type" in marker.markersDS && marker.markersDS.type === "null")) {
             errors.push({
                 property: `dynamicMarkers/${index + 1}/markersDS`,
                 message: "A data source should be selected in order to retrieve a list of markers"

--- a/packages/pluggableWidgets/maps-native/src/package.xml
+++ b/packages/pluggableWidgets/maps-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Maps" version="2.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Maps" version="2.1.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Maps.xml"/>
         </widgetFiles>

--- a/packages/pluggableWidgets/maps-native/typings/MapsProps.d.ts
+++ b/packages/pluggableWidgets/maps-native/typings/MapsProps.d.ts
@@ -61,7 +61,7 @@ export interface MarkersPreviewType {
 }
 
 export interface DynamicMarkersPreviewType {
-    markersDS: {} | null;
+    markersDS: {} | { type: string } | null;
     locationType: LocationTypeEnum;
     address: string;
     latitude: string;


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fix native widgets datasource preview typings & usage due to datasource preview api change in MX 9.2 (PAG-1400).

## Relevant changes
- Adjust data source preview typings of: carousel, maps, line chart & bar chart.
- Fix consistency checks for: maps, line chart & bar chart.

## What should be covered while testing?
Test data source consistency checks before and after/on MX 9.2.

## Extra comments
PR #736 should be merged before merging this PR to master.
