### PR TITLE
[WC-723] Add support for icon and tile images

### DIFF
--- a/packages/pluggableWidgets/image-viewer-web/src/ImageViewer.editorPreview.tsx
+++ b/packages/pluggableWidgets/image-viewer-web/src/ImageViewer.editorPreview.tsx
@@ -12,20 +12,11 @@ export function preview(props: ImageViewerPreviewProps): ReactElement | null {
     let image = ImageViewerPlaceholder;
     switch (props.datasource) {
         case "image":
-            // TODO: Remove these when preview typing for `image` property is aligned properly by PageEditor
-            const imageObject:
-                | { type: "static"; imageUrl: string }
-                | { type: "dynamic"; entity: string }
-                | null = props.imageObject as any;
-            const defaultImageObject:
-                | { type: "static"; imageUrl: string }
-                | { type: "dynamic"; entity: string }
-                | null = props.defaultImageDynamic as any;
-            if (imageObject?.type === "static") {
+            if (props.imageObject?.type === "static") {
                 // The optional chaining in the conditional guarantees the object is set here.
-                image = imageObject.imageUrl;
-            } else if (defaultImageObject?.type === "static") {
-                image = defaultImageObject.imageUrl;
+                image = props.imageObject.imageUrl;
+            } else if (props.defaultImageDynamic?.type === "static") {
+                image = props.defaultImageDynamic.imageUrl;
             }
             break;
         case "icon":

--- a/packages/pluggableWidgets/image-viewer-web/typings/ImageViewerProps.d.ts
+++ b/packages/pluggableWidgets/image-viewer-web/typings/ImageViewerProps.d.ts
@@ -42,8 +42,8 @@ export interface ImageViewerPreviewProps {
     class: string;
     style: string;
     datasource: DatasourceEnum;
-    imageObject: string;
-    defaultImageDynamic: string;
+    imageObject: { type: "static"; imageUrl: string; } | { type: "dynamic"; entity: string; } | null;
+    defaultImageDynamic: { type: "static"; imageUrl: string; } | { type: "dynamic"; entity: string; } | null;
     imageUrl: string;
     imageIcon: { type: "glyph"; iconClass: string; } | { type: "image"; imageUrl: string; } | null;
     onClickType: OnClickTypeEnum;

--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- We added support for icon and tile images. Now you can use an image file instead of `<icon>` in your `MyWidget.xml`. In order to use, please make sure you follow the pattern `src/MyWidget.icon.png` (24x24px) and `src/MyWidget.tile.png` (256x192px)
+
+### Changed
+- We fixed the formatting of Preview typings
+
 ## [9.4.3] - 2021-08-12
 
 ### Changed
@@ -13,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [9.4.2] - 2021-08-11
 
 ### Changed
-- We changed the behavior of commonjs pluggin for rollup to identify the correct way to handle require (as default or not).
+- We changed the behavior of commonjs plugin for rollup to identify the correct way to handle require (as default or not).
 
 ## [9.4.1] - 2021-08-05
 

--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - We fixed the formatting of Preview typings
+- We fixed the Preview typings for Icon property.
 
 ## [9.4.3] - 2021-08-12
 

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -268,7 +268,14 @@ export default async args => {
         return [
             isTypescript ? widgetTyping({ sourceDir: join(sourcePath, "src") }) : null,
             clear({ targets: [outDir, mpkDir] }),
-            command([() => cp(join(sourcePath, "src/**/*.xml"), outDir)]),
+            command([
+                () => {
+                    cp(join(sourcePath, "src/**/*.xml"), outDir);
+                    if (existsSync(`src/${widgetName}.icon.png`) || existsSync(`src/${widgetName}.tile.png`)) {
+                        cp(join(sourcePath, `src/${widgetName}.@(tile|icon).png`), outDir);
+                    }
+                }
+            ]),
             args.watch && platform === "web" && !production && projectPath ? livereload() : null
         ];
     }


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Feature specific
- Comply with PM's requirements ✅

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
In order to support files for icons and tiles we added a copy command to zip the files together with the mpk contents.
To use it you need to place the files inside the src folder and also follow the pattern of `WidgetName.tile.png` and `WidgetName.icon.png`.

## Relevant changes
If you are using the new files you dont need to define the icon property inside the `Widget.xml`. Note, this will only work in SP 9.6.0

IMPORTANT: The existsSync is being used otherwise it will throw a warning saying the file doesnt exist.

## What should be covered while testing?
Check if the file is being copied to dist/tmp and also zipped inside the mpk file.
