### PR TITLE
[WC-661]  Accordion (web) - Fix default property values

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build:web": "npm run build -- --scope '*-web'",
     "publish": "ts-node --project ./scripts/tsconfig.json ./scripts/release/Release.ts",
     "release": "lerna run release --ignore @mendix/custom-widgets-utils-internal",
+    "release:marketplace": "lerna run release:marketplace",
     "release:native": "npm run release -- --scope '*-native'",
     "release:web": "npm run release -- --scope '*-web'",
     "version": "ts-node --project ./scripts/tsconfig.json ./scripts/release/BumpVersion.ts",

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.xml
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.xml
@@ -64,7 +64,7 @@
                             </property>
                         </propertyGroup>
                         <propertyGroup caption="State">
-                            <property key="initialCollapsedState" type="enumeration" defaultValue="expanded">
+                            <property key="initialCollapsedState" type="enumeration" defaultValue="collapsed">
                                 <caption>Start as</caption>
                                 <description />
                                 <enumerationValues>
@@ -73,7 +73,7 @@
                                     <enumerationValue key="dynamic">Dynamic</enumerationValue>
                                 </enumerationValues>
                             </property>
-                            <property key="initiallyCollapsed" type="expression" defaultValue="false">
+                            <property key="initiallyCollapsed" type="expression" defaultValue="true">
                                 <caption>Start as collapsed</caption>
                                 <description/>
                                 <returnType type="Boolean"/>


### PR DESCRIPTION
## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Change default property values for start as properties, because the user experience was bad when upgrading the widget:
it required users to always reconfigure the widget when in single mode by enabling advanced mode.

## Relevant changes
Default values for start as properties

## What should be covered while testing?
x
