### PR TITLE
[NC-419] Add native e2e tests for progress bar

### DIFF
--- a/packages/pluggableWidgets/progress-bar-native/detox.config.js
+++ b/packages/pluggableWidgets/progress-bar-native/detox.config.js
@@ -1,0 +1,1 @@
+module.exports = require("../../../detox/detox.config.js");

--- a/packages/pluggableWidgets/progress-bar-native/package.json
+++ b/packages/pluggableWidgets/progress-bar-native/package.json
@@ -15,6 +15,10 @@
     "release": "pluggable-widgets-tools release:native",
     "lint": "eslint --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:native",
+    "test:e2e:local:ios": "detox test --configuration ios.simulator.developerapp",
+    "test:e2e:local:ios:debug": "detox test --record-logs all -l trace --configuration ios.simulator.developerapp",
+    "test:e2e:local:android": "detox test --configuration android.emulator.developerapp",
+    "test:e2e:local:android:debug": "detox test --record-logs all -l trace --configuration android.emulator.developerapp",
     "version": "npm run release"
   },
   "dependencies": {
@@ -24,6 +28,7 @@
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
+    "detox": "^18.20.0",
     "eslint": "^7.20.0"
   }
 }

--- a/packages/pluggableWidgets/progress-bar-native/tests/e2e/ProgressBar.spec.ts
+++ b/packages/pluggableWidgets/progress-bar-native/tests/e2e/ProgressBar.spec.ts
@@ -1,0 +1,50 @@
+import { device, expect, waitFor } from "detox";
+import { Widget } from "../../../../../tests/e2e/helpers-native";
+
+describe("Progress Bar", () => {
+    beforeAll(async () => {
+        const progressBarWidget = Widget("btnProgressBar").getElement();
+        await progressBarWidget.tap();
+
+        const textBox = Widget("textBoxProgressBarValue").getElement();
+        await waitFor(textBox).toBeVisible().withTimeout(10000);
+        await textBox.tap();
+        await textBox.clearText();
+        await textBox.typeText("75");
+    });
+
+    it("renders the progress bar with dynamic values", async () => {
+        const progressBarId = Widget("progressBarDynamic");
+        const progressBar = progressBarId.getElement();
+
+        await expect(progressBar).toBeVisible();
+        await progressBar.tap();
+    });
+
+    it("renders the progress bar with static values", async () => {
+        const progressBarId = Widget("progressBarStatic");
+        const progressBar = progressBarId.getElement();
+
+        await expect(progressBar).toBeVisible();
+        await progressBar.tap();
+    });
+
+    it("does not render the progress bar with visibility set as false", async () => {
+        const progressBarId = Widget("progressBarNoVisibility");
+        const progressBar = progressBarId.getElement();
+
+        await expect(progressBar).not.toBeVisible();
+    });
+
+    it("renders the progress bar with custom style as Success", async () => {
+        const progressBarId = Widget("progressBarSuccess");
+        const progressBar = progressBarId.getElement();
+
+        await expect(progressBar).toBeVisible();
+        await progressBar.tap();
+    });
+
+    afterAll(async () => {
+        await device.reloadReactNative();
+    });
+});


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ❌
- Compatible with Studio ❌
- Cross-browser compatible ❌

#### Native specific
- Works in Android ✅
- Works in iOS ✅
- Works in Tablet ✅

#### Feature specific
- Comply with designs ✅ ❌
- Comply with PM's requirements ✅ ❌

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [X] Other (test)

## What is the purpose of this PR?
Add native e2e tests of Progress Bar

## Relevant changes
Added relevant test spec and related detox config. Please use the project **NativeComponentsTestProject(Branch line 'add-native-e2e-tests')** at [https://github.com/mendix/Native-Mobile-Resources](url) to run the tests locally. 

## What should be covered while testing?
Automated tests should pass on the local machine
