### PR TITLE
[WC-722]: adding padding of dataviews

### DIFF
--- a/packages/theming/atlas/CHANGELOG-atlas-core.md
+++ b/packages/theming/atlas/CHANGELOG-atlas-core.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [3.0.7] - 2021-08-19
+
 ### Added
+- We added default padding for data view placed directly inside placeholders. (Ticket #128307)
 - We added styles, exclusion variables and design properties for Gallery widget.
 
 ## [3.0.6] - 2021-08-12

--- a/packages/theming/atlas/package.json
+++ b/packages/theming/atlas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/atlas-ui",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "Mendix Atlas UI is the foundation of making beautiful apps with Mendix. For more information about the framework go to https://atlas.mendix.com.",
   "testProject": {
     "githubUrl": "https://github.com/mendix/Atlas-Design-System",

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_data-view.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_data-view.scss
@@ -46,4 +46,10 @@
 
         background-color: inherit;
     }
+
+    .mx-placeholder {
+        > .mx-dataview {
+            padding: $spacing-large;
+        }
+    }
 }


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ✅
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
When placing dataview directly inside a placeholder it doest contain a default padding. So this PR adds it.

## Relevant changes
--

## What should be covered while testing?
Just Dataview inside and outside a popup without a layout grid outside.
