### PR TITLE
[WC-651] Make headers composable and introduce custom icons

### DIFF
--- a/packages/pluggableWidgets/tree-view-web/src/TreeView.editorConfig.ts
+++ b/packages/pluggableWidgets/tree-view-web/src/TreeView.editorConfig.ts
@@ -1,5 +1,6 @@
 import {
     hidePropertiesIn,
+    hidePropertyIn,
     Properties,
     StructurePreviewProps,
     transformGroupsIntoTabs
@@ -11,9 +12,16 @@ export function getProperties(
     defaultProperties: Properties,
     platform: "web" | "desktop"
 ): Properties {
+    if (values.headerType === "text") {
+        hidePropertyIn(defaultProperties, values, "headerContent");
+    } else if (values.headerType === "custom") {
+        hidePropertyIn(defaultProperties, values, "headerCaption");
+    }
+
     if (!values.hasChildren) {
         hidePropertiesIn(defaultProperties, values, ["startExpanded", "children"]);
     }
+
     if (platform === "web") {
         transformGroupsIntoTabs(defaultProperties);
     }

--- a/packages/pluggableWidgets/tree-view-web/src/TreeView.editorConfig.ts
+++ b/packages/pluggableWidgets/tree-view-web/src/TreeView.editorConfig.ts
@@ -12,6 +12,14 @@ export function getProperties(
     defaultProperties: Properties,
     platform: "web" | "desktop"
 ): Properties {
+    if (!values.advancedMode) {
+        hidePropertiesIn(defaultProperties, values, ["showIcon", "expandIcon", "collapseIcon"]);
+    }
+
+    if (values.showIcon === "no") {
+        hidePropertiesIn(defaultProperties, values, ["expandIcon", "collapseIcon"]);
+    }
+
     if (values.headerType === "text") {
         hidePropertyIn(defaultProperties, values, "headerContent");
     } else if (values.headerType === "custom") {

--- a/packages/pluggableWidgets/tree-view-web/src/TreeView.tsx
+++ b/packages/pluggableWidgets/tree-view-web/src/TreeView.tsx
@@ -8,7 +8,8 @@ export function TreeView(props: TreeViewContainerProps): ReactElement {
         props.datasource.items?.map(item => {
             return {
                 id: item.id,
-                value: props.headerCaption?.get(item).value,
+                value:
+                    props.headerType === "text" ? props.headerCaption?.get(item).value : props.headerContent?.get(item),
                 content: props.children?.get(item)
             };
         }) ?? [];

--- a/packages/pluggableWidgets/tree-view-web/src/TreeView.tsx
+++ b/packages/pluggableWidgets/tree-view-web/src/TreeView.tsx
@@ -1,4 +1,5 @@
 import { createElement, ReactElement } from "react";
+import { ValueStatus } from "mendix";
 import { TreeViewContainerProps } from "../typings/TreeViewProps";
 import { TreeView as TreeViewComponent } from "./components/TreeView";
 
@@ -14,6 +15,9 @@ export function TreeView(props: TreeViewContainerProps): ReactElement {
             };
         }) ?? [];
 
+    const expandIcon = props.expandIcon?.status === ValueStatus.Available ? props.expandIcon.value : null;
+    const collapseIcon = props.collapseIcon?.status === ValueStatus.Available ? props.collapseIcon.value : null;
+
     return (
         <TreeViewComponent
             name={props.name}
@@ -22,6 +26,10 @@ export function TreeView(props: TreeViewContainerProps): ReactElement {
             items={items}
             isUserDefinedLeafNode={!props.hasChildren}
             startExpanded={props.startExpanded}
+            showCustomIcon={props.advancedMode}
+            iconPlacement={props.showIcon}
+            expandIcon={expandIcon}
+            collapseIcon={collapseIcon}
         />
     );
 }

--- a/packages/pluggableWidgets/tree-view-web/src/TreeView.tsx
+++ b/packages/pluggableWidgets/tree-view-web/src/TreeView.tsx
@@ -8,7 +8,7 @@ export function TreeView(props: TreeViewContainerProps): ReactElement {
         props.datasource.items?.map(item => {
             return {
                 id: item.id,
-                value: props.caption?.get(item).value,
+                value: props.headerCaption?.get(item).value,
                 content: props.children?.get(item)
             };
         }) ?? [];

--- a/packages/pluggableWidgets/tree-view-web/src/TreeView.xml
+++ b/packages/pluggableWidgets/tree-view-web/src/TreeView.xml
@@ -12,7 +12,7 @@
                 <description/>
             </property>
             <!-- TODO: Dynamic headers -->
-            <property key="caption" type="textTemplate" dataSource="datasource" required="false">
+            <property key="headerCaption" type="textTemplate" dataSource="datasource" required="false">
                 <caption>Header caption</caption>
                 <description/>
             </property>

--- a/packages/pluggableWidgets/tree-view-web/src/TreeView.xml
+++ b/packages/pluggableWidgets/tree-view-web/src/TreeView.xml
@@ -11,7 +11,18 @@
                 <caption>Data source</caption>
                 <description/>
             </property>
-            <!-- TODO: Dynamic headers -->
+            <property key="headerType" type="enumeration" defaultValue="text">
+                <caption>Header type</caption>
+                <description />
+                <enumerationValues>
+                    <enumerationValue key="text">Text</enumerationValue>
+                    <enumerationValue key="custom">Custom</enumerationValue>
+                </enumerationValues>
+            </property>
+            <property key="headerContent" type="widgets" dataSource="datasource" required="false">
+                <caption>Header</caption>
+                <description/>
+            </property>
             <property key="headerCaption" type="textTemplate" dataSource="datasource" required="false">
                 <caption>Header caption</caption>
                 <description/>

--- a/packages/pluggableWidgets/tree-view-web/src/TreeView.xml
+++ b/packages/pluggableWidgets/tree-view-web/src/TreeView.xml
@@ -7,38 +7,40 @@
     <icon>iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAABnlBMVEUAAAD///+A//9V//+Av/9mzP9gv/9Vxv9Ns/9duf9Vv/9Osf9Jtv9Vu/9Qv/9LtP9RvP9Jtv9Osf9Ktf9Ms/9Puf9Ns/9Ktf9Ms/hKtfhOsfhNs/lLtPlLtPlKtflIsflMs/pJsfpNs/pIsvpKsPpLtPtKsftJsvtJsvdJs/hLtPhKsfhJsvhXV1dLsflKsvlKsvlKsvlKsvpKsvdKs/dJsfdIsvhKsPhJsfhKsPhJsvhKsfhIsPlKsflJsPlKsflIsflJsvdKsvdJsfhJsPhJsfhKsvhIsvhJsfhIsPhKsfhJsvlJsfdJsfdIsPdKsfdJsfdJsfdIsfdIsfhIsfhIsfhJsfhJsfhIsPhJsPhIsfhJsfdJsfdJsfdJsfdIsPdJsfdJsPhIsfhJsfhIsfhJsfhIsfhJsfhJsPhJsfhJsfhIsfhIsPhJsfdIsPdJsPdVVVVJsfdJsfdJsfdIsPdJsfdIsPdIsPdJsfhJsPhIsPhJsfhIsPhIsfhJsfhJsPhIsfhJsfhJsPhIsPhIsfhJsPhJsPhIsfhIsPdVVVU8lPiOAAAAiHRSTlMAAQIDBAUICQoLDA0ODxARExUXGBsdHh8lJicoKSwtLi8xMjU3PT4/QkZHSElJUlNWWV1gZGVqa2xucHV4eXt8f4SHiYuMjpGTm5yeoKGio6SnqaqtsbO2uLm+wMHEyMnLzM3O0NHU1dba3d7f4eLj4+Tn6Onr7O3u7/Dy8/T19vf4+fr7/P3+LOCsiQAAAeRJREFUeAHt1/lTEmEYwPHHhYyiLEjtPtLu0siOsLL7MLtNOjRLs8MyU7Q7K4hyv/7Xve/sLrAzArPvMFPT7Oen9wf4MsDz7OyKI9QxvWBgukM8Ru9XBfEsGKpvQAL6/wORY48+5ieu7zIN7HiG4+5yo0B7Hs/oMoNA4i0lN4IHkreA+Ssbmva/BOztAQP7nqL1iBJ7BfQGCxy30WYt0Q4C44ECbb9Qih+7BpgLFLgN2BOF0WbTQBboFEsUs6/wDXBnx+xHfAKcXuKcV5j8jZdwmQ7SqhlcpqO8e5Yi/zJt6ZvMTfXvrBWQRO+YOws/feucLqDZFwwvKJ02rrRRIPkBz/dmk8AAkDsU3/sJuGkQSKGcVIejgN1eM9DYfX/yx+uH3S3iSLwHHkfUyXoODNcKdGVx/L62VrR+IL9JtD0oqaoB6yIlubS7UpwSRwZ401gl0HAHn0xs9TtgJCKOdQWgp0rgPEr+3PrYxhMv0IYH9FBtFs9l4GuyYqALJeu83Dr8GdcZKWrSI9FXKdAyB0y1iqt1BI2xqJSkgfltFQL39Ki1SVF8CKWwVcpEx4HBxQMplCNSZukgcFZ8DqAsGojPAEMNUm5l5svVqPg9cAP/2D1SeJcWBsLA398F84euOj32hf4AR3v7uNFLZj0AAAAASUVORK5CYII=</icon>
     <properties>
         <propertyGroup caption="General">
-            <property key="datasource" type="datasource" isList="true">
-                <caption>Data source</caption>
-                <description/>
-            </property>
-            <property key="headerType" type="enumeration" defaultValue="text">
-                <caption>Header type</caption>
-                <description />
-                <enumerationValues>
-                    <enumerationValue key="text">Text</enumerationValue>
-                    <enumerationValue key="custom">Custom</enumerationValue>
-                </enumerationValues>
-            </property>
-            <property key="headerContent" type="widgets" dataSource="datasource" required="false">
-                <caption>Header</caption>
-                <description/>
-            </property>
-            <property key="headerCaption" type="textTemplate" dataSource="datasource" required="false">
-                <caption>Header caption</caption>
-                <description/>
-            </property>
-            <property key="hasChildren" type="boolean" defaultValue="false">
-                <caption>Has children</caption>
-                <description/>
-            </property>
-            <property key="startExpanded" type="boolean" defaultValue="false">
-                <caption>Start state expanded</caption>
-                <description/>
-            </property>
-            <property key="children" type="widgets" dataSource="datasource" required="false">
-                <caption>Content</caption>
-                <description />
-            </property>
+            <propertyGroup caption="General">
+                <property key="datasource" type="datasource" isList="true">
+                    <caption>Data source</caption>
+                    <description/>
+                </property>
+                <property key="headerType" type="enumeration" defaultValue="text">
+                    <caption>Header type</caption>
+                    <description />
+                    <enumerationValues>
+                        <enumerationValue key="text">Text</enumerationValue>
+                        <enumerationValue key="custom">Custom</enumerationValue>
+                    </enumerationValues>
+                </property>
+                <property key="headerContent" type="widgets" dataSource="datasource" required="false">
+                    <caption>Header</caption>
+                    <description/>
+                </property>
+                <property key="headerCaption" type="textTemplate" dataSource="datasource" required="false">
+                    <caption>Header caption</caption>
+                    <description/>
+                </property>
+                <property key="hasChildren" type="boolean" defaultValue="false">
+                    <caption>Has children</caption>
+                    <description/>
+                </property>
+                <property key="startExpanded" type="boolean" defaultValue="false">
+                    <caption>Start state expanded</caption>
+                    <description/>
+                </property>
+                <property key="children" type="widgets" dataSource="datasource" required="false">
+                    <caption>Content</caption>
+                    <description />
+                </property>
+            </propertyGroup>
         </propertyGroup>
     </properties>
 </widget>

--- a/packages/pluggableWidgets/tree-view-web/src/TreeView.xml
+++ b/packages/pluggableWidgets/tree-view-web/src/TreeView.xml
@@ -42,5 +42,32 @@
                 </property>
             </propertyGroup>
         </propertyGroup>
+        <propertyGroup caption="Visualization">
+            <propertyGroup caption="Icon">
+                <property key="showIcon" type="enumeration" defaultValue="right">
+                    <caption>Show icon</caption>
+                    <description/>
+                    <enumerationValues>
+                        <enumerationValue key="right">Right</enumerationValue>
+                        <enumerationValue key="left">Left</enumerationValue>
+                        <enumerationValue key="no">No</enumerationValue>
+                    </enumerationValues>
+                </property>
+                <property key="expandIcon" type="icon" required="false">
+                    <caption>Expand icon</caption>
+                    <description/>
+                </property>
+                <property key="collapseIcon" type="icon" required="false">
+                    <caption>Collapse icon</caption>
+                    <description/>
+                </property>
+            </propertyGroup>
+        </propertyGroup>
+        <propertyGroup caption="Advanced">
+            <property key="advancedMode" type="boolean" defaultValue="false">
+                <caption>Advanced options</caption>
+                <description/>
+            </property>
+        </propertyGroup>
     </properties>
 </widget>

--- a/packages/pluggableWidgets/tree-view-web/src/components/Icon.tsx
+++ b/packages/pluggableWidgets/tree-view-web/src/components/Icon.tsx
@@ -1,0 +1,21 @@
+import { createElement, ReactElement } from "react";
+import classNames from "classnames";
+import { WebIcon } from "mendix";
+
+interface IconProps {
+    icon: WebIcon | null;
+    className?: string;
+}
+
+export function Icon({ icon, className = "" }: IconProps): ReactElement | null {
+    if (!icon) {
+        return null;
+    }
+    if (icon.type === "glyph") {
+        return <span className={classNames("glyphicon", icon.iconClass, className)} aria-hidden />;
+    }
+    if (icon.type === "image") {
+        return <img className={className} src={icon.iconUrl} aria-hidden alt="" />;
+    }
+    return null;
+}

--- a/packages/pluggableWidgets/tree-view-web/src/components/TreeView.tsx
+++ b/packages/pluggableWidgets/tree-view-web/src/components/TreeView.tsx
@@ -6,7 +6,7 @@ import "../ui/TreeView.scss";
 
 interface TreeViewObject {
     id: GUID;
-    value: string | undefined;
+    value: string | ReactNode | undefined;
     content: ReactNode;
 }
 

--- a/packages/pluggableWidgets/tree-view-web/src/components/__tests__/TreeView.spec.tsx
+++ b/packages/pluggableWidgets/tree-view-web/src/components/__tests__/TreeView.spec.tsx
@@ -42,6 +42,21 @@ describe("TreeView", () => {
         expect(treeViewBranches.at(2).text()).not.toContain("Third content");
     });
 
+    it("handles tree headers properly even if they are composed with widgets", () => {
+        const newItems = [
+            ...items,
+            { id: "44" as GUID, value: <div>This is the 44 header</div>, content: <div>Fourth content</div> }
+        ];
+        const treeView = mount(<TreeView class="" items={newItems} isUserDefinedLeafNode={false} startExpanded />);
+
+        // There is not really another way to properly identify that we're dealing with tree view branches.
+        const treeViewBranches = treeView.find(".widget-tree-view-branch");
+        expect(treeViewBranches).toHaveLength(newItems.length);
+
+        expect(treeViewBranches.at(3).html()).toContain("<div>This is the 44 header</div>");
+        expect(treeViewBranches.at(3).text()).toContain("Fourth content");
+    });
+
     it("shows the tree view headers in the correct order as a button when not defined as a leaf node", () => {
         const treeView = mount(<TreeView class="" items={items} isUserDefinedLeafNode={false} startExpanded={false} />);
 

--- a/packages/pluggableWidgets/tree-view-web/src/components/__tests__/TreeView.spec.tsx
+++ b/packages/pluggableWidgets/tree-view-web/src/components/__tests__/TreeView.spec.tsx
@@ -1,6 +1,6 @@
 import { GUID } from "mendix";
 import { createElement } from "react";
-import { mount } from "enzyme";
+import { mount, ReactWrapper } from "enzyme";
 import { TreeView, TreeViewProps } from "../TreeView";
 
 const items: TreeViewProps["items"] = [
@@ -9,9 +9,23 @@ const items: TreeViewProps["items"] = [
     { id: "33" as GUID, value: "Third header", content: <div>Third content</div> }
 ];
 
+const defaultProps: TreeViewProps = {
+    name: "",
+    class: "",
+    items: [],
+    isUserDefinedLeafNode: false,
+    startExpanded: false,
+    showCustomIcon: false,
+    iconPlacement: "right",
+    expandIcon: null,
+    collapseIcon: null
+};
+
 describe("TreeView", () => {
     it("shows everything properly when starting expanded", () => {
-        const treeView = mount(<TreeView class="" items={items} isUserDefinedLeafNode={false} startExpanded />);
+        const treeView = mount(
+            <TreeView {...defaultProps} class="" items={items} isUserDefinedLeafNode={false} startExpanded />
+        );
 
         // There is not really another way to properly identify that we're dealing with tree view branches.
         const treeViewBranches = treeView.find(".widget-tree-view-branch");
@@ -27,7 +41,9 @@ describe("TreeView", () => {
     });
 
     it("does not show the tree view item content when not starting expanded", () => {
-        const treeView = mount(<TreeView class="" items={items} isUserDefinedLeafNode={false} startExpanded={false} />);
+        const treeView = mount(
+            <TreeView {...defaultProps} class="" items={items} isUserDefinedLeafNode={false} startExpanded={false} />
+        );
 
         // There is not really another way to properly identify that we're dealing with tree view branches.
         const treeViewBranches = treeView.find(".widget-tree-view-branch");
@@ -47,7 +63,9 @@ describe("TreeView", () => {
             ...items,
             { id: "44" as GUID, value: <div>This is the 44 header</div>, content: <div>Fourth content</div> }
         ];
-        const treeView = mount(<TreeView class="" items={newItems} isUserDefinedLeafNode={false} startExpanded />);
+        const treeView = mount(
+            <TreeView {...defaultProps} class="" items={newItems} isUserDefinedLeafNode={false} startExpanded />
+        );
 
         // There is not really another way to properly identify that we're dealing with tree view branches.
         const treeViewBranches = treeView.find(".widget-tree-view-branch");
@@ -58,7 +76,9 @@ describe("TreeView", () => {
     });
 
     it("shows the tree view headers in the correct order as a button when not defined as a leaf node", () => {
-        const treeView = mount(<TreeView class="" items={items} isUserDefinedLeafNode={false} startExpanded={false} />);
+        const treeView = mount(
+            <TreeView {...defaultProps} class="" items={items} isUserDefinedLeafNode={false} startExpanded={false} />
+        );
 
         const treeViewHeaders = treeView.find('[role="button"]');
 
@@ -69,7 +89,9 @@ describe("TreeView", () => {
     });
 
     it("does not render the tree view headers as a button when defined as a leaf node", () => {
-        const treeView = mount(<TreeView class="" items={items} isUserDefinedLeafNode startExpanded={false} />);
+        const treeView = mount(
+            <TreeView {...defaultProps} class="" items={items} isUserDefinedLeafNode startExpanded={false} />
+        );
 
         const treeViewHeaders = treeView.find('[role="button"]');
 
@@ -80,7 +102,9 @@ describe("TreeView", () => {
     });
 
     it("correctly collapses and expands the tree view branch content when clicking on the header", () => {
-        const treeView = mount(<TreeView class="" items={items} isUserDefinedLeafNode={false} startExpanded={false} />);
+        const treeView = mount(
+            <TreeView {...defaultProps} class="" items={items} isUserDefinedLeafNode={false} startExpanded={false} />
+        );
 
         expect(treeView.text()).not.toContain("Second content");
 
@@ -98,7 +122,9 @@ describe("TreeView", () => {
     });
 
     it("correctly collapses and expands the tree view branch content when interacting through the keyboard", () => {
-        const treeView = mount(<TreeView class="" items={items} isUserDefinedLeafNode={false} startExpanded={false} />);
+        const treeView = mount(
+            <TreeView {...defaultProps} class="" items={items} isUserDefinedLeafNode={false} startExpanded={false} />
+        );
 
         expect(treeView.text()).not.toContain("Second content");
 
@@ -113,5 +139,47 @@ describe("TreeView", () => {
         // collapse
         secondTreeViewHeader.simulate("keydown", { key: " " });
         expect(treeView.text()).not.toContain("Second content");
+    });
+
+    it("shows custom the expand and close icon accordingly", () => {
+        const treeView = mount(
+            <TreeView
+                {...defaultProps}
+                class=""
+                items={items}
+                isUserDefinedLeafNode={false}
+                startExpanded={false}
+                showCustomIcon
+                expandIcon={{ type: "glyph", iconClass: "expand-icon" }}
+                collapseIcon={{ type: "image", iconUrl: "collapse-image" }}
+            />
+        );
+
+        // There is not really another way to properly identify that we're dealing with tree view branches.
+        const treeViewBranches = treeView.find(".widget-tree-view-branch");
+        const firstTreeViewBranchHeader = treeViewBranches.at(0).find("header");
+
+        expect(firstTreeViewBranchHeader).toHaveLength(1);
+        expect(firstTreeViewBranchHeader.text()).toContain("First header");
+
+        function getExpandIconFromBranchHeader(header: ReactWrapper<any>): ReactWrapper<any> {
+            return header.findWhere(
+                node => node.type() === "span" && node.hasClass("glyphicon") && node.hasClass("expand-icon")
+            );
+        }
+
+        function getCollapseImageFromBranchHeader(header: ReactWrapper<any>): ReactWrapper<any> {
+            return header.findWhere(node => node.type() === "img" && node.prop("src") === "collapse-image");
+        }
+
+        expect(getExpandIconFromBranchHeader(firstTreeViewBranchHeader)).toHaveLength(1);
+        expect(getCollapseImageFromBranchHeader(firstTreeViewBranchHeader)).toHaveLength(0);
+
+        firstTreeViewBranchHeader.simulate("click");
+
+        const updatedFirstHeader = treeView.find(".widget-tree-view-branch").at(0).find("header");
+
+        expect(getExpandIconFromBranchHeader(updatedFirstHeader)).toHaveLength(0);
+        expect(getCollapseImageFromBranchHeader(updatedFirstHeader)).toHaveLength(1);
     });
 });

--- a/packages/pluggableWidgets/tree-view-web/src/ui/TreeView.scss
+++ b/packages/pluggableWidgets/tree-view-web/src/ui/TreeView.scss
@@ -4,20 +4,31 @@
     display: flex;
     flex-direction: column;
 
-    .widget-tree-view-header-clickable {
+    .widget-tree-view-branch-header-clickable {
         cursor: pointer;
     }
 
-    .widget-tree-view-header {
+    .widget-tree-view-branch-header {
         display: flex;
         flex-direction: row;
         justify-content: space-between;
+        align-items: center;
         margin: 0;
         padding: 8px 0;
+
+        .glyphicon.widget-tree-view-branch-header-icon {
+            font-size: 16px;
+        }
     }
 
-    h2 {
+    .widget-tree-view-branch-header-reversed {
+        flex-direction: row-reverse;
+    }
+
+    .widget-tree-view-branch-header-value {
+        flex: 1;
         font-size: 16px;
+        margin: 0 8px;
     }
 
     .widget-tree-view-body {

--- a/packages/pluggableWidgets/tree-view-web/typings/TreeViewProps.d.ts
+++ b/packages/pluggableWidgets/tree-view-web/typings/TreeViewProps.d.ts
@@ -4,9 +4,11 @@
  * @author Mendix UI Content Team
  */
 import { ComponentType, CSSProperties } from "react";
-import { ListValue, ListExpressionValue, ListWidgetValue } from "mendix";
+import { DynamicValue, ListValue, ListExpressionValue, ListWidgetValue, WebIcon } from "mendix";
 
 export type HeaderTypeEnum = "text" | "custom";
+
+export type ShowIconEnum = "right" | "left" | "no";
 
 export interface TreeViewContainerProps {
     name: string;
@@ -20,6 +22,10 @@ export interface TreeViewContainerProps {
     hasChildren: boolean;
     startExpanded: boolean;
     children?: ListWidgetValue;
+    showIcon: ShowIconEnum;
+    expandIcon?: DynamicValue<WebIcon>;
+    collapseIcon?: DynamicValue<WebIcon>;
+    advancedMode: boolean;
 }
 
 export interface TreeViewPreviewProps {
@@ -32,4 +38,8 @@ export interface TreeViewPreviewProps {
     hasChildren: boolean;
     startExpanded: boolean;
     children: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
+    showIcon: ShowIconEnum;
+    expandIcon: { type: "glyph"; iconClass: string; } | { type: "image"; imageUrl: string; } | null;
+    collapseIcon: { type: "glyph"; iconClass: string; } | { type: "image"; imageUrl: string; } | null;
+    advancedMode: boolean;
 }

--- a/packages/pluggableWidgets/tree-view-web/typings/TreeViewProps.d.ts
+++ b/packages/pluggableWidgets/tree-view-web/typings/TreeViewProps.d.ts
@@ -6,12 +6,16 @@
 import { ComponentType, CSSProperties } from "react";
 import { ListValue, ListExpressionValue, ListWidgetValue } from "mendix";
 
+export type HeaderTypeEnum = "text" | "custom";
+
 export interface TreeViewContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
     tabIndex?: number;
     datasource: ListValue;
+    headerType: HeaderTypeEnum;
+    headerContent?: ListWidgetValue;
     headerCaption?: ListExpressionValue<string>;
     hasChildren: boolean;
     startExpanded: boolean;
@@ -22,6 +26,8 @@ export interface TreeViewPreviewProps {
     class: string;
     style: string;
     datasource: {} | { type: string } | null;
+    headerType: HeaderTypeEnum;
+    headerContent: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     headerCaption: string;
     hasChildren: boolean;
     startExpanded: boolean;

--- a/packages/pluggableWidgets/tree-view-web/typings/TreeViewProps.d.ts
+++ b/packages/pluggableWidgets/tree-view-web/typings/TreeViewProps.d.ts
@@ -12,7 +12,7 @@ export interface TreeViewContainerProps {
     style?: CSSProperties;
     tabIndex?: number;
     datasource: ListValue;
-    caption?: ListExpressionValue<string>;
+    headerCaption?: ListExpressionValue<string>;
     hasChildren: boolean;
     startExpanded: boolean;
     children?: ListWidgetValue;
@@ -22,7 +22,7 @@ export interface TreeViewPreviewProps {
     class: string;
     style: string;
     datasource: {} | { type: string } | null;
-    caption: string;
+    headerCaption: string;
     hasChildren: boolean;
     startExpanded: boolean;
     children: { widgetCount: number; renderer: ComponentType<{caption?: string}> };


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅ 
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
- Make headers composable, exactly the same as accordion (2nd commit)
- allow configuration of custom icons and placement, similar to accordion (4th commit)
- group General widget properties into another group for Studio (3rd commit)