### PR TITLE
feat(barcode-scanner-native): add widget property for throttle

### DIFF
--- a/packages/pluggableWidgets/barcode-scanner-native/src/BarcodeScanner.tsx
+++ b/packages/pluggableWidgets/barcode-scanner-native/src/BarcodeScanner.tsx
@@ -13,7 +13,7 @@ export type Props = BarcodeScannerProps<BarcodeScannerStyle>;
 
 export class BarcodeScanner extends Component<Props> {
     private readonly styles = flattenStyles(defaultBarcodeScannerStyle, this.props.style);
-    private readonly onBarCodeReadHandler = throttle(this.onBarCodeRead.bind(this), 2000);
+    private readonly onBarCodeReadHandler = throttle(this.onBarCodeRead.bind(this), this.props.throttlems);
 
     render(): JSX.Element {
         return (

--- a/packages/pluggableWidgets/barcode-scanner-native/src/BarcodeScanner.xml
+++ b/packages/pluggableWidgets/barcode-scanner-native/src/BarcodeScanner.xml
@@ -29,6 +29,10 @@
                     <caption>On detect</caption>
                     <description/>
                 </property>
+                <property key="throttlems" type="integer" defaultValue="2000" required="true">
+                 <caption>Throttle (ms)</caption>
+                  <description>How often can the widget fire the "on detect" event? Lower means more frequent events. This could cause duplicate reads, so be sure to handle this accordingly! (Default is 2000.)</description>
+                </property>
             </propertyGroup>
             <propertyGroup caption="Common">
                 <systemProperty key="Name"/>

--- a/packages/pluggableWidgets/barcode-scanner-native/src/__tests__/BarcodeScanner.spec.tsx
+++ b/packages/pluggableWidgets/barcode-scanner-native/src/__tests__/BarcodeScanner.spec.tsx
@@ -18,7 +18,8 @@ describe("BarcodeScanner", () => {
             showMask: false,
             name: "barcode-scanner-test",
             style: [],
-            barcode: new EditableValueBuilder<string>().build()
+            barcode: new EditableValueBuilder<string>().build(),
+            throttlems: 2000
         };
     });
 

--- a/packages/pluggableWidgets/barcode-scanner-native/typings/BarcodeScannerProps.d.ts
+++ b/packages/pluggableWidgets/barcode-scanner-native/typings/BarcodeScannerProps.d.ts
@@ -12,6 +12,7 @@ export interface BarcodeScannerProps<Style> {
     showMask: boolean;
     showAnimatedLine: boolean;
     onDetect?: ActionValue;
+    throttlems: number;
 }
 
 export interface BarcodeScannerPreviewProps {
@@ -21,4 +22,5 @@ export interface BarcodeScannerPreviewProps {
     showMask: boolean;
     showAnimatedLine: boolean;
     onDetect: {} | null;
+    throttlems: number | null;
 }


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ✅ 
- Contains Atlas changes ❌
- Compatible with: MX 7️⃣, 8️⃣, 9️⃣

#### Native specific
- Works in Android ✅ 
- Works in iOS ✅ 
- Works in Tablet ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Add the capability for the Mendix developer to change the throttling on the barcode scanner 

## Relevant changes
Prior to this commit, the barcode scanner could only fire an `onBarCodeRead` event every 2 seconds. I removed the hardcoded 2 seconds and turned that value into a widget property.

## What should be covered while testing?
various values of the `throttlems` property.
