### PR TITLE
Disabled quill before update

### DIFF
--- a/packages/customWidgets/rich-text-web/src/components/RichText.ts
+++ b/packages/customWidgets/rich-text-web/src/components/RichText.ts
@@ -212,6 +212,7 @@ export class RichText extends Component<RichTextProps> {
     private updateEditor(props: RichTextProps): void {
         if (this.quill) {
             try {
+                this.quill.disable();
                 this.quill.clipboard.dangerouslyPasteHTML(this.sanitize(props.value), "silent");
                 this.quill.enable(!props.readOnly);
                 this.setEditorStyle(props);


### PR DESCRIPTION
A Quill js bug causes to steal the focus, this was reported in the issue https://github.com/mendixlabs/rich-text/issues/32

The solution is to disable the editor before updating the content, as suggested in the https://github.com/quilljs/quill/issues/2156#issuecomment-619530283
