### PR TITLE
[WC-702] Video Player - Renaming properties

### DIFF
--- a/packages/pluggableWidgets/video-player-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/video-player-web/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [2.0.1] - 2021-08-16
+
+### Changed
+- We renamed the video Link and Poster Link widget properties.
+
 ## [2.0.0] - 2021-07-12
 
 ### Added

--- a/packages/pluggableWidgets/video-player-web/package.json
+++ b/packages/pluggableWidgets/video-player-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "video-player-web",
   "widgetName": "VideoPlayer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Player for YouTube, Dailymotion, Vimeo and Mp4 videos",
   "copyright": "© Mendix Technology BV 2021. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.editorConfig.ts
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.editorConfig.ts
@@ -42,13 +42,13 @@ export function check(values: VideoPlayerPreviewProps): Problem[] {
     if (values.type === "dynamic" && !values.videoUrl) {
         errors.push({
             property: "videoUrl",
-            message: "Providing a video link is required"
+            message: "Providing a video URL is required"
         });
     }
     if (values.type === "expression" && !values.urlExpression) {
         errors.push({
             property: "urlExpression",
-            message: "Providing a video link is required"
+            message: "Providing a video URL is required"
         });
     }
     return errors;

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.editorPreview.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.editorPreview.tsx
@@ -36,5 +36,5 @@ export class preview extends Component<VideoPlayerPreviewProps, {}> {
 }
 
 export function getPreviewCss(): string {
-    return require("./ui/VideoPlayer.css");
+    return require("./ui/VideoPlayer.css") + require("./ui/VideoPlayerPreview.css");
 }

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<widget id="com.mendix.widget.web.videoplayer.VideoPlayer" pluginWidget="true" needsEntityContext="true" supportedPlatform="Web" offlineCapable="true" xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd">
+<widget id="com.mendix.widget.web.videoplayer.VideoPlayer" pluginWidget="true" needsEntityContext="true" supportedPlatform="Web" offlineCapable="true" xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../../node_modules/mendix/custom_widget.xsd">
     <name>Video Player</name>
     <description>Shows a video from YouTube, Vimeo, Dailymotion and Mp4</description>
     <icon>
@@ -17,21 +17,21 @@
                     </enumerationValues>
                 </property>
                 <property key="urlExpression" type="expression" required="false">
-                    <caption>Video link</caption>
+                    <caption>Video URL</caption>
                     <description>The web address of the video: YouTube, Vimeo, Dailymotion or MP4.</description>
                     <returnType type="String"/>
                 </property>
                 <property key="posterExpression" type="expression" required="false">
-                    <caption>Poster link</caption>
+                    <caption>Poster URL</caption>
                     <description>The web address of the poster image. A poster image is a custom preview image that will be shown in the player until the user starts the video.</description>
                     <returnType type="String"/>
                 </property>
                 <property key="videoUrl" type="textTemplate" required="false">
-                    <caption>Video link</caption>
+                    <caption>Video URL</caption>
                     <description>The web address of the video: YouTube, Vimeo, Dailymotion or MP4.</description>
                 </property>
                 <property key="posterUrl" type="textTemplate" required="false">
-                    <caption>Poster link</caption>
+                    <caption>Poster URL</caption>
                     <description>The web address of the poster image. A poster image is a custom preview image that will be shown in the player until the user starts the video.</description>
                 </property>
             </propertyGroup>
@@ -40,24 +40,26 @@
                 <systemProperty key="TabIndex"/>
             </propertyGroup>
         </propertyGroup>
-        <propertyGroup caption="Behavior">
-            <property key="autoStart" type="boolean" defaultValue="false">
-                <caption>Auto start</caption>
-                <description>Automatically start playing the video when the page loads.</description>
-            </property>
-            <property key="showControls" type="boolean" defaultValue="true">
-                <caption>Show Controls</caption>
-                <description>Display video controls (control bar, display icons, dock buttons). Available for YouTube, Dailymotion and external videos.</description>
-            </property>
-            <property key="muted" type="boolean" defaultValue="false">
-                <caption>Muted</caption>
-                <description>Start the video on mute.</description>
-            </property>
-            <property key="loop" type="boolean" defaultValue="false">
-                <caption>Loop</caption>
-                <description>Loop the video after it finishes. Available for YouTube, Vimeo, and external videos.
-                </description>
-            </property>
+        <propertyGroup caption="Controls">
+            <propertyGroup caption="Controls">
+                <property key="autoStart" type="boolean" defaultValue="false">
+                    <caption>Auto start</caption>
+                    <description>Automatically start playing the video when the page loads.</description>
+                </property>
+                <property key="showControls" type="boolean" defaultValue="true">
+                    <caption>Show Controls</caption>
+                    <description>Display video controls (control bar, display icons, dock buttons). Available for YouTube, Dailymotion and external videos.</description>
+                </property>
+                <property key="muted" type="boolean" defaultValue="false">
+                    <caption>Muted</caption>
+                    <description>Start the video on mute.</description>
+                </property>
+                <property key="loop" type="boolean" defaultValue="false">
+                    <caption>Loop</caption>
+                    <description>Loop the video after it finishes. Available for YouTube, Vimeo, and external videos.
+                    </description>
+                </property>
+            </propertyGroup>
         </propertyGroup>
         <propertyGroup caption="Dimensions">
             <propertyGroup caption="Dimensions">

--- a/packages/pluggableWidgets/video-player-web/src/package.xml
+++ b/packages/pluggableWidgets/video-player-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="VideoPlayer" version="2.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="VideoPlayer" version="2.0.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="VideoPlayer.xml"/>
         </widgetFiles>

--- a/packages/pluggableWidgets/video-player-web/src/ui/VideoPlayerPreview.css
+++ b/packages/pluggableWidgets/video-player-web/src/ui/VideoPlayerPreview.css
@@ -1,0 +1,3 @@
+.widget-video-player-html5 {
+    pointer-events: none;
+}


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

#### Feature specific
- Comply with designs ✅
- Comply with PM's requirements ✅

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Rename properties from Link to URL, remove clicks from the video tag (In Studio) to prevent enter fullscreen when double clicking or play the video when single clicking and adding missing group for controls.

## Relevant changes
--

## What should be covered while testing?
Studio + Studio Pro smoke test
