### PR TITLE
[NC-454] Fix native slider decimal output

### DIFF
--- a/packages/pluggableWidgets/slider-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/slider-native/CHANGELOG.md
@@ -4,3 +4,6 @@ All notable changes to this widget will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+ - We fixed an issue where the widget sometimes threw a validation error when the step size property included decimals.

--- a/packages/pluggableWidgets/slider-native/package.json
+++ b/packages/pluggableWidgets/slider-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slider-native",
   "widgetName": "Slider",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/pluggableWidgets/slider-native/src/Slider.tsx
+++ b/packages/pluggableWidgets/slider-native/src/Slider.tsx
@@ -1,6 +1,6 @@
 import { available, flattenStyles, toNumber, unavailable } from "@mendix/piw-native-utils-internal";
 import { executeAction } from "@mendix/piw-utils-internal";
-import { ValueStatus } from "mendix";
+import { ValueStatus, Option } from "mendix";
 import MultiSlider, { MarkerProps } from "@ptomasroos/react-native-multi-slider";
 import { createElement, ReactElement, useCallback, useRef, useState } from "react";
 import { LayoutChangeEvent, Text, View } from "react-native";
@@ -23,7 +23,10 @@ export function Slider(props: Props): ReactElement {
     const editable = props.editable !== "never" && !props.valueAttribute.readOnly && validProps;
     const styles = flattenStyles(defaultSliderStyle, props.style);
     // We have to fix the decimal count ourselves because of an unresolved bug in the library: https://github.com/ptomasroos/react-native-multi-slider/issues/211
-    const decimalCount = useCallback((value: Big): number => value?.toString().split(".")?.[1]?.length || 0, []);
+    const decimalCount = useCallback(
+        (value: Option<Big>): number => value?.toString().split(".")?.[1]?.length || 0,
+        []
+    );
 
     const customMarker = () => (markerProps: MarkerProps): JSX.Element => (
         <Marker {...markerProps} testID={`${props.name}$marker`} />
@@ -59,7 +62,7 @@ export function Slider(props: Props): ReactElement {
 
             executeAction(props.onChange);
         },
-        [props.valueAttribute, props.onChange, props.stepSize, decimalCount]
+        [lastValue, props.valueAttribute, props.onChange, props.stepSize, decimalCount]
     );
 
     return (

--- a/packages/pluggableWidgets/slider-native/src/package.xml
+++ b/packages/pluggableWidgets/slider-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Slider" version="1.0.5"
+    <clientModule name="Slider" version="1.1.0"
         xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Slider.xml"/>


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ✅
- Contains Atlas changes ✅ 
- Compatible with: MX  8️⃣, 9️⃣

#### Native specific
- Works in Android ✅ 
- Works in iOS ✅ 
- Works in Tablet ✅ 

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
To fix a bug coming from the library where the value sometimes has a very long decimal number. This is not yet fixed in the library, therefore I added a fix in the widget.

## Relevant changes
I updated the code so the value coming from the library will always have the same amount of decimals as the size of the steps. Eg. steps of 0.1 would mean the resulting value will always have 1 decimal.

## What should be covered while testing?
If the value in the database is as expected.
If the issue is resolved.