### PR TITLE
[WC-354] Add lazy loading for tree view nodes

### DIFF
--- a/packages/pluggableWidgets/tree-view-web/src/TreeView.editorConfig.ts
+++ b/packages/pluggableWidgets/tree-view-web/src/TreeView.editorConfig.ts
@@ -26,6 +26,10 @@ export function getProperties(
         hidePropertyIn(defaultProperties, values, "headerCaption");
     }
 
+    if (values.shouldLazyLoad) {
+        hidePropertyIn(defaultProperties, values, "startExpanded");
+    }
+
     if (!values.hasChildren) {
         hidePropertiesIn(defaultProperties, values, ["startExpanded", "children"]);
     }

--- a/packages/pluggableWidgets/tree-view-web/src/TreeView.tsx
+++ b/packages/pluggableWidgets/tree-view-web/src/TreeView.tsx
@@ -28,6 +28,7 @@ export function TreeView(props: TreeViewContainerProps): ReactElement {
             style={props.style}
             items={items}
             isUserDefinedLeafNode={!props.hasChildren}
+            shouldLazyLoad={props.shouldLazyLoad}
             startExpanded={props.startExpanded}
             showCustomIcon={props.advancedMode}
             iconPlacement={props.showIcon}

--- a/packages/pluggableWidgets/tree-view-web/src/TreeView.tsx
+++ b/packages/pluggableWidgets/tree-view-web/src/TreeView.tsx
@@ -30,7 +30,7 @@ export function TreeView(props: TreeViewContainerProps): ReactElement {
             isUserDefinedLeafNode={!props.hasChildren}
             shouldLazyLoad={props.shouldLazyLoad}
             startExpanded={props.startExpanded}
-            showCustomIcon={props.advancedMode}
+            showCustomIcon={props.advancedMode && (Boolean(props.expandIcon) || Boolean(props.collapseIcon))}
             iconPlacement={props.showIcon}
             expandIcon={expandIcon}
             collapseIcon={collapseIcon}

--- a/packages/pluggableWidgets/tree-view-web/src/TreeView.xml
+++ b/packages/pluggableWidgets/tree-view-web/src/TreeView.xml
@@ -32,6 +32,10 @@
                     <caption>Has children</caption>
                     <description/>
                 </property>
+                <property key="shouldLazyLoad" type="boolean" defaultValue="false">
+                    <caption>Lazy load</caption>
+                    <description/>
+                </property>
                 <property key="startExpanded" type="boolean" defaultValue="false">
                     <caption>Start state expanded</caption>
                     <description/>

--- a/packages/pluggableWidgets/tree-view-web/src/assets/loading-circle.svg
+++ b/packages/pluggableWidgets/tree-view-web/src/assets/loading-circle.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="10.5" stroke="#F8F8F8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<mask id="path-2-inside-1" fill="white">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 12.0524C0 18.6274 5.37258 24 12.0524 24C18.6274 24 24 18.6274 24 12.0524C24 5.37258 18.6274 0 12.0524 0"/>
+</mask>
+<path d="M24 12.0524L21 12.0524L24 12.0524ZM-3 12.0524C-3 20.3013 3.73282 27 12.0524 27V21C7.01235 21 3 16.9535 3 12.0524H-3ZM12.0524 27C20.2843 27 27 20.2843 27 12.0524L21 12.0524C21 16.9706 16.9706 21 12.0524 21V27ZM27 12.0524C27 3.73282 20.3013 -3 12.0524 -3V3C16.9535 3 21 7.01235 21 12.0524L27 12.0524Z" fill="#264AE5" mask="url(#path-2-inside-1)"/>
+</svg>

--- a/packages/pluggableWidgets/tree-view-web/src/components/TreeView.tsx
+++ b/packages/pluggableWidgets/tree-view-web/src/components/TreeView.tsx
@@ -19,6 +19,7 @@ import {
 } from "./TreeViewBranchContext";
 
 import "../ui/TreeView.scss";
+import loadingCircleSvg from "../assets/loading-circle.svg";
 
 export interface TreeViewObject extends ObjectItem {
     value: string | ReactNode | undefined;
@@ -52,6 +53,8 @@ export function TreeView({
     expandIcon,
     collapseIcon
 }: TreeViewProps): ReactElement | null {
+    const { childShouldShowPlaceholder: shouldShowPlaceholder } = useContext(TreeViewBranchContext);
+
     const renderHeaderIcon = useCallback<TreeViewBranchProps["renderHeaderIcon"]>(
         (treeViewIsExpanded: boolean) =>
             showCustomIcon ? (
@@ -87,7 +90,12 @@ export function TreeView({
     useInformParentContextToHaveChildNodes(items, isInsideAnotherTreeView);
 
     if (!items) {
-        return null;
+        return shouldShowPlaceholder ? (
+            <div className="widget-tree-view-lazy-loading-placeholder">
+                <img src={loadingCircleSvg} className="widget-tree-view-loading-spinner" alt="Loading spinner" />
+                <span className="widget-tree-view-placeholder-text">Loading...</span>
+            </div>
+        ) : null;
     }
 
     return (
@@ -187,7 +195,8 @@ function TreeViewBranch(props: TreeViewBranchProps): ReactElement {
                 <TreeViewBranchContext.Provider
                     value={{
                         level: currentContextLevel + 1,
-                        informParentToHaveChildNodes
+                        informParentToHaveChildNodes,
+                        childShouldShowPlaceholder: props.shouldLazyLoad
                     }}
                 >
                     <div

--- a/packages/pluggableWidgets/tree-view-web/src/components/TreeView.tsx
+++ b/packages/pluggableWidgets/tree-view-web/src/components/TreeView.tsx
@@ -139,20 +139,29 @@ function getTreeViewHeaderAccessibilityProps(isLeafNode: boolean): HTMLAttribute
 
 const treeViewBodyClassName = "widget-tree-view-body";
 
+const enum TreeViewState {
+    COLLAPSED_WITH_JS = "COLLAPSED_WITH_JS",
+    COLLAPSED_WITH_CSS = "COLLAPSED_WITH_CSS",
+    EXPANDED = "EXPANDED"
+}
+
 function TreeViewBranch(props: TreeViewBranchProps): ReactElement {
     const { level: currentContextLevel } = useContext(TreeViewBranchContext);
-    const [treeViewState, setTreeViewState] = useState<"COLLAPSED_WITH_JS" | "COLLAPSED_WITH_CSS" | "EXPANDED">(
-        !props.shouldLazyLoad && props.startExpanded ? "EXPANDED" : "COLLAPSED_WITH_JS"
+    const [treeViewState, setTreeViewState] = useState<TreeViewState>(
+        !props.shouldLazyLoad && props.startExpanded ? TreeViewState.EXPANDED : TreeViewState.COLLAPSED_WITH_JS
     );
     const [isActualLeafNode, setIsActualLeafNode] = useState<boolean>(props.isUserDefinedLeafNode || !props.children);
 
     const toggleTreeViewContent = useCallback(() => {
         if (!isActualLeafNode) {
             setTreeViewState(treeViewState => {
-                if (treeViewState === "COLLAPSED_WITH_JS" || treeViewState === "COLLAPSED_WITH_CSS") {
-                    return "EXPANDED";
+                if (
+                    treeViewState === TreeViewState.COLLAPSED_WITH_JS ||
+                    treeViewState === TreeViewState.COLLAPSED_WITH_CSS
+                ) {
+                    return TreeViewState.EXPANDED;
                 }
-                return props.shouldLazyLoad ? "COLLAPSED_WITH_CSS" : "COLLAPSED_WITH_JS";
+                return props.shouldLazyLoad ? TreeViewState.COLLAPSED_WITH_CSS : TreeViewState.COLLAPSED_WITH_JS;
             });
         }
     }, [isActualLeafNode, props.shouldLazyLoad]);
@@ -189,9 +198,9 @@ function TreeViewBranch(props: TreeViewBranchProps): ReactElement {
                 <span className="widget-tree-view-branch-header-value">{props.value}</span>
                 {!isActualLeafNode &&
                     props.iconPlacement !== "no" &&
-                    props.renderHeaderIcon(treeViewState === "EXPANDED")}
+                    props.renderHeaderIcon(treeViewState === TreeViewState.EXPANDED)}
             </header>
-            {!isActualLeafNode && treeViewState !== "COLLAPSED_WITH_JS" && (
+            {!isActualLeafNode && treeViewState !== TreeViewState.COLLAPSED_WITH_JS && (
                 <TreeViewBranchContext.Provider
                     value={{
                         level: currentContextLevel + 1,
@@ -201,7 +210,7 @@ function TreeViewBranch(props: TreeViewBranchProps): ReactElement {
                 >
                     <div
                         className={classNames(treeViewBodyClassName, {
-                            "widget-tree-view-branch-hidden": treeViewState === "COLLAPSED_WITH_CSS"
+                            "widget-tree-view-branch-hidden": treeViewState === TreeViewState.COLLAPSED_WITH_CSS
                         })}
                     >
                         {props.children}

--- a/packages/pluggableWidgets/tree-view-web/src/components/TreeViewBranchContext.ts
+++ b/packages/pluggableWidgets/tree-view-web/src/components/TreeViewBranchContext.ts
@@ -3,11 +3,13 @@ import { createContext, useContext, useEffect } from "react";
 export interface TreeViewBranchContextProps {
     level: number;
     informParentToHaveChildNodes: (hasChildNodes: boolean) => void;
+    childShouldShowPlaceholder: boolean;
 }
 
 export const TreeViewBranchContext = createContext<TreeViewBranchContextProps>({
     level: 0,
-    informParentToHaveChildNodes: () => null
+    informParentToHaveChildNodes: () => null,
+    childShouldShowPlaceholder: false
 });
 
 export const useInformParentContextToHaveChildNodes = (

--- a/packages/pluggableWidgets/tree-view-web/src/components/TreeViewBranchContext.ts
+++ b/packages/pluggableWidgets/tree-view-web/src/components/TreeViewBranchContext.ts
@@ -3,12 +3,14 @@ import { createContext, useContext, useEffect } from "react";
 export interface TreeViewBranchContextProps {
     level: number;
     informParentToHaveChildNodes: (hasChildNodes: boolean) => void;
+    informParentIsLoading: (isLoading: boolean) => void;
     childShouldShowPlaceholder: boolean;
 }
 
 export const TreeViewBranchContext = createContext<TreeViewBranchContextProps>({
     level: 0,
     informParentToHaveChildNodes: () => null,
+    informParentIsLoading: () => null,
     childShouldShowPlaceholder: false
 });
 

--- a/packages/pluggableWidgets/tree-view-web/src/components/__tests__/TreeView.spec.tsx
+++ b/packages/pluggableWidgets/tree-view-web/src/components/__tests__/TreeView.spec.tsx
@@ -14,6 +14,7 @@ const defaultProps: TreeViewProps = {
     class: "",
     items: [],
     isUserDefinedLeafNode: false,
+    shouldLazyLoad: false,
     startExpanded: false,
     showCustomIcon: false,
     iconPlacement: "right",

--- a/packages/pluggableWidgets/tree-view-web/src/components/__tests__/TreeView.spec.tsx
+++ b/packages/pluggableWidgets/tree-view-web/src/components/__tests__/TreeView.spec.tsx
@@ -325,4 +325,80 @@ describe("TreeView", () => {
         expect(treeViewHeader).toHaveLength(1);
         expect(treeViewHeader.getDOMNode().getAttribute("role")).not.toBe("button");
     });
+
+    describe("with lazy loading enabled", () => {
+        const itemsWithNestedTreeView: TreeViewProps["items"] = [
+            {
+                id: "11" as GUID,
+                value: "Parent treeview with a nested treeview that is filled",
+                content: (
+                    <TreeView
+                        {...defaultProps}
+                        class=""
+                        items={items}
+                        isUserDefinedLeafNode={false}
+                        startExpanded={false}
+                    />
+                )
+            }
+        ];
+
+        it("starts in the collapsed state", () => {
+            const treeView = mount(
+                <TreeView
+                    {...defaultProps}
+                    class=""
+                    items={itemsWithNestedTreeView}
+                    isUserDefinedLeafNode={false}
+                    startExpanded
+                    shouldLazyLoad
+                />
+            );
+            const clickableHeader = treeView.find("header").filter("[role='button']");
+            expect(clickableHeader).toHaveLength(1);
+            expect(treeView.text()).not.toContain("First header");
+        });
+
+        it("expands the nested tree view normally", () => {
+            const treeView = mount(
+                <TreeView
+                    {...defaultProps}
+                    class=""
+                    items={itemsWithNestedTreeView}
+                    isUserDefinedLeafNode={false}
+                    startExpanded
+                    shouldLazyLoad
+                />
+            );
+            const clickableHeader = treeView.find("header").filter("[role='button']");
+            expect(clickableHeader).toHaveLength(1);
+            expect(treeView.text()).not.toContain("First header");
+
+            clickableHeader.simulate("click");
+            expect(treeView.text()).toContain("First header");
+        });
+
+        it("collapses the nested treeview through CSS instead of JS after being expanded once", () => {
+            const treeView = mount(
+                <TreeView
+                    {...defaultProps}
+                    class=""
+                    items={itemsWithNestedTreeView}
+                    isUserDefinedLeafNode={false}
+                    startExpanded
+                    shouldLazyLoad
+                />
+            );
+            const clickableHeader = treeView.find("header").filter("[role='button']");
+            expect(clickableHeader).toHaveLength(1);
+            expect(treeView.text()).not.toContain("First header");
+
+            clickableHeader.simulate("click");
+            expect(treeView.text()).toContain("First header");
+
+            clickableHeader.simulate("click");
+            expect(treeView.text()).toContain("First header");
+            expect(treeView.find(".widget-tree-view-body").hasClass("widget-tree-view-branch-hidden")).toBe(true);
+        });
+    });
 });

--- a/packages/pluggableWidgets/tree-view-web/src/components/__tests__/TreeView.spec.tsx
+++ b/packages/pluggableWidgets/tree-view-web/src/components/__tests__/TreeView.spec.tsx
@@ -400,5 +400,69 @@ describe("TreeView", () => {
             expect(treeView.text()).toContain("First header");
             expect(treeView.find(".widget-tree-view-body").hasClass("widget-tree-view-branch-hidden")).toBe(true);
         });
+
+        function getLoadingSpinnerFromBranchHeader(header: ReactWrapper<any>): ReactWrapper<any> {
+            return header.findWhere(node => node.type() === "img" && node.hasClass("widget-tree-view-loading-spinner"));
+        }
+
+        it("shows a loading spinner icon when opening for the first time", () => {
+            const treeView = mount(
+                <TreeView
+                    {...defaultProps}
+                    {...customIconProps}
+                    class=""
+                    items={items}
+                    isUserDefinedLeafNode={false}
+                    startExpanded
+                    shouldLazyLoad
+                />
+            );
+
+            // There is not really another way to properly identify that we're dealing with tree view branches.
+            const treeViewBranches = treeView.find(".widget-tree-view-branch");
+            const firstTreeViewBranchHeader = treeViewBranches.at(0).find("header");
+
+            expect(firstTreeViewBranchHeader).toHaveLength(1);
+
+            expect(getExpandIconFromBranchHeader(firstTreeViewBranchHeader)).toHaveLength(1);
+            expect(getCollapseImageFromBranchHeader(firstTreeViewBranchHeader)).toHaveLength(0);
+
+            firstTreeViewBranchHeader.simulate("click");
+
+            const updatedFirstHeader = treeView.find(".widget-tree-view-branch").at(0).find("header");
+            expect(getExpandIconFromBranchHeader(updatedFirstHeader)).toHaveLength(0);
+            expect(getCollapseImageFromBranchHeader(updatedFirstHeader)).toHaveLength(0);
+            expect(getLoadingSpinnerFromBranchHeader(updatedFirstHeader)).toHaveLength(1);
+        });
+
+        it("the nested treeview should tell the parent it can change from the loading spinner to the next state", () => {
+            const treeView = mount(
+                <TreeView
+                    {...defaultProps}
+                    {...customIconProps}
+                    class=""
+                    items={itemsWithNestedTreeView}
+                    isUserDefinedLeafNode={false}
+                    startExpanded
+                    shouldLazyLoad
+                />
+            );
+
+            // There is not really another way to properly identify that we're dealing with tree view branches.
+            const treeViewBranches = treeView.find(".widget-tree-view-branch");
+            const firstTreeViewBranchHeader = treeViewBranches.at(0).find("header");
+
+            expect(firstTreeViewBranchHeader).toHaveLength(1);
+
+            expect(getExpandIconFromBranchHeader(firstTreeViewBranchHeader)).toHaveLength(1);
+            expect(getCollapseImageFromBranchHeader(firstTreeViewBranchHeader)).toHaveLength(0);
+
+            firstTreeViewBranchHeader.simulate("click");
+
+            const updatedFirstHeader = treeView.find(".widget-tree-view-branch").at(0).find("header");
+            expect(getExpandIconFromBranchHeader(updatedFirstHeader)).toHaveLength(0);
+            expect(getCollapseImageFromBranchHeader(updatedFirstHeader)).toHaveLength(1);
+            expect(getLoadingSpinnerFromBranchHeader(updatedFirstHeader)).toHaveLength(0);
+        });
     });
 });

--- a/packages/pluggableWidgets/tree-view-web/src/ui/TreeView.scss
+++ b/packages/pluggableWidgets/tree-view-web/src/ui/TreeView.scss
@@ -35,4 +35,8 @@
         padding-left: 12px;
         border-left: blue 1px solid;
     }
+
+    .widget-tree-view-branch-hidden {
+        display: none;
+    }
 }

--- a/packages/pluggableWidgets/tree-view-web/src/ui/TreeView.scss
+++ b/packages/pluggableWidgets/tree-view-web/src/ui/TreeView.scss
@@ -40,3 +40,30 @@
         display: none;
     }
 }
+
+.widget-tree-view-lazy-loading-placeholder {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-left: 9px;
+
+    .widget-tree-view-placeholder-text {
+        margin-left: 8px;
+        color: #264ae5;
+        font-size: 16px;
+    }
+
+    .widget-tree-view-loading-spinner {
+        width: 16px;
+        height: 16px;
+        animation: spin 2s linear infinite;
+    }
+    @keyframes spin {
+        0% {
+            transform: rotate(0deg);
+        }
+        100% {
+            transform: rotate(360deg);
+        }
+    }
+}

--- a/packages/pluggableWidgets/tree-view-web/src/ui/TreeView.scss
+++ b/packages/pluggableWidgets/tree-view-web/src/ui/TreeView.scss
@@ -19,6 +19,21 @@
         .glyphicon.widget-tree-view-branch-header-icon {
             font-size: 16px;
         }
+
+        .widget-tree-view-loading-spinner {
+            width: 16px;
+            height: 16px;
+            animation: spin 2s linear infinite;
+        }
+
+        @keyframes spin {
+            0% {
+                transform: rotate(0deg);
+            }
+            100% {
+                transform: rotate(360deg);
+            }
+        }
     }
 
     .widget-tree-view-branch-header-reversed {
@@ -38,32 +53,5 @@
 
     .widget-tree-view-branch-hidden {
         display: none;
-    }
-}
-
-.widget-tree-view-lazy-loading-placeholder {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    margin-left: 9px;
-
-    .widget-tree-view-placeholder-text {
-        margin-left: 8px;
-        color: #264ae5;
-        font-size: 16px;
-    }
-
-    .widget-tree-view-loading-spinner {
-        width: 16px;
-        height: 16px;
-        animation: spin 2s linear infinite;
-    }
-    @keyframes spin {
-        0% {
-            transform: rotate(0deg);
-        }
-        100% {
-            transform: rotate(360deg);
-        }
     }
 }

--- a/packages/pluggableWidgets/tree-view-web/typings/TreeViewProps.d.ts
+++ b/packages/pluggableWidgets/tree-view-web/typings/TreeViewProps.d.ts
@@ -20,6 +20,7 @@ export interface TreeViewContainerProps {
     headerContent?: ListWidgetValue;
     headerCaption?: ListExpressionValue<string>;
     hasChildren: boolean;
+    shouldLazyLoad: boolean;
     startExpanded: boolean;
     children?: ListWidgetValue;
     showIcon: ShowIconEnum;
@@ -36,6 +37,7 @@ export interface TreeViewPreviewProps {
     headerContent: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     headerCaption: string;
     hasChildren: boolean;
+    shouldLazyLoad: boolean;
     startExpanded: boolean;
     children: { widgetCount: number; renderer: ComponentType<{caption?: string}> };
     showIcon: ShowIconEnum;


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Adds lazy loading to tree view nodes behind a widget property and adds a placeholder loading state.
