### PR TITLE
[WC-635 & WC-636] Improve take a picture action

### DIFF
--- a/packages/jsActions/nanoflow-actions-web/CHANGELOG.md
+++ b/packages/jsActions/nanoflow-actions-web/CHANGELOG.md
@@ -4,3 +4,27 @@ All notable changes to this widget will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.2.0] - Unreleased
+
+### Added
+- Added the possibility to customize the picture quality from the "Take a picture" action.
+
+### Changed
+- Changed the confirmation screen to hide the control buttons after confirmation while the picture is loading in the "Take a picture" action.
+- Changed the "Take a picture" action to hide the action buttons after taking a picture while waiting for the picture to be processed.
+
+## [2.1.1] - 2021-07-01
+
+### Changed
+- We changed the category of 'Take picture' action to 'Web camera'.
+
+## [2.1.0] - 2021-05-28
+
+### Added
+- We've added a JavaScript action to allow take picture in PWA and web apps.
+
+## [2.0.0] - 2021-04-20
+
+### Added
+- Adding compatibility with Studio Pro 9.

--- a/packages/jsActions/nanoflow-actions-web/package.json
+++ b/packages/jsActions/nanoflow-actions-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoflow-actions-web",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/jsActions/nanoflow-actions-web/src/TakePicture.ts
+++ b/packages/jsActions/nanoflow-actions-web/src/TakePicture.ts
@@ -458,11 +458,16 @@ export async function TakePicture(
                         document.body.appendChild(confirmationWrapper);
 
                         saveBtn.addEventListener("click", () => {
-                            cleanupConfirmationElements();
+                            cleanupConfirmationButtons();
                             savePicture(videoCanvas, closeControlHandler);
                         });
 
                         closeBtn.addEventListener("click", () => cleanupConfirmationElements());
+
+                        // eslint-disable-next-line no-inner-declarations
+                        function cleanupConfirmationButtons(): void {
+                            confirmationWrapper.removeChild(buttonWrapper);
+                        }
 
                         // eslint-disable-next-line no-inner-declarations
                         function cleanupConfirmationElements(): void {

--- a/packages/jsActions/nanoflow-actions-web/src/TakePicture.ts
+++ b/packages/jsActions/nanoflow-actions-web/src/TakePicture.ts
@@ -115,7 +115,6 @@ export async function TakePicture(
         switchControl.addEventListener("click", switchControlHandler);
 
         actionControl.addEventListener("click", () => {
-            video.pause();
             removeAllControlButtons();
             if (showConfirmationScreen) {
                 // Delay the `takePictureHandler` to the next cycle so the UI preparations can go first. Otherwise, the control-buttons are not removed while the second screen is being set up.
@@ -126,6 +125,7 @@ export async function TakePicture(
                     });
                 }, 0);
             } else {
+                video.pause();
                 const videoCanvas = getVideoCanvas();
                 savePicture(videoCanvas, () => {
                     videoCanvas.remove();
@@ -455,6 +455,7 @@ export async function TakePicture(
                         confirmationWrapper = document.createElement("div");
                         confirmationWrapper.classList.add("take-picture-confirm-wrapper");
 
+                        video.pause();
                         // Element to retrieve the blob from mediaStream (not rendered on the screen)
                         const videoCanvas = getVideoCanvas();
 

--- a/packages/jsActions/nanoflow-actions-web/src/TakePicture.ts
+++ b/packages/jsActions/nanoflow-actions-web/src/TakePicture.ts
@@ -118,10 +118,13 @@ export async function TakePicture(
             video.pause();
             removeAllControlButtons();
             if (showConfirmationScreen) {
-                takePictureHandler(() => {
-                    addAllControlButtons();
-                    video.play();
-                });
+                // Delay the `takePictureHandler` to the next cycle so the UI preparations can go first. Otherwise, the control-buttons are not removed while the second screen is being set up.
+                setTimeout(() => {
+                    takePictureHandler(() => {
+                        addAllControlButtons();
+                        video.play();
+                    });
+                }, 0);
             } else {
                 const videoCanvas = getVideoCanvas();
                 savePicture(videoCanvas, () => {


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
- Fix confirmation screen not reacting to confirming (now it hides the button and pauses the feed)
- Add possibility to choose picture quality
- Hide buttons when making a picture and it's loading (regardless of whether confirmation screen will be shown)

## What should be covered while testing?
All the above cases and also whether trying the same flow multiple times works properly (had a few moments where the UI would be weird after repeating the same flow).
