### PR TITLE
[NC-393] Local notification actions

### DIFF
--- a/packages/pluggableWidgets/notifications-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/notifications-native/CHANGELOG.md
@@ -4,3 +4,9 @@ All notable changes to this widget will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- Handle local notification "On open" actions. Note: local notification's do not handle "On receive" actions, despite being able to configure these in the modeler.
+
+### Fixed
+- A configured "Actions" property will receive the correct value; a concatenation of matching action names. 

--- a/packages/pluggableWidgets/notifications-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/notifications-native/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
-- Handle local notification "On open" actions. Note: local notification's do not handle "On receive" actions, despite being able to configure these in the modeler.
+- Handle local notification "On open" actions. Note: local notification's do not handle "On receive" actions, despite being able to configure these in Studio Pro.
 
 ### Fixed
 - A configured "Actions" property will receive the correct value; a concatenation of matching action names. 

--- a/packages/pluggableWidgets/notifications-native/package.json
+++ b/packages/pluggableWidgets/notifications-native/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@mendix/piw-utils-internal": "^1.0.0",
     "@react-native-firebase/app": "10.1.0",
-    "@react-native-firebase/messaging": "10.5.1"
+    "@react-native-firebase/messaging": "10.5.1",
+    "react-native-push-notification": "^6.1.2"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/notifications-native/package.json
+++ b/packages/pluggableWidgets/notifications-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notifications-native",
   "widgetName": "Notifications",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/pluggableWidgets/notifications-native/src/Notifications.tsx
+++ b/packages/pluggableWidgets/notifications-native/src/Notifications.tsx
@@ -51,21 +51,11 @@ export function Notifications(props: NotificationsProps<undefined>): null {
             if (actions.length === 0) {
                 return;
             }
-            if (props.guid) {
-                props.guid.setValue(notification.data?.guid);
-            }
-            if (props.title) {
-                props.title.setValue(title);
-            }
-            if (props.subtitle) {
-                props.subtitle.setValue(subtitle);
-            }
-            if (props.body) {
-                props.body.setValue(body);
-            }
-            if (props.action) {
-                props.action.setValue(actions.map(action => action.name).join(" "));
-            }
+            props.guid?.setValue(notification.data?.guid);
+            props.title?.setValue(title);
+            props.subtitle?.setValue(subtitle);
+            props.body?.setValue(body);
+            props.action?.setValue(actions.map(action => action.name).join(" "));
 
             actions.forEach(action => executeAction(getHandler(action)));
         },
@@ -75,18 +65,18 @@ export function Notifications(props: NotificationsProps<undefined>): null {
     const remoteMessageHandlerHelpers = (
         notification: FirebaseMessagingTypes.Notification
     ): Pick<Notification, "title" | "subTitle" | "body"> => ({
-        title: notification?.title,
-        body: notification?.body,
+        title: notification.title,
+        body: notification.body,
         subTitle: notification.ios?.subtitle
     });
 
     const onReceive = useCallback(
         (message: FirebaseMessagingTypes.RemoteMessage): void => {
-            const { notification } = message;
+            const { notification, data } = message;
             if (notification) {
                 handleNotification(
                     {
-                        data: message.data,
+                        data,
                         ...remoteMessageHandlerHelpers(notification)
                     },
                     action => action.onReceive
@@ -98,11 +88,11 @@ export function Notifications(props: NotificationsProps<undefined>): null {
 
     const onOpen = useCallback(
         (message: FirebaseMessagingTypes.RemoteMessage): void => {
-            const { notification } = message;
+            const { notification, data } = message;
             if (notification) {
                 handleNotification(
                     {
-                        data: message.data,
+                        data,
                         ...remoteMessageHandlerHelpers(notification)
                     },
                     action => action.onOpen

--- a/packages/pluggableWidgets/notifications-native/src/Notifications.tsx
+++ b/packages/pluggableWidgets/notifications-native/src/Notifications.tsx
@@ -102,7 +102,7 @@ export function Notifications(props: NotificationsProps<undefined>): null {
 
     useEffect(() => {
         // wait for all used DynamicValues are available before configuring, else handleNotification is invoked while
-        // properties in scope are loading. Note that handlers passed to `configure` are only ever registered once.
+        // properties in scope are loading.
         if (loadNotifications) {
             PushNotification.configure({
                 // called when user taps local notification

--- a/packages/pluggableWidgets/notifications-native/src/Notifications.tsx
+++ b/packages/pluggableWidgets/notifications-native/src/Notifications.tsx
@@ -66,7 +66,7 @@ export function Notifications(props: NotificationsProps<undefined>): null {
             props.body.setValue(body);
         }
         if (props.action) {
-            props.action.setValue(actions.join(" "));
+            props.action.setValue(actions.map(action => action.name).join(" "));
         }
 
         actions.forEach(action => executeAction(getHandler(action)));

--- a/packages/pluggableWidgets/notifications-native/src/Notifications.tsx
+++ b/packages/pluggableWidgets/notifications-native/src/Notifications.tsx
@@ -2,12 +2,10 @@ import messaging, { FirebaseMessagingTypes } from "@react-native-firebase/messag
 import PushNotification from "react-native-push-notification";
 import { executeAction } from "@mendix/piw-utils-internal";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ActionValue, ValueStatus } from "mendix";
+import { ActionValue, ValueStatus, Option } from "mendix";
 import "@react-native-firebase/app";
 
 import { ActionsType, NotificationsProps } from "../typings/NotificationsProps";
-
-declare type Option<T> = T | undefined;
 
 // re-declare the library's type because: 1) it doesn't match library version 2) the definition file exports two symbols with same name.
 interface IPushNotification {

--- a/packages/pluggableWidgets/notifications-native/src/Notifications.xml
+++ b/packages/pluggableWidgets/notifications-native/src/Notifications.xml
@@ -17,7 +17,7 @@
                     <property key="onReceive" type="action" required="false">
                         <caption>On receive</caption>
                         <category>Action</category>
-                        <description>Called when the notification is received while the application is running.</description>
+                        <description>Called when the notification is received while the application is running. Only applicable to remote notifications.</description>
                     </property>
                     <property key="onOpen" type="action" required="false">
                         <caption>On open</caption>

--- a/packages/pluggableWidgets/notifications-native/src/package.xml
+++ b/packages/pluggableWidgets/notifications-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Notifications" version="2.0.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Notifications" version="2.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Notifications.xml"/>
         </widgetFiles>


### PR DESCRIPTION
## Checklist
- Compatible with: MX 9️⃣

#### Native specific
- Works in Android ✅ 
- Works in iOS ✅ 
- Works in Tablet ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Add handling of local notification actions

## Relevant changes
Apparently this widget was refactored and the handling of location notification configured actions was mistakenly removed.

This PR add this functionality back in.

Note: only configured onOpen actions are invoked (i.e. when the local notification is tapped). With the library we are using, there is no way to handle the event whereby a local notification is received (i.e. it appears on your screen)

## What should be covered while testing?
- does the local notification event functionality work as expected?
- do the properties (guid / title/ etc.) get updated as expected?
- is there no regression for remote notifications?

## Queries/todos
- [x] Should this be backported to MX8 module? No
- [x] **NB** [This](https://github.com/zo0r/react-native-push-notification/tree/6.1.2#usage) states that the handler function must call `finish`, however during dev-testing on both Android and iOS the value passed to `onNotification` doesn't include a `finish` property, also Android and iOS behaved as expected during dev-testing. [This](https://reactnative.dev/docs/pushnotificationios#finish) docs describe this property as only applicable to remote notifications. I think if during testing things go fine, this can be ignored. 
- [x] Document the inability for local notifications to execute `onReceive` events. https://mendix.atlassian.net/browse/NC-466
