### PR TITLE
fix: Align image preview props type (9.5!)

### DIFF
--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
@@ -21,7 +21,7 @@ export interface ActionsPreviewType {
     name: string;
     enabled: boolean;
     action: {} | null;
-    image: string;
+    image: { type: "static"; imageUrl: string; } | { type: "dynamic"; entity: string; } | null;
 }
 
 export interface MyWidgetProps<Style> {
@@ -54,7 +54,7 @@ export interface MyWidgetPreviewProps {
     mywidgetType: MywidgetTypeEnum;
     tries: number | null;
     amount: number | null;
-    image: string;
+    image: { type: "static"; imageUrl: string; } | { type: "dynamic"; entity: string; } | null;
     onClickAction: {} | null;
     onChange: {} | null;
     actions: ActionsPreviewType[];
@@ -85,7 +85,7 @@ export interface ActionsPreviewType {
     name: string;
     enabled: boolean;
     action: {} | null;
-    image: string;
+    image: { type: "static"; imageUrl: string; } | { type: "dynamic"; entity: string; } | null;
 }
 
 export interface MyWidgetContainerProps {
@@ -120,7 +120,7 @@ export interface MyWidgetPreviewProps {
     mywidgetType: MywidgetTypeEnum;
     tries: number | null;
     amount: number | null;
-    image: string;
+    image: { type: "static"; imageUrl: string; } | { type: "dynamic"; entity: string; } | null;
     onClickAction: {} | null;
     onChange: {} | null;
     actions: ActionsPreviewType[];
@@ -151,7 +151,7 @@ export interface ActionsPreviewType {
     name: string;
     enabled: boolean;
     action: {} | null;
-    image: string;
+    image: { type: "static"; imageUrl: string; } | { type: "dynamic"; entity: string; } | null;
 }
 
 export interface MyWidgetContainerProps {
@@ -187,7 +187,7 @@ export interface MyWidgetPreviewProps {
     mywidgetType: MywidgetTypeEnum;
     tries: number | null;
     amount: number | null;
-    image: string;
+    image: { type: "static"; imageUrl: string; } | { type: "dynamic"; entity: string; } | null;
     onClickAction: {} | null;
     onChange: {} | null;
     actions: ActionsPreviewType[];

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
@@ -11,7 +11,7 @@ export interface ActionsType {
 }
 
 export interface ActionsPreviewType {
-    image: string;
+    image: { type: "static"; imageUrl: string; } | { type: "dynamic"; entity: string; } | null;
 }
 
 export interface MyWidgetContainerProps {

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
@@ -31,7 +31,7 @@ function toPreviewPropType(prop: Property, generatedTypes: string[]): string {
         case "icon":
             return '{ type: "glyph"; iconClass: string; } | { type: "image"; imageUrl: string; } | null';
         case "image":
-            return "string";
+            return '{ type: "static"; imageUrl: string; } | { type: "dynamic"; entity: string; } | null';
         case "file":
             return "string";
         case "datasource":


### PR DESCRIPTION
## This PR contains
- [X] Bug fix

## What is the purpose of this PR?
Align the image preview props type with what's passed from Studio Pro 9.5 on. Studio already used to do this, and the docs also stated so. Instead of a string, we're now passing an object with a type and either imageUrl or entity.
JIRA-issue: https://mendix.atlassian.net/browse/PAG-1579

## Extra comments (optional)
I changed the test files manually. Hope that's how I was supposed to do it 😅. Also, once this is done, the `editorPreview` of imageViewer can be fixed properly (which now hacks around this misalignment).
And let op: 9.5 will still take a while.

Thanks guyz