### PR TITLE
fix(atlas-ui): fix menubar z-index

### DIFF
--- a/packages/theming/atlas/CHANGELOG-atlas-core.md
+++ b/packages/theming/atlas/CHANGELOG-atlas-core.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [3.0.6] - 2021-08-12
+
+### Changed
+- We fixed the z-index (priority) of the menu bar.
+
 ## [3.0.5] - 2021-07-27
 
 ### Changed

--- a/packages/theming/atlas/package.json
+++ b/packages/theming/atlas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/atlas-ui",
-  "version": "3.0.4",
+  "version": "3.0.6",
   "description": "Mendix Atlas UI is the foundation of making beautiful apps with Mendix. For more information about the framework go to https://atlas.mendix.com.",
   "testProject": {
     "githubUrl": "https://github.com/mendix/Atlas-Design-System",

--- a/packages/theming/atlas/src/themesource/atlas_core/web/layouts/_layout-atlas.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/layouts/_layout-atlas.scss
@@ -53,7 +53,7 @@
         // Topbar
         .region-topbar {
             position: relative;
-            z-index: 1; // Show dropshadow
+            z-index: 2; // Show dropshadow
             min-height: $topbar-minimalheight;
             background-color: $navtopbar-bg;
 


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ❌
- Contains Atlas changes ✅
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Ajusts z-index of menubar to allow dropdowns to be on top of sticky headers of DG2

## Relevant changes
--

## What should be covered while testing?
--
