### PR TITLE
[UFC-181] add es6 output format in pluggable-widgets-tools for modern client support

### DIFF
--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -52,35 +52,42 @@ export default async args => {
     const result = [];
 
     if (platform === "web") {
-        result.push({
-            input: widgetEntry,
-            output: {
-                format: "amd",
-                file: join(outDir, `${outWidgetFile}.js`),
-                sourcemap: !production ? "inline" : false
-            },
-            external: webExternal,
-            plugins: [
-                ...getClientComponentPlugins(),
-                url({ include: imagesAndFonts, limit: 100000 }),
-                sass({ output: production, insert: !production, include: /\.(css|sass|scss)$/, processor }),
-                alias({
-                    entries: {
-                        "react-hot-loader/root": join(__dirname, "hot")
-                    }
-                }),
-                ...getCommonPlugins({
-                    sourceMaps: !production,
-                    extensions: webExtensions,
-                    transpile: production,
-                    babelConfig: {
-                        presets: [["@babel/preset-env", { targets: { safari: "12" } }]],
-                        allowAllFormats: true
-                    },
-                    external: webExternal
-                })
-            ],
-            onwarn
+        ["amd", "es"].forEach(outputFormat => {
+            result.push({
+                input: widgetEntry,
+                output: {
+                    format: outputFormat,
+                    file: join(outDir, `${outWidgetFile}.${outputFormat === "es" ? "mjs" : "js"}`),
+                    sourcemap: !production ? "inline" : false
+                },
+                external: webExternal,
+                plugins: [
+                    ...getClientComponentPlugins(),
+                    url({ include: imagesAndFonts, limit: 100000 }),
+                    sass({
+                        output: outputFormat === "amd",
+                        insert: !production,
+                        include: /\.(css|sass|scss)$/,
+                        processor
+                    }),
+                    alias({
+                        entries: {
+                            "react-hot-loader/root": join(__dirname, "hot")
+                        }
+                    }),
+                    ...getCommonPlugins({
+                        sourceMaps: !production,
+                        extensions: webExtensions,
+                        transpile: production,
+                        babelConfig: {
+                            presets: [["@babel/preset-env", { targets: { safari: "12" } }]],
+                            allowAllFormats: true
+                        },
+                        external: webExternal
+                    })
+                ],
+                onwarn
+            });
         });
     }
 

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -65,7 +65,7 @@ export default async args => {
                     ...getClientComponentPlugins(),
                     url({ include: imagesAndFonts, limit: 100000 }),
                     sass({
-                        output: outputFormat === "amd",
+                        output: production && outputFormat === "amd",
                         insert: !production,
                         include: /\.(css|sass|scss)$/,
                         processor


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

**_Please remove unnecessary emojis and sections and this comment before proceeding_**

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (describe)

## What is the purpose of this PR?
_The purpose of this PR is to add another output as `es6` module for widgets in `pluggable-widgets-tools` in order to make widgets compatible with modern client._