### PR TITLE
fix(pluggable-widgets-tools): fix commonjs require settings

### DIFF
--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [9.4.2] - 2021-08-11
+
+### Changed
+- We changed the behavior of commonjs pluggin for rollup to identify the correct way to handle require (as default or not).
+
 ## [9.4.1] - 2021-08-05
 
 ### Added

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -219,7 +219,7 @@ export default async args => {
             commonjs({
                 extensions: config.extensions,
                 transformMixedEsModules: true,
-                requireReturnsDefault: true,
+                requireReturnsDefault: "auto",
                 ignore: id => (config.external || []).some(value => new RegExp(value).test(id))
             }),
             replace({

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.4.1",
+  "version": "9.4.2",
   "description": "Mendix Pluggable Widgets Tools",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2021. All rights reserved.",


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fix how commonjs plugin handles require (as default or not). Before it was always set to true, but the plugin itself can auto detect the correct configuration for each module being transpiled/bundled.

## Relevant changes
Switched from true to "auto" 

## What should be covered while testing?
Not necessary. If the e2e succeeds we are good to go.
