### PR TITLE
[WC-709] Accordion - Fix previews with no data

### DIFF
--- a/packages/pluggableWidgets/accordion-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/accordion-web/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [1.1.1] - 2021-08-16
+
+### Changed
+- We fixed a display issue while using the Accordion in Structure and Design Mode/Studio when there is no group configured.
+
 ## [1.1.0] - 2021-07-22
 
 ### Added

--- a/packages/pluggableWidgets/accordion-web/package.json
+++ b/packages/pluggableWidgets/accordion-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "accordion-web",
   "widgetName": "Accordion",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A Mendix pluggable widget to display expandable list items.",
   "copyright": "© Mendix Technology BV 2021. All rights reserved.",
   "license": "Apache-2.0",

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
@@ -117,6 +117,7 @@ export function getPreview(values: AccordionPreviewProps): StructurePreviewProps
                       collapsed: true as any,
                       onToggleCollapsed: null,
                       content: {
+                          // eslint-disable-next-line no-empty-pattern
                           renderer: ({}: { caption: string }) => null,
                           widgetCount: 0
                       }

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorPreview.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorPreview.tsx
@@ -33,6 +33,7 @@ export function preview(props: PreviewProps): ReactElement {
                       collapsed: true as any,
                       onToggleCollapsed: null,
                       content: {
+                          // eslint-disable-next-line no-empty-pattern
                           renderer: ({}: { caption: string; children: ReactElement }) => (
                               <div>Add groups in order to place widgets here.</div>
                           )

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorPreview.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorPreview.tsx
@@ -5,7 +5,7 @@ import { WebIcon } from "mendix";
 import { Accordion } from "./components/Accordion";
 import { useIconGenerator } from "./utils/iconGenerator";
 
-import { AccordionPreviewProps } from "../typings/AccordionProps";
+import { AccordionPreviewProps, GroupsPreviewType } from "../typings/AccordionProps";
 
 // This interface is necessary to overcome incorrect exposure of class names with the "className" prop. In the future they will be exposed with a "class" prop (Jira Issue PAG-1317).
 interface PreviewProps extends Omit<AccordionPreviewProps, "class"> {
@@ -19,7 +19,28 @@ export function getPreviewCss(): string {
 export function preview(props: PreviewProps): ReactElement {
     const style = parseStyle(props.style);
 
-    const accordionGroups = props.groups.map((group, index) => ({
+    const groups =
+        props.groups.length > 0
+            ? props.groups
+            : [
+                  {
+                      headerRenderMode: "text",
+                      headerText: "[No groups configured]",
+                      headerHeading: "headingOne" as const,
+                      visible: true as any,
+                      dynamicClass: "",
+                      initiallyCollapsed: true as any,
+                      collapsed: true as any,
+                      onToggleCollapsed: null,
+                      content: {
+                          renderer: ({}: { caption: string; children: ReactElement }) => (
+                              <div>Add groups in order to place widgets here.</div>
+                          )
+                      }
+                  } as GroupsPreviewType
+              ];
+
+    const accordionGroups = groups.map((group, index) => ({
         header:
             group.headerRenderMode === "text" ? (
                 <h3>{group.headerText}</h3>

--- a/packages/pluggableWidgets/accordion-web/src/package.xml
+++ b/packages/pluggableWidgets/accordion-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Accordion" version="1.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Accordion" version="1.1.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Accordion.xml"/>
         </widgetFiles>


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX  9️⃣

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fix structure preview and Studio/Design mode when there is no group configured. Before it was showing just a blank canvas making the usage very difficult.

Bonus: In order to reach the general properties of accordion I added the same header as Gallery and Data Grid as the Accordion uses Selectable objects for the list items (groups).

## Relevant changes
--

## What should be covered while testing?
General DX of Accordion.
