### PR TITLE
fix(pluggable-widgets-tools): downgrade rollup-plugin-sass version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28652,96 +28652,45 @@
 			}
 		},
 		"rollup-plugin-sass": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-sass/-/rollup-plugin-sass-1.2.2.tgz",
-			"integrity": "sha512-yvHQPg1JS4d23gwHTwTbokH+FV/0bPBVf5QmlvCOzfAhXe0luY0pUgVaWC2qfnoKetp2Oqh5lK7oW/4CXGWs1Q==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-sass/-/rollup-plugin-sass-1.2.4.tgz",
+			"integrity": "sha512-MnX0JAjL/Uz8Wmz8vdHe0cEHfHBTDyaa6QRZV0nWTmoDWf53fa3QSyLY9kSuVB+lbheBbhx7qM8EjTAlbzk9Ww==",
 			"requires": {
-				"babel-runtime": "^6.23.0",
+				"@babel/runtime-corejs3": "^7.14.8",
+				"@rollup/pluginutils": "^4.1.1",
 				"fs-extra": "^0.30.0",
 				"pify": "^3.0.0",
 				"resolve": "^1.5.0",
-				"rollup-pluginutils": ">= 1.3.1",
-				"sass": "1.7.2"
+				"sass": "^1.7.2"
 			},
 			"dependencies": {
-				"anymatch": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+				"@babel/runtime-corejs3": {
+					"version": "7.15.3",
+					"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.15.3.tgz",
+					"integrity": "sha512-30A3lP+sRL6ml8uhoJSs+8jwpKzbw8CqBvDc1laeptxPm5FahumJxirigcbD2qTs71Sonvj1cyZB0OKGAmxQ+A==",
 					"requires": {
-						"micromatch": "^3.1.4",
-						"normalize-path": "^2.1.1"
-					},
-					"dependencies": {
-						"normalize-path": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-							"requires": {
-								"remove-trailing-separator": "^1.0.1"
-							}
-						}
+						"core-js-pure": "^3.16.0",
+						"regenerator-runtime": "^0.13.4"
 					}
 				},
-				"binary-extensions": {
-					"version": "1.13.1",
-					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-					"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
-				},
-				"braces": {
-					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+				"@rollup/pluginutils": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
+					"integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"estree-walker": "^2.0.1",
+						"picomatch": "^2.2.2"
 					}
 				},
-				"chokidar": {
-					"version": "2.1.8",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-					"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-					"requires": {
-						"anymatch": "^2.0.0",
-						"async-each": "^1.0.1",
-						"braces": "^2.3.2",
-						"fsevents": "^1.2.7",
-						"glob-parent": "^3.1.0",
-						"inherits": "^2.0.3",
-						"is-binary-path": "^1.0.0",
-						"is-glob": "^4.0.0",
-						"normalize-path": "^3.0.0",
-						"path-is-absolute": "^1.0.0",
-						"readdirp": "^2.2.1",
-						"upath": "^1.1.1"
-					}
+				"core-js-pure": {
+					"version": "3.16.2",
+					"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.2.tgz",
+					"integrity": "sha512-oxKe64UH049mJqrKkynWp6Vu0Rlm/BTXO/bJZuN2mmR3RtOFNepLlSWDd1eo16PzHpQAoNG97rLU1V/YxesJjw=="
 				},
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"fill-range": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
-					}
+				"estree-walker": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+					"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
 				},
 				"fs-extra": {
 					"version": "0.30.0",
@@ -28755,56 +28704,6 @@
 						"rimraf": "^2.2.8"
 					}
 				},
-				"fsevents": {
-					"version": "1.2.13",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-					"optional": true,
-					"requires": {
-						"bindings": "^1.5.0",
-						"nan": "^2.12.1"
-					}
-				},
-				"glob-parent": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-					"requires": {
-						"is-glob": "^3.1.0",
-						"path-dirname": "^1.0.0"
-					},
-					"dependencies": {
-						"is-glob": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-							"requires": {
-								"is-extglob": "^2.1.0"
-							}
-						}
-					}
-				},
-				"is-binary-path": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-					"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-					"requires": {
-						"binary-extensions": "^1.0.0"
-					}
-				},
-				"is-extendable": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-				},
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
 				"jsonfile": {
 					"version": "2.4.0",
 					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -28813,45 +28712,10 @@
 						"graceful-fs": "^4.1.6"
 					}
 				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				},
 				"pify": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				},
-				"readdirp": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-					"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"micromatch": "^3.1.10",
-						"readable-stream": "^2.0.2"
-					}
-				},
-				"sass": {
-					"version": "1.7.2",
-					"resolved": "https://registry.npmjs.org/sass/-/sass-1.7.2.tgz",
-					"integrity": "sha512-zUm2NXL77WtQDbp4MKgysAxH41Fzs5BnBUogEPi8IKNQ1M5rKoFe46YBXfxr0I+cQX+xbSc//psSdq5eyYhJsg==",
-					"requires": {
-						"chokidar": "^2.0.0"
-					}
-				},
-				"to-regex-range": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-					"requires": {
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1"
-					}
 				}
 			}
 		},

--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - We fixed the formatting of Preview typings
 - We fixed the Preview typings for Icon property.
+- We downgraded the version of `rollup-plugin-sass` to 1.2.4 in order to prevent a library version issue throwing `The "path" argument must be of type string. Received an instance of RegExp`.
 
 ## [9.4.3] - 2021-08-12
 

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -105,7 +105,7 @@
     "rollup-plugin-command": "^1.1.3",
     "rollup-plugin-livereload": "^2.0.0",
     "rollup-plugin-re": "^1.0.7",
-    "rollup-plugin-sass": "^1.2.2",
+    "rollup-plugin-sass": "1.2.4",
     "rollup-plugin-terser": "^7.0.2",
     "semver": "^7.3.2",
     "shelljs": "^0.8.4",


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fixes the following error being thrown by `rollup-plugin-sass` in version 1.2.5.

```
 [!] TypeError: The "path" argument must be of type string. Received an instance of RegExp
 TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received an instance of RegExp
     at validateString (internal/validators.js:124:11)
     at Object.resolve (path.js:1074:7)
     at /tmp/pwt_test_1711/node_modules/rollup-plugin-sass/node_modules/rollup-pluginutils/dist/pluginutils.cjs.js:183:68
```

Reported also in the library itself. https://github.com/differui/rollup-plugin-sass/issues/81

## Relevant changes
--

## What should be covered while testing?
Automation should be enough as the error was in the build.
