### PR TITLE
[WC-715] Data Grid - Fixing filter positions when virtual scrolling is enabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5710,13 +5710,13 @@
 			}
 		},
 		"@types/react-datepicker": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@types/react-datepicker/-/react-datepicker-3.1.1.tgz",
-			"integrity": "sha512-vwNrgaIMJThvvwmtnA8jSVVJZ0FNgljQrq1jDA4MtYJIDmVmd9NNrFaXf9u2JqR2nS+8Kvi8OVs/tnAbUqZhHw==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@types/react-datepicker/-/react-datepicker-4.1.4.tgz",
+			"integrity": "sha512-7M+rLLRVIq4tnrupI/wZn8BQEVIawjVItsOQGgZTYE/L9oTJ9rzmu4im6BNr5meWehXvNWbM4DOeuciaz6exWg==",
 			"requires": {
+				"@popperjs/core": "^2.9.2",
 				"@types/react": "*",
-				"date-fns": "^2.0.1",
-				"popper.js": "^1.14.1"
+				"date-fns": "^2.0.1"
 			}
 		},
 		"@types/react-dnd": {
@@ -11512,15 +11512,6 @@
 				"capture-stack-trace": "^1.0.0"
 			}
 		},
-		"create-react-context": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
-			"integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-			"requires": {
-				"gud": "^1.0.0",
-				"warning": "^4.0.3"
-			}
-		},
 		"cross-env": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
@@ -15819,11 +15810,6 @@
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
 			"optional": true
-		},
-		"gud": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
 		},
 		"gulp": {
 			"version": "4.0.2",
@@ -25286,11 +25272,6 @@
 			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
 			"integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
 		},
-		"popper.js": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-			"integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-		},
 		"portfinder": {
 			"version": "1.0.28",
 			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -26448,15 +26429,16 @@
 			}
 		},
 		"react-datepicker": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-3.3.0.tgz",
-			"integrity": "sha512-QnIlBxDSWEGBi2X5P1BqWzvfnPFRKhtrsgAcujUVwyWeID/VatFaAOEjEjfD1bXR9FuSYVLlLR3j/vbG19hWOA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.2.1.tgz",
+			"integrity": "sha512-0gcvHMnX8rS1fV90PjjsB7MQdsWNU77JeVHf6bbwK9HnFxgwjVflTx40ebKmHV+leqe+f+FgUP9Nvqbe5RGyfA==",
 			"requires": {
+				"@popperjs/core": "^2.9.2",
 				"classnames": "^2.2.6",
 				"date-fns": "^2.0.1",
 				"prop-types": "^15.7.2",
-				"react-onclickoutside": "^6.9.0",
-				"react-popper": "^1.3.4"
+				"react-onclickoutside": "^6.10.0",
+				"react-popper": "^2.2.5"
 			}
 		},
 		"react-devtools-core": {
@@ -27802,9 +27784,9 @@
 			}
 		},
 		"react-onclickoutside": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.9.0.tgz",
-			"integrity": "sha512-8ltIY3bC7oGhj2nPAvWOGi+xGFybPNhJM0V1H8hY/whNcXgmDeaeoCMPPd8VatrpTsUWjb/vGzrmu6SrXVty3A=="
+			"version": "6.11.2",
+			"resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.11.2.tgz",
+			"integrity": "sha512-640486eSwU/t5iD6yeTlefma8dI3bxPXD93hM9JGKyYITAd0P1JFkkcDeyHZRqNpY/fv1YW0Fad9BXr44OY8wQ=="
 		},
 		"react-overlays": {
 			"version": "5.0.1",
@@ -27852,31 +27834,18 @@
 			}
 		},
 		"react-popper": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
-			"integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
+			"integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
 			"requires": {
-				"@babel/runtime": "^7.1.2",
-				"create-react-context": "^0.3.0",
-				"deep-equal": "^1.1.1",
-				"popper.js": "^1.14.4",
-				"prop-types": "^15.6.1",
-				"typed-styles": "^0.0.7",
+				"react-fast-compare": "^3.0.1",
 				"warning": "^4.0.2"
 			},
 			"dependencies": {
-				"deep-equal": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-					"integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-					"requires": {
-						"is-arguments": "^1.0.4",
-						"is-date-object": "^1.0.1",
-						"is-regex": "^1.0.4",
-						"object-is": "^1.0.1",
-						"object-keys": "^1.1.1",
-						"regexp.prototype.flags": "^1.2.0"
-					}
+				"react-fast-compare": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+					"integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
 				}
 			}
 		},
@@ -31656,11 +31625,6 @@
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.24"
 			}
-		},
-		"typed-styles": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-			"integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
 		},
 		"typedarray": {
 			"version": "0.0.6",

--- a/packages/pluggableWidgets/datagrid-date-filter-web/package.json
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/package.json
@@ -27,11 +27,11 @@
     "@mendix/piw-utils-internal": "^1.0.0",
     "classnames": "^2.2.6",
     "date-fns": "^2.16.1",
-    "react-datepicker": "^3.3.0"
+    "react-datepicker": "^4.2.1"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
-    "@types/react-datepicker": "^3.1.1",
+    "@types/react-datepicker": "^4.1.4",
     "eslint": "^7.20.0"
   }
 }

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/components/DatePicker.tsx
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/components/DatePicker.tsx
@@ -6,12 +6,14 @@ import {
     MutableRefObject,
     ReactElement,
     SetStateAction,
+    useMemo,
     useRef,
     useState
 } from "react";
 import DatePickerComponent from "react-datepicker";
 import classNames from "classnames";
 import { isDate, isValid } from "date-fns";
+import { createPortal } from "react-dom";
 
 interface DatePickerProps {
     adjustable: boolean;
@@ -28,8 +30,11 @@ export const DatePicker = forwardRef(
     (props: DatePickerProps, ref: MutableRefObject<DatePickerComponent> | null): ReactElement => {
         const [open, setOpen] = useState(false);
         const buttonRef = useRef<HTMLButtonElement>(null);
+        const id = useMemo(() => `datepicker_` + Math.random(), []);
+        const Portal = createPortal(<div id={id} style={{ position: "fixed" }} />, document.body);
         return (
             <Fragment>
+                {Portal}
                 <span className="sr-only" id={`${props.name}-label`}>
                     {props.screenReaderInputCaption}
                 </span>
@@ -57,21 +62,15 @@ export const DatePicker = forwardRef(
                         setOpen(false);
                     }}
                     placeholderText={props.placeholder}
-                    popperPlacement="bottom-start"
-                    popperModifiers={{
-                        offset: {
-                            enabled: true,
-                            offset: "0, 0"
-                        },
-                        preventOverflow: {
-                            enabled: true,
-                            escapeWithReference: false,
-                            boundariesElement: "viewport"
-                        },
-                        flip: {
-                            enabled: false
+                    popperPlacement="bottom-end"
+                    popperModifiers={[
+                        {
+                            name: "offset",
+                            options: {
+                                offset: [0, 0]
+                            }
                         }
-                    }}
+                    ]}
                     preventOpenOnFocus
                     ref={ref}
                     selected={props.value}
@@ -81,6 +80,7 @@ export const DatePicker = forwardRef(
                     showYearDropdown
                     strictParsing
                     useWeekdaysShort
+                    portalId={id}
                 />
                 <button ref={buttonRef} className="btn btn-default btn-calendar" onClick={() => setOpen(prev => !prev)}>
                     <span className="glyphicon glyphicon-calendar" />

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/DatagridDateFilter.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/DatagridDateFilter.spec.tsx
@@ -32,6 +32,8 @@ describe("Date Filter", () => {
                 singleAttribute: new ListAttributeValueBuilder().withType("DateTime").withFilterable(true).build()
             } as FilterContextValue);
             (window as any).mx = mxObject;
+
+            jest.spyOn(global.Math, "random").mockReturnValue(0.123456789);
         });
 
         it("renders correctly", () => {
@@ -63,6 +65,8 @@ describe("Date Filter", () => {
                 }
             } as FilterContextValue);
             (window as any).mx = mxObject;
+
+            jest.spyOn(global.Math, "random").mockReturnValue(0.123456789);
         });
 
         it("renders correctly", () => {

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/DatePicker.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/DatePicker.spec.tsx
@@ -1,8 +1,18 @@
 import { render, shallow } from "enzyme";
 import { createElement } from "react";
 import { DatePicker } from "../DatePicker";
+import ReactDOM from "react-dom";
 
 describe("Date picker component", () => {
+    beforeAll(() => {
+        jest.spyOn(global.Math, "random").mockReturnValue(0.123456789);
+
+        // @ts-ignore
+        jest.spyOn(ReactDOM, "createPortal").mockReturnValue((element, node) => {
+            return element;
+        });
+    });
+
     it("renders correctly", () => {
         const component = render(
             <DatePicker adjustable value={null} setValue={jest.fn()} dateFormat="dd/MM/yyyy" locale="nl-NL" />
@@ -33,7 +43,7 @@ describe("Date picker component", () => {
             <DatePicker adjustable value={null} setValue={setValue} dateFormat="dd/MM/yyyy" locale="nl-NL" />
         );
 
-        component.find("a").simulate("change", { target: { value: "01/12/2020" } });
+        component.find("r").simulate("change", { target: { value: "01/12/2020" } });
 
         expect(setValue).toBeCalledTimes(1);
     });

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/DatePicker.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/DatePicker.spec.tsx
@@ -51,7 +51,7 @@ describe("Date picker component", () => {
             />
         );
 
-        fireEvent.change(await component.findByPlaceholderText("Placeholder"), { target: { value: "01/12/2020" } });
+        fireEvent.change(component.getByPlaceholderText("Placeholder"), { target: { value: "01/12/2020" } });
 
         expect(setValue).toBeCalledTimes(1);
     });

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/DatePicker.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/DatePicker.spec.tsx
@@ -1,5 +1,6 @@
-import { render, shallow } from "enzyme";
 import { createElement } from "react";
+import { render as renderEnzyme } from "enzyme";
+import { render, fireEvent } from "@testing-library/react";
 import { DatePicker } from "../DatePicker";
 import ReactDOM from "react-dom";
 
@@ -14,7 +15,7 @@ describe("Date picker component", () => {
     });
 
     it("renders correctly", () => {
-        const component = render(
+        const component = renderEnzyme(
             <DatePicker adjustable value={null} setValue={jest.fn()} dateFormat="dd/MM/yyyy" locale="nl-NL" />
         );
 
@@ -22,7 +23,7 @@ describe("Date picker component", () => {
     });
 
     it("renders correctly when is not adjustable", () => {
-        const component = render(
+        const component = renderEnzyme(
             <DatePicker adjustable={false} value={null} setValue={jest.fn()} dateFormat="dd/MM/yyyy" locale="nl-NL" />
         );
 
@@ -30,20 +31,27 @@ describe("Date picker component", () => {
     });
 
     it("renders correctly with different locale and date format", () => {
-        const component = render(
+        const component = renderEnzyme(
             <DatePicker adjustable={false} value={null} setValue={jest.fn()} dateFormat="yyyy-MM-dd" locale="pt-BR" />
         );
 
         expect(component).toMatchSnapshot();
     });
 
-    it("calls for setValue when value changes", () => {
+    it("calls for setValue when value changes", async () => {
         const setValue = jest.fn();
-        const component = shallow(
-            <DatePicker adjustable value={null} setValue={setValue} dateFormat="dd/MM/yyyy" locale="nl-NL" />
+        const component = render(
+            <DatePicker
+                adjustable
+                value={null}
+                setValue={setValue}
+                dateFormat="dd/MM/yyyy"
+                locale="nl-NL"
+                placeholder="Placeholder"
+            />
         );
 
-        component.find("r").simulate("change", { target: { value: "01/12/2020" } });
+        fireEvent.change(await component.findByPlaceholderText("Placeholder"), { target: { value: "01/12/2020" } });
 
         expect(setValue).toBeCalledTimes(1);
     });

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/FilterComponent.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/FilterComponent.spec.tsx
@@ -1,8 +1,16 @@
 import { render } from "enzyme";
 import { createElement } from "react";
 import { FilterComponent } from "../FilterComponent";
+import ReactDOM from "react-dom";
 
 describe("Filter component", () => {
+    beforeAll(() => {
+        // @ts-ignore
+        jest.spyOn(ReactDOM, "createPortal").mockReturnValue((element, node) => {
+            return element;
+        });
+    });
+
     it("renders correctly", () => {
         const component = render(<FilterComponent adjustable defaultFilter="equal" />);
 

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/__snapshots__/DatagridDateFilter.spec.tsx.snap
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/__snapshots__/DatagridDateFilter.spec.tsx.snap
@@ -80,11 +80,34 @@ exports[`Date Filter with multiple attributes renders correctly 1`] = `
         setValue={[Function]}
         value={null}
       >
+        <Portal
+          containerInfo={
+            <body>
+              <div
+                id="datepicker_0.123456789"
+                style="position: fixed;"
+              />
+              <div
+                id="datepicker_0.123456789"
+                style="position: fixed;"
+              />
+            </body>
+          }
+        >
+          <div
+            id="datepicker_0.123456789"
+            style={
+              Object {
+                "position": "fixed",
+              }
+            }
+          />
+        </Portal>
         <span
           className="sr-only"
           id="filter-test-label"
         />
-        <a
+        <r
           allowSameDay={false}
           ariaLabelledBy="filter-test-label"
           autoFocus={false}
@@ -116,22 +139,20 @@ exports[`Date Filter with multiple attributes renders correctly 1`] = `
           onYearChange={[Function]}
           open={false}
           popperModifiers={
-            Object {
-              "flip": Object {
-                "enabled": false,
+            Array [
+              Object {
+                "name": "offset",
+                "options": Object {
+                  "offset": Array [
+                    0,
+                    0,
+                  ],
+                },
               },
-              "offset": Object {
-                "enabled": true,
-                "offset": "0, 0",
-              },
-              "preventOverflow": Object {
-                "boundariesElement": "viewport",
-                "enabled": true,
-                "escapeWithReference": false,
-              },
-            }
+            ]
           }
-          popperPlacement="bottom-start"
+          popperPlacement="bottom-end"
+          portalId="datepicker_0.123456789"
           preventOpenOnFocus={true}
           previousMonthButtonLabel="Previous Month"
           previousYearButtonLabel="Previous Year"
@@ -139,6 +160,7 @@ exports[`Date Filter with multiple attributes renders correctly 1`] = `
           renderDayContents={[Function]}
           selected={null}
           shouldCloseOnSelect={false}
+          showFourColumnMonthYearPicker={false}
           showFullMonthYearPicker={false}
           showMonthDropdown={true}
           showMonthYearPicker={false}
@@ -158,29 +180,27 @@ exports[`Date Filter with multiple attributes renders correctly 1`] = `
           withPortal={false}
           yearItemNumber={12}
         >
-          <o
+          <r
             enableTabLoop={true}
             hidePopper={true}
             popperComponent={null}
             popperModifiers={
-              Object {
-                "flip": Object {
-                  "enabled": false,
+              Array [
+                Object {
+                  "name": "offset",
+                  "options": Object {
+                    "offset": Array [
+                      0,
+                      0,
+                    ],
+                  },
                 },
-                "offset": Object {
-                  "enabled": true,
-                  "offset": "0, 0",
-                },
-                "preventOverflow": Object {
-                  "boundariesElement": "viewport",
-                  "enabled": true,
-                  "escapeWithReference": false,
-                },
-              }
+              ]
             }
             popperOnKeyDown={[Function]}
-            popperPlacement="bottom-start"
+            popperPlacement="bottom-end"
             popperProps={Object {}}
+            portalId="datepicker_0.123456789"
             targetComponent={
               <div
                 className="react-datepicker__input-container"
@@ -206,36 +226,32 @@ exports[`Date Filter with multiple attributes renders correctly 1`] = `
               className="react-datepicker-manager"
             >
               <Reference>
-                <InnerReference
-                  setReferenceNode={[Function]}
+                <div
+                  className="react-datepicker-wrapper"
                 >
                   <div
-                    className="react-datepicker-wrapper"
+                    className="react-datepicker__input-container"
                   >
-                    <div
-                      className="react-datepicker__input-container"
-                    >
-                      <input
-                        aria-labelledby="filter-test-label"
-                        autoFocus={false}
-                        className="form-control filter-input"
-                        disabled={false}
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        readOnly={false}
-                        type="text"
-                        value=""
-                      />
-                    </div>
+                    <input
+                      aria-labelledby="filter-test-label"
+                      autoFocus={false}
+                      className="form-control filter-input"
+                      disabled={false}
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      readOnly={false}
+                      type="text"
+                      value=""
+                    />
                   </div>
-                </InnerReference>
+                </div>
               </Reference>
             </Manager>
-          </o>
-        </a>
+          </r>
+        </r>
         <button
           className="btn btn-default btn-calendar"
           onClick={[Function]}
@@ -330,11 +346,30 @@ exports[`Date Filter with single attribute renders correctly 1`] = `
         setValue={[Function]}
         value={null}
       >
+        <Portal
+          containerInfo={
+            <body>
+              <div
+                id="datepicker_0.123456789"
+                style="position: fixed;"
+              />
+            </body>
+          }
+        >
+          <div
+            id="datepicker_0.123456789"
+            style={
+              Object {
+                "position": "fixed",
+              }
+            }
+          />
+        </Portal>
         <span
           className="sr-only"
           id="filter-test-label"
         />
-        <a
+        <r
           allowSameDay={false}
           ariaLabelledBy="filter-test-label"
           autoFocus={false}
@@ -366,22 +401,20 @@ exports[`Date Filter with single attribute renders correctly 1`] = `
           onYearChange={[Function]}
           open={false}
           popperModifiers={
-            Object {
-              "flip": Object {
-                "enabled": false,
+            Array [
+              Object {
+                "name": "offset",
+                "options": Object {
+                  "offset": Array [
+                    0,
+                    0,
+                  ],
+                },
               },
-              "offset": Object {
-                "enabled": true,
-                "offset": "0, 0",
-              },
-              "preventOverflow": Object {
-                "boundariesElement": "viewport",
-                "enabled": true,
-                "escapeWithReference": false,
-              },
-            }
+            ]
           }
-          popperPlacement="bottom-start"
+          popperPlacement="bottom-end"
+          portalId="datepicker_0.123456789"
           preventOpenOnFocus={true}
           previousMonthButtonLabel="Previous Month"
           previousYearButtonLabel="Previous Year"
@@ -389,6 +422,7 @@ exports[`Date Filter with single attribute renders correctly 1`] = `
           renderDayContents={[Function]}
           selected={null}
           shouldCloseOnSelect={false}
+          showFourColumnMonthYearPicker={false}
           showFullMonthYearPicker={false}
           showMonthDropdown={true}
           showMonthYearPicker={false}
@@ -408,29 +442,27 @@ exports[`Date Filter with single attribute renders correctly 1`] = `
           withPortal={false}
           yearItemNumber={12}
         >
-          <o
+          <r
             enableTabLoop={true}
             hidePopper={true}
             popperComponent={null}
             popperModifiers={
-              Object {
-                "flip": Object {
-                  "enabled": false,
+              Array [
+                Object {
+                  "name": "offset",
+                  "options": Object {
+                    "offset": Array [
+                      0,
+                      0,
+                    ],
+                  },
                 },
-                "offset": Object {
-                  "enabled": true,
-                  "offset": "0, 0",
-                },
-                "preventOverflow": Object {
-                  "boundariesElement": "viewport",
-                  "enabled": true,
-                  "escapeWithReference": false,
-                },
-              }
+              ]
             }
             popperOnKeyDown={[Function]}
-            popperPlacement="bottom-start"
+            popperPlacement="bottom-end"
             popperProps={Object {}}
+            portalId="datepicker_0.123456789"
             targetComponent={
               <div
                 className="react-datepicker__input-container"
@@ -456,36 +488,32 @@ exports[`Date Filter with single attribute renders correctly 1`] = `
               className="react-datepicker-manager"
             >
               <Reference>
-                <InnerReference
-                  setReferenceNode={[Function]}
+                <div
+                  className="react-datepicker-wrapper"
                 >
                   <div
-                    className="react-datepicker-wrapper"
+                    className="react-datepicker__input-container"
                   >
-                    <div
-                      className="react-datepicker__input-container"
-                    >
-                      <input
-                        aria-labelledby="filter-test-label"
-                        autoFocus={false}
-                        className="form-control filter-input"
-                        disabled={false}
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        readOnly={false}
-                        type="text"
-                        value=""
-                      />
-                    </div>
+                    <input
+                      aria-labelledby="filter-test-label"
+                      autoFocus={false}
+                      className="form-control filter-input"
+                      disabled={false}
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      readOnly={false}
+                      type="text"
+                      value=""
+                    />
                   </div>
-                </InnerReference>
+                </div>
               </Reference>
             </Manager>
-          </o>
-        </a>
+          </r>
+        </r>
         <button
           className="btn btn-default btn-calendar"
           onClick={[Function]}

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/__snapshots__/DatagridDateFilter.spec.tsx.snap
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/__snapshots__/DatagridDateFilter.spec.tsx.snap
@@ -66,6 +66,7 @@ exports[`Date Filter with multiple attributes renders correctly 1`] = `
               aria-haspopup={true}
               className="btn btn-default filter-selector-button button-icon equal"
               onClick={[Function]}
+              onKeyDown={[Function]}
             >
                
             </button>
@@ -332,6 +333,7 @@ exports[`Date Filter with single attribute renders correctly 1`] = `
               aria-haspopup={true}
               className="btn btn-default filter-selector-button button-icon equal"
               onClick={[Function]}
+              onKeyDown={[Function]}
             >
                
             </button>

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/__snapshots__/DatagridDateFilter.spec.tsx.snap
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/__snapshots__/DatagridDateFilter.spec.tsx.snap
@@ -256,6 +256,7 @@ exports[`Date Filter with multiple attributes renders correctly 1`] = `
         <button
           className="btn btn-default btn-calendar"
           onClick={[Function]}
+          onKeyDown={[Function]}
         >
           <span
             className="glyphicon glyphicon-calendar"
@@ -519,6 +520,7 @@ exports[`Date Filter with single attribute renders correctly 1`] = `
         <button
           className="btn btn-default btn-calendar"
           onClick={[Function]}
+          onKeyDown={[Function]}
         >
           <span
             className="glyphicon glyphicon-calendar"

--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/components/FilterComponent.tsx
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/components/FilterComponent.tsx
@@ -31,7 +31,7 @@ export function FilterComponent(props: FilterComponentProps): ReactElement {
     const componentRef = useRef<HTMLDivElement>(null);
     const optionsRef = useRef<HTMLUListElement>(null);
 
-    const [position, onAnimateFrameHandler] = usePositionObserver(componentRef.current);
+    const position = usePositionObserver(componentRef.current, show);
 
     const setMultiSelectFilters = useCallback(
         (selectedOptions: FilterOption[]) => {
@@ -122,14 +122,6 @@ export function FilterComponent(props: FilterComponentProps): ReactElement {
     useEffect(() => {
         props.updateFilters?.(selectedFilters);
     }, [selectedFilters]);
-
-    useEffect(() => {
-        let cleanup;
-        if (show) {
-            cleanup = onAnimateFrameHandler();
-        }
-        return cleanup;
-    }, [onAnimateFrameHandler, show]);
 
     const showPlaceholder = selectedFilters.length === 0 || valueInput === props.emptyOptionCaption;
 

--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/components/FilterComponent.tsx
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/components/FilterComponent.tsx
@@ -150,6 +150,13 @@ export function FilterComponent(props: FilterComponentProps): ReactElement {
                             e.preventDefault();
                             e.stopPropagation();
                             onClick(option);
+                        } else if (
+                            (e.key === "Tab" && (index + 1 === options.length || (e.shiftKey && index === 0))) ||
+                            e.key === "Escape"
+                        ) {
+                            e.preventDefault();
+                            setShow(false);
+                            componentRef.current?.querySelector("input")?.focus();
                         }
                     }}
                     role="menuitem"

--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/components/__tests__/FilterComponent.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/components/__tests__/FilterComponent.spec.tsx
@@ -1,12 +1,17 @@
 import { mount, render, shallow } from "enzyme";
 import { createElement } from "react";
 import { FilterComponent } from "../FilterComponent";
+import { render as renderTestingLib, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
 
 const defaultOptions = [
     { caption: "1", value: "_1" },
     { caption: "2", value: "_2" },
     { caption: "3", value: "_3" }
 ];
+
+jest.useFakeTimers();
 
 describe("Filter selector", () => {
     describe("with single selection", () => {
@@ -173,6 +178,99 @@ describe("Filter selector", () => {
 
                 expect(component.find("input").first().prop("value")).toBe("2,3");
             });
+        });
+    });
+
+    describe("focus", () => {
+        beforeEach(() => (document.body.innerHTML = ""));
+
+        it("changes focused element when pressing the input", () => {
+            const component = renderTestingLib(
+                <FilterComponent options={defaultOptions} emptyOptionCaption="Click me" />
+            );
+
+            expect(document.body).toHaveFocus();
+            const input = component.getByPlaceholderText("Click me");
+            expect(input).toBeDefined();
+            fireEvent.click(input);
+
+            jest.advanceTimersByTime(10);
+
+            const items = component.getAllByRole("menuitem");
+            expect(items[0]).toHaveFocus();
+        });
+
+        it("changes focused element back to the input when pressing shift+tab in the first element", () => {
+            const component = renderTestingLib(
+                <FilterComponent options={defaultOptions} emptyOptionCaption="Click me" />
+            );
+
+            expect(document.body).toHaveFocus();
+
+            const input = component.getByPlaceholderText("Click me");
+            expect(input).toBeDefined();
+            fireEvent.click(input);
+
+            jest.advanceTimersByTime(10);
+
+            const items = component.getAllByRole("menuitem");
+            expect(items[0]).toHaveFocus();
+
+            userEvent.tab({ shift: true });
+
+            jest.advanceTimersByTime(10);
+
+            expect(input).toHaveFocus();
+        });
+
+        it("changes focused element back to the input when pressing tab on the last item", () => {
+            const component = renderTestingLib(
+                <FilterComponent options={[{ caption: "1", value: "_1" }]} emptyOptionCaption="Click me" />
+            );
+
+            expect(document.body).toHaveFocus();
+
+            const input = component.getByPlaceholderText("Click me");
+            fireEvent.click(input);
+
+            jest.advanceTimersByTime(10);
+
+            const items = component.getAllByRole("menuitem");
+            expect(items[0]).toHaveFocus();
+
+            userEvent.tab();
+            expect(items[1]).toHaveFocus();
+            userEvent.tab();
+
+            jest.advanceTimersByTime(10);
+
+            expect(input).toHaveFocus();
+        });
+
+        it("changes focused element back to the input when pressing escape on the last item", () => {
+            const component = renderTestingLib(
+                <FilterComponent options={[{ caption: "1", value: "_1" }]} emptyOptionCaption="Click me" />
+            );
+
+            expect(document.body).toHaveFocus();
+
+            const input = component.getByPlaceholderText("Click me");
+            fireEvent.click(input);
+
+            jest.advanceTimersByTime(10);
+
+            const items = component.getAllByRole("menuitem");
+            expect(items[0]).toHaveFocus();
+
+            userEvent.tab();
+
+            expect(items[1]).toHaveFocus();
+
+            userEvent.keyboard("{esc}");
+
+            jest.advanceTimersByTime(10);
+
+            expect(input).toHaveFocus();
         });
     });
 });

--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/components/__tests__/FilterComponent.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/components/__tests__/FilterComponent.spec.tsx
@@ -1,7 +1,7 @@
 import { mount, render, shallow } from "enzyme";
 import { createElement } from "react";
 import { FilterComponent } from "../FilterComponent";
-import { render as renderTestingLib, fireEvent } from "@testing-library/react";
+import { render as renderTestingLib, fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
@@ -185,35 +185,31 @@ describe("Filter selector", () => {
         beforeEach(() => (document.body.innerHTML = ""));
 
         it("changes focused element when pressing the input", () => {
-            const component = renderTestingLib(
-                <FilterComponent options={defaultOptions} emptyOptionCaption="Click me" />
-            );
+            renderTestingLib(<FilterComponent options={defaultOptions} emptyOptionCaption="Click me" />);
 
             expect(document.body).toHaveFocus();
-            const input = component.getByPlaceholderText("Click me");
+            const input = screen.getByPlaceholderText("Click me");
             expect(input).toBeDefined();
             fireEvent.click(input);
 
             jest.advanceTimersByTime(10);
 
-            const items = component.getAllByRole("menuitem");
+            const items = screen.getAllByRole("menuitem");
             expect(items[0]).toHaveFocus();
         });
 
         it("changes focused element back to the input when pressing shift+tab in the first element", () => {
-            const component = renderTestingLib(
-                <FilterComponent options={defaultOptions} emptyOptionCaption="Click me" />
-            );
+            renderTestingLib(<FilterComponent options={defaultOptions} emptyOptionCaption="Click me" />);
 
             expect(document.body).toHaveFocus();
 
-            const input = component.getByPlaceholderText("Click me");
+            const input = screen.getByPlaceholderText("Click me");
             expect(input).toBeDefined();
             fireEvent.click(input);
 
             jest.advanceTimersByTime(10);
 
-            const items = component.getAllByRole("menuitem");
+            const items = screen.getAllByRole("menuitem");
             expect(items[0]).toHaveFocus();
 
             userEvent.tab({ shift: true });
@@ -224,18 +220,18 @@ describe("Filter selector", () => {
         });
 
         it("changes focused element back to the input when pressing tab on the last item", () => {
-            const component = renderTestingLib(
+            renderTestingLib(
                 <FilterComponent options={[{ caption: "1", value: "_1" }]} emptyOptionCaption="Click me" />
             );
 
             expect(document.body).toHaveFocus();
 
-            const input = component.getByPlaceholderText("Click me");
+            const input = screen.getByPlaceholderText("Click me");
             fireEvent.click(input);
 
             jest.advanceTimersByTime(10);
 
-            const items = component.getAllByRole("menuitem");
+            const items = screen.getAllByRole("menuitem");
             expect(items[0]).toHaveFocus();
 
             userEvent.tab();
@@ -247,19 +243,26 @@ describe("Filter selector", () => {
             expect(input).toHaveFocus();
         });
 
-        it("changes focused element back to the input when pressing escape on the last item", () => {
-            const component = renderTestingLib(
-                <FilterComponent options={[{ caption: "1", value: "_1" }]} emptyOptionCaption="Click me" />
+        it("changes focused element back to the input when pressing escape on any item", () => {
+            renderTestingLib(
+                <FilterComponent
+                    options={[
+                        { caption: "1", value: "_1" },
+                        { caption: "2", value: "_2" }
+                    ]}
+                    emptyOptionCaption="Click me"
+                />
             );
 
             expect(document.body).toHaveFocus();
 
-            const input = component.getByPlaceholderText("Click me");
+            const input = screen.getByPlaceholderText("Click me");
             fireEvent.click(input);
 
             jest.advanceTimersByTime(10);
 
-            const items = component.getAllByRole("menuitem");
+            const items = screen.getAllByRole("menuitem");
+            expect(items).toHaveLength(3);
             expect(items[0]).toHaveFocus();
 
             userEvent.tab();

--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/components/__tests__/FilterComponent.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/components/__tests__/FilterComponent.spec.tsx
@@ -44,32 +44,34 @@ describe("Filter selector", () => {
 
         describe("when value changes", () => {
             it("calls updateFilters when value changes", () => {
+                const onClickProps = { preventDefault: jest.fn(), stopPropagation: jest.fn() };
                 const updateFilterHandler = jest.fn();
                 const component = shallow(
                     <FilterComponent options={defaultOptions} updateFilters={updateFilterHandler} />
                 );
 
                 const input = component.find("input");
-                input.simulate("click");
+                input.simulate("click", onClickProps);
 
                 const item = component.find("li").first();
-                item.simulate("click");
+                item.simulate("click", onClickProps);
 
                 expect(updateFilterHandler).toBeCalled();
             });
             it("shows selected option on input value", () => {
+                const onClickProps = { preventDefault: jest.fn(), stopPropagation: jest.fn() };
                 const defaultOption = defaultOptions[1];
                 const component = shallow(
                     <FilterComponent options={defaultOptions} defaultValue={defaultOption.value} />
                 );
 
                 const input = component.find("input");
-                input.simulate("click");
+                input.simulate("click", onClickProps);
 
                 expect(component.find("input").first().prop("value")).toBe(defaultOption.caption);
 
                 const item = component.find("li").last(); // [cap 3: val:_3]
-                item.simulate("click");
+                item.simulate("click", onClickProps);
 
                 expect(component.find("input").first().prop("value")).toBe(defaultOptions[2].caption);
             });
@@ -143,29 +145,31 @@ describe("Filter selector", () => {
 
         describe("when value changes", () => {
             it("calls updateFilters when value changes", () => {
+                const onClickProps = { preventDefault: jest.fn(), stopPropagation: jest.fn() };
                 const updateFiltersHandler = jest.fn();
                 const component = mount(
                     <FilterComponent multiSelect options={defaultOptions} updateFilters={updateFiltersHandler} />
                 );
 
                 const input = component.find("input");
-                input.simulate("click");
+                input.simulate("click", onClickProps);
 
                 const item = component.find("li").first();
-                item.simulate("click");
+                item.simulate("click", onClickProps);
 
                 expect(updateFiltersHandler).toBeCalled();
             });
             it("shows selected options on input value", () => {
+                const onClickProps = { preventDefault: jest.fn(), stopPropagation: jest.fn() };
                 const component = mount(<FilterComponent multiSelect options={defaultOptions} />);
 
                 const input = component.find("input");
-                input.simulate("click");
+                input.simulate("click", onClickProps);
 
                 const item = component.find("li").at(1);
-                item.simulate("click");
+                item.simulate("click", onClickProps);
                 const item2 = component.find("li").at(2);
-                item2.simulate("click");
+                item2.simulate("click", onClickProps);
 
                 expect(component.find("input").first().prop("value")).toBe("2,3");
             });

--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/tests/e2e/specs/DataGridDropDownFilter.spec.ts
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/tests/e2e/specs/DataGridDropDownFilter.spec.ts
@@ -13,7 +13,7 @@ describe("datagrid-dropdown-filter-web", () => {
 
             dropdown.click();
 
-            const dropdownOption = page.getElement(".dropdown-list > li:nth-child(1)", dropdown);
+            const dropdownOption = page.getElement(".dropdown-list > li:nth-child(1)");
 
             dropdownOption.click();
 
@@ -37,9 +37,9 @@ describe("datagrid-dropdown-filter-web", () => {
 
             dropdown.click();
 
-            const dropdownOption = page.getElement(".dropdown-list > li:nth-child(1)", dropdown);
+            const dropdownOption = page.getElement(".dropdown-list > li:nth-child(1)");
 
-            const dropdownOption2 = page.getElement(".dropdown-list > li:nth-child(2)", dropdown);
+            const dropdownOption2 = page.getElement(".dropdown-list > li:nth-child(2)");
 
             dropdownOption.click();
 
@@ -78,7 +78,7 @@ describe("datagrid-dropdown-filter-web", () => {
 
             dropdown.click();
 
-            const dropdownOption = page.getElement(".dropdown-list > li:nth-child(3) > div", dropdown);
+            const dropdownOption = page.getElement(".dropdown-list > li:nth-child(3) > div");
 
             expect(dropdownOption.getText()).toContain("No");
 

--- a/packages/pluggableWidgets/datagrid-number-filter-web/src/components/__tests__/__snapshots__/DatagridNumberFilter.spec.tsx.snap
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/src/components/__tests__/__snapshots__/DatagridNumberFilter.spec.tsx.snap
@@ -66,6 +66,7 @@ exports[`Number Filter with multiple attributes renders correctly 1`] = `
               aria-haspopup={true}
               className="btn btn-default filter-selector-button button-icon equal"
               onClick={[Function]}
+              onKeyDown={[Function]}
             >
                
             </button>
@@ -148,6 +149,7 @@ exports[`Number Filter with single attribute renders correctly 1`] = `
               aria-haspopup={true}
               className="btn btn-default filter-selector-button button-icon equal"
               onClick={[Function]}
+              onKeyDown={[Function]}
             >
                
             </button>

--- a/packages/pluggableWidgets/datagrid-text-filter-web/src/components/__tests__/__snapshots__/DatagridTextFilter.spec.tsx.snap
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/src/components/__tests__/__snapshots__/DatagridTextFilter.spec.tsx.snap
@@ -78,6 +78,7 @@ exports[`Text Filter with multiple attributes renders correctly 1`] = `
               aria-haspopup={true}
               className="btn btn-default filter-selector-button button-icon equal"
               onClick={[Function]}
+              onKeyDown={[Function]}
             >
                
             </button>
@@ -173,6 +174,7 @@ exports[`Text Filter with single attribute renders correctly 1`] = `
               aria-haspopup={true}
               className="btn btn-default filter-selector-button button-icon equal"
               onClick={[Function]}
+              onKeyDown={[Function]}
             >
                
             </button>

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -190,6 +190,7 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
                 ),
                 [FilterContext, customFiltersState, filterList, multipleInitialFilters, props.filtersPlaceholder]
             )}
+            name={props.name}
             numberOfItems={props.datasource.totalCount}
             onSettingsChange={props.onConfigurationChange ? onConfigurationChange : undefined}
             page={currentPage}

--- a/packages/pluggableWidgets/datagrid-web/src/components/ColumnSelector.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/ColumnSelector.tsx
@@ -1,4 +1,4 @@
-import { createElement, Dispatch, ReactElement, SetStateAction, useEffect, useRef, useState } from "react";
+import { createElement, Dispatch, ReactElement, SetStateAction, useCallback, useMemo, useRef, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEye } from "@fortawesome/free-regular-svg-icons";
 import { useOnClickOutside, usePositionObserver } from "@mendix/piw-utils-internal";
@@ -8,6 +8,7 @@ import { createPortal } from "react-dom";
 export interface ColumnSelectorProps {
     columns: ColumnProperty[];
     hiddenColumns: string[];
+    name?: string;
     setHiddenColumns: Dispatch<SetStateAction<string[]>>;
 }
 
@@ -19,11 +20,40 @@ export function ColumnSelector(props: ColumnSelectorProps): ReactElement {
 
     useOnClickOutside([buttonRef, optionsRef], () => setShow(false));
 
+    const onClick = useCallback(
+        (isVisible: boolean, id: string) =>
+            props.setHiddenColumns(prev => {
+                if (!isVisible) {
+                    prev.splice(
+                        prev.findIndex(v => v === id),
+                        1
+                    );
+                    return [...prev];
+                } else {
+                    return [...prev, id];
+                }
+            }),
+        [props.setHiddenColumns]
+    );
+
+    const firstHidableColumnIndex = useMemo(() => props.columns.findIndex(c => c.canHide), [props.columns]);
+    const lastHidableColumnIndex = useMemo(() => {
+        const index = props.columns
+            .slice()
+            .reverse()
+            .findIndex(c => c.canHide);
+        const count = props.columns.length - 1;
+
+        return index > -1 ? count - index : count;
+    }, [props.columns]);
 
     const optionsComponent = createPortal(
         <ul
             ref={optionsRef}
+            id={`${props.name}-column-selectors`}
             className="column-selectors"
+            data-focusindex={0}
+            role="menu"
             style={{
                 position: "fixed",
                 top: position?.bottom,
@@ -33,27 +63,42 @@ export function ColumnSelector(props: ColumnSelectorProps): ReactElement {
             {props.columns.map((column: ColumnProperty, index: number) => {
                 const isVisible = !props.hiddenColumns.includes(column.id);
                 return column.canHide ? (
-                    <li key={index}>
+                    <li
+                        key={index}
+                        onClick={e => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            onClick(isVisible, column.id);
+                        }}
+                        onKeyDown={e => {
+                            if (e.key === "Enter" || e.key === " ") {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                onClick(isVisible, column.id);
+                            } else if (
+                                (e.key === "Tab" &&
+                                    (index === lastHidableColumnIndex ||
+                                        (e.shiftKey && index === firstHidableColumnIndex))) ||
+                                e.key === "Escape"
+                            ) {
+                                e.preventDefault();
+                                setShow(false);
+                                buttonRef.current?.focus();
+                            }
+                        }}
+                        role="menuitem"
+                        tabIndex={0}
+                    >
                         <input
                             checked={isVisible}
                             disabled={isVisible && props.columns.length - props.hiddenColumns.length === 1}
-                            id={`checkbox_toggle_${index}`}
-                            onClick={() => {
-                                props.setHiddenColumns(prev => {
-                                    if (!isVisible) {
-                                        prev.splice(
-                                            prev.findIndex(v => v === column.id),
-                                            1
-                                        );
-                                        return [...prev];
-                                    } else {
-                                        return [...prev, column.id];
-                                    }
-                                });
-                            }}
+                            id={`${props.name}_checkbox_toggle_${index}`}
                             type="checkbox"
+                            tabIndex={-1}
                         />
-                        <label htmlFor={`checkbox_toggle_${index}`}>{column.header}</label>
+                        <label htmlFor={`${props.name}_checkbox_toggle_${index}`} style={{ pointerEvents: "none" }}>
+                            {column.header}
+                        </label>
                     </li>
                 ) : null;
             })}
@@ -61,15 +106,30 @@ export function ColumnSelector(props: ColumnSelectorProps): ReactElement {
         document.body
     );
 
+    const containerClick = useCallback(() => {
+        setShow(show => !show);
+        setTimeout(() => {
+            (optionsRef.current?.querySelector("li") as HTMLElement)?.focus();
+        }, 10);
+    }, []);
+
     return (
         <div className="th column-selector">
             <div className="column-selector-content">
                 <button
                     ref={buttonRef}
                     className="btn btn-default column-selector-button"
-                    onClick={() => {
-                        setShow(show => !show);
+                    onClick={containerClick}
+                    onKeyDown={e => {
+                        if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            containerClick();
+                        }
                     }}
+                    aria-haspopup
+                    aria-expanded={show}
+                    aria-controls={`${props.name}-column-selectors`}
                 >
                     <FontAwesomeIcon icon={faEye} />
                 </button>

--- a/packages/pluggableWidgets/datagrid-web/src/components/ColumnSelector.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/ColumnSelector.tsx
@@ -15,17 +15,10 @@ export function ColumnSelector(props: ColumnSelectorProps): ReactElement {
     const [show, setShow] = useState(false);
     const optionsRef = useRef<HTMLUListElement>(null);
     const buttonRef = useRef<HTMLButtonElement>(null);
-    const [position, onAnimateFrameHandler] = usePositionObserver(buttonRef.current);
+    const position = usePositionObserver(buttonRef.current, show);
 
     useOnClickOutside([buttonRef, optionsRef], () => setShow(false));
 
-    useEffect(() => {
-        let cleanup;
-        if (show) {
-            cleanup = onAnimateFrameHandler();
-        }
-        return cleanup;
-    }, [onAnimateFrameHandler, show]);
 
     const optionsComponent = createPortal(
         <ul

--- a/packages/pluggableWidgets/datagrid-web/src/components/ColumnSelector.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/ColumnSelector.tsx
@@ -24,11 +24,7 @@ export function ColumnSelector(props: ColumnSelectorProps): ReactElement {
         (isVisible: boolean, id: string) =>
             props.setHiddenColumns(prev => {
                 if (!isVisible) {
-                    prev.splice(
-                        prev.findIndex(v => v === id),
-                        1
-                    );
-                    return [...prev];
+                    return prev.filter(v => v !== id);
                 } else {
                     return [...prev, id];
                 }
@@ -37,15 +33,7 @@ export function ColumnSelector(props: ColumnSelectorProps): ReactElement {
     );
 
     const firstHidableColumnIndex = useMemo(() => props.columns.findIndex(c => c.canHide), [props.columns]);
-    const lastHidableColumnIndex = useMemo(() => {
-        const index = props.columns
-            .slice()
-            .reverse()
-            .findIndex(c => c.canHide);
-        const count = props.columns.length - 1;
-
-        return index > -1 ? count - index : count;
-    }, [props.columns]);
+    const lastHidableColumnIndex = useMemo(() => props.columns.map(c => c.canHide).lastIndexOf(true), [props.columns]);
 
     const optionsComponent = createPortal(
         <ul
@@ -57,7 +45,7 @@ export function ColumnSelector(props: ColumnSelectorProps): ReactElement {
             style={{
                 position: "fixed",
                 top: position?.bottom,
-                right: position?.right ? document.body.clientWidth - position.right : undefined
+                right: position?.right !== undefined ? document.body.clientWidth - position.right : undefined
             }}
         >
             {props.columns.map((column: ColumnProperty, index: number) => {

--- a/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
@@ -42,6 +42,7 @@ export interface TableProps<T> {
     hasMoreItems: boolean;
     headerFilters?: ReactNode;
     headerWrapperRenderer: (columnIndex: number, header: ReactElement) => ReactElement;
+    name?: string;
     numberOfItems?: number;
     paging: boolean;
     page: number;
@@ -279,6 +280,7 @@ export function Table<T>(props: TableProps<T>): ReactElement {
                         <ColumnSelector
                             columns={tableColumns}
                             hiddenColumns={hiddenColumns}
+                            name={props.name}
                             setHiddenColumns={setHiddenColumns}
                         />
                     )}

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/ColumnSelector.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/ColumnSelector.spec.tsx
@@ -1,6 +1,6 @@
 import { shallow } from "enzyme";
 import { createElement } from "react";
-import { render as renderTestingLib, fireEvent } from "@testing-library/react";
+import { render as renderTestingLib, fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { ColumnSelector, ColumnSelectorProps } from "../ColumnSelector";
@@ -19,31 +19,31 @@ describe("Column Selector", () => {
         beforeEach(() => (document.body.innerHTML = ""));
 
         it("changes focused element when pressing the button", () => {
-            const component = renderTestingLib(<ColumnSelector {...mockColumnSelectorProps()} />);
+            renderTestingLib(<ColumnSelector {...mockColumnSelectorProps()} />);
 
             expect(document.body).toHaveFocus();
-            const button = component.getByRole("button");
+            const button = screen.getByRole("button");
             expect(button).toBeDefined();
             fireEvent.click(button);
 
             jest.advanceTimersByTime(10);
 
-            const items = component.getAllByRole("menuitem");
+            const items = screen.getAllByRole("menuitem");
             expect(items[0]).toHaveFocus();
         });
 
         it("changes focused element back to the input when pressing shift+tab in the first element", () => {
-            const component = renderTestingLib(<ColumnSelector {...mockColumnSelectorProps()} />);
+            renderTestingLib(<ColumnSelector {...mockColumnSelectorProps()} />);
 
             expect(document.body).toHaveFocus();
 
-            const button = component.getByRole("button");
+            const button = screen.getByRole("button");
             expect(button).toBeDefined();
             fireEvent.click(button);
 
             jest.advanceTimersByTime(10);
 
-            const items = component.getAllByRole("menuitem");
+            const items = screen.getAllByRole("menuitem");
             expect(items[0]).toHaveFocus();
 
             userEvent.tab({ shift: true });
@@ -54,7 +54,7 @@ describe("Column Selector", () => {
         });
 
         it("changes focused element back to the input when pressing tab on the last item", () => {
-            const component = renderTestingLib(
+            renderTestingLib(
                 <ColumnSelector
                     {...mockColumnSelectorProps()}
                     columns={
@@ -76,12 +76,12 @@ describe("Column Selector", () => {
 
             expect(document.body).toHaveFocus();
 
-            const button = component.getByRole("button");
+            const button = screen.getByRole("button");
             fireEvent.click(button);
 
             jest.advanceTimersByTime(10);
 
-            const items = component.getAllByRole("menuitem");
+            const items = screen.getAllByRole("menuitem");
             expect(items[0]).toHaveFocus();
 
             userEvent.tab();
@@ -93,18 +93,50 @@ describe("Column Selector", () => {
             expect(button).toHaveFocus();
         });
 
-        it("changes focused element back to the input when pressing escape on the last item", () => {
-            const component = renderTestingLib(<ColumnSelector {...mockColumnSelectorProps()} />);
+        it("changes focused element back to the input when pressing escape on any item", () => {
+            renderTestingLib(
+                <ColumnSelector
+                    {...mockColumnSelectorProps()}
+                    columns={
+                        [
+                            {
+                                id: "id",
+                                header: "Test",
+                                canHide: true
+                            },
+                            {
+                                id: "id2",
+                                header: "Test2",
+                                canHide: false
+                            },
+                            {
+                                id: "id3",
+                                header: "Test3",
+                                canHide: true
+                            },
+                            {
+                                id: "id4",
+                                header: "Test4",
+                                canHide: true
+                            }
+                        ] as ColumnProperty[]
+                    }
+                />
+            );
 
             expect(document.body).toHaveFocus();
 
-            const button = component.getByRole("button");
+            const button = screen.getByRole("button");
             fireEvent.click(button);
 
             jest.advanceTimersByTime(10);
 
-            const items = component.getAllByRole("menuitem");
+            const items = screen.getAllByRole("menuitem");
+            expect(items).toHaveLength(3);
             expect(items[0]).toHaveFocus();
+
+            userEvent.tab();
+            expect(items[1]).toHaveFocus();
 
             userEvent.keyboard("{esc}");
 

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/ColumnSelector.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/ColumnSelector.spec.tsx
@@ -1,13 +1,117 @@
 import { shallow } from "enzyme";
 import { createElement } from "react";
+import { render as renderTestingLib, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
 import { ColumnSelector, ColumnSelectorProps } from "../ColumnSelector";
 import { ColumnProperty } from "../Table";
+
+jest.useFakeTimers();
 
 describe("Column Selector", () => {
     it("renders the structure correctly", () => {
         const component = shallow(<ColumnSelector {...mockColumnSelectorProps()} />);
 
         expect(component).toMatchSnapshot();
+    });
+
+    describe("focus", () => {
+        beforeEach(() => (document.body.innerHTML = ""));
+
+        it("changes focused element when pressing the button", () => {
+            const component = renderTestingLib(<ColumnSelector {...mockColumnSelectorProps()} />);
+
+            expect(document.body).toHaveFocus();
+            const button = component.getByRole("button");
+            expect(button).toBeDefined();
+            fireEvent.click(button);
+
+            jest.advanceTimersByTime(10);
+
+            const items = component.getAllByRole("menuitem");
+            expect(items[0]).toHaveFocus();
+        });
+
+        it("changes focused element back to the input when pressing shift+tab in the first element", () => {
+            const component = renderTestingLib(<ColumnSelector {...mockColumnSelectorProps()} />);
+
+            expect(document.body).toHaveFocus();
+
+            const button = component.getByRole("button");
+            expect(button).toBeDefined();
+            fireEvent.click(button);
+
+            jest.advanceTimersByTime(10);
+
+            const items = component.getAllByRole("menuitem");
+            expect(items[0]).toHaveFocus();
+
+            userEvent.tab({ shift: true });
+
+            jest.advanceTimersByTime(10);
+
+            expect(button).toHaveFocus();
+        });
+
+        it("changes focused element back to the input when pressing tab on the last item", () => {
+            const component = renderTestingLib(
+                <ColumnSelector
+                    {...mockColumnSelectorProps()}
+                    columns={
+                        [
+                            {
+                                id: "id",
+                                header: "Test",
+                                canHide: true
+                            },
+                            {
+                                id: "id2",
+                                header: "Test2",
+                                canHide: true
+                            }
+                        ] as ColumnProperty[]
+                    }
+                />
+            );
+
+            expect(document.body).toHaveFocus();
+
+            const button = component.getByRole("button");
+            fireEvent.click(button);
+
+            jest.advanceTimersByTime(10);
+
+            const items = component.getAllByRole("menuitem");
+            expect(items[0]).toHaveFocus();
+
+            userEvent.tab();
+            expect(items[1]).toHaveFocus();
+            userEvent.tab();
+
+            jest.advanceTimersByTime(10);
+
+            expect(button).toHaveFocus();
+        });
+
+        it("changes focused element back to the input when pressing escape on the last item", () => {
+            const component = renderTestingLib(<ColumnSelector {...mockColumnSelectorProps()} />);
+
+            expect(document.body).toHaveFocus();
+
+            const button = component.getByRole("button");
+            fireEvent.click(button);
+
+            jest.advanceTimersByTime(10);
+
+            const items = component.getAllByRole("menuitem");
+            expect(items[0]).toHaveFocus();
+
+            userEvent.keyboard("{esc}");
+
+            jest.advanceTimersByTime(10);
+
+            expect(button).toHaveFocus();
+        });
     });
 });
 
@@ -17,10 +121,7 @@ function mockColumnSelectorProps(): ColumnSelectorProps {
             {
                 id: "id",
                 header: "Test",
-                canHide: false,
-                canDrag: false,
-                canResize: false,
-                canSort: false
+                canHide: true
             }
         ] as ColumnProperty[],
         hiddenColumns: [],

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/__snapshots__/ColumnSelector.spec.tsx.snap
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/__snapshots__/ColumnSelector.spec.tsx.snap
@@ -8,8 +8,12 @@ exports[`Column Selector renders the structure correctly 1`] = `
     className="column-selector-content"
   >
     <button
+      aria-controls="undefined-column-selectors"
+      aria-expanded={false}
+      aria-haspopup={true}
       className="btn btn-default column-selector-button"
       onClick={[Function]}
+      onKeyDown={[Function]}
     >
       <FontAwesomeIcon
         border={false}

--- a/packages/pluggableWidgets/dropdown-sort-web/src/components/SortComponent.tsx
+++ b/packages/pluggableWidgets/dropdown-sort-web/src/components/SortComponent.tsx
@@ -77,6 +77,14 @@ export function SortComponent(props: SortComponentProps): ReactElement {
                             e.preventDefault();
                             e.stopPropagation();
                             onClick(option);
+                        } else if (e.key === "Tab" && index + 1 === props.options.length) {
+                            e.preventDefault();
+                            setShow(false);
+                            componentRef.current?.querySelector("button")?.focus();
+                        } else if ((e.key === "Tab" && e.shiftKey && index === 0) || e.key === "Escape") {
+                            e.preventDefault();
+                            setShow(false);
+                            componentRef.current?.querySelector("input")?.focus();
                         }
                     }}
                     role="menuitem"

--- a/packages/pluggableWidgets/dropdown-sort-web/src/components/SortComponent.tsx
+++ b/packages/pluggableWidgets/dropdown-sort-web/src/components/SortComponent.tsx
@@ -34,7 +34,7 @@ export function SortComponent(props: SortComponentProps): ReactElement {
     const componentRef = useRef<HTMLDivElement>(null);
     const optionsRef = useRef<HTMLUListElement>(null);
 
-    const [position, onAnimateFrameHandler] = usePositionObserver(componentRef.current);
+    const position = usePositionObserver(componentRef.current, show);
 
     const onClick = useCallback((option: SortOption) => {
         setValueInput(option.caption);
@@ -49,14 +49,6 @@ export function SortComponent(props: SortComponentProps): ReactElement {
             props.updateSort?.(selectedSort, direction);
         }
     }, [direction, selectedSort]);
-
-    useEffect(() => {
-        let cleanup;
-        if (show) {
-            cleanup = onAnimateFrameHandler();
-        }
-        return cleanup;
-    }, [onAnimateFrameHandler, show]);
 
     const showPlaceholder = !selectedSort || valueInput === props.emptyOptionCaption;
 

--- a/packages/pluggableWidgets/dropdown-sort-web/src/components/SortComponent.tsx
+++ b/packages/pluggableWidgets/dropdown-sort-web/src/components/SortComponent.tsx
@@ -1,6 +1,7 @@
-import { createElement, ReactElement, useCallback, useEffect, useRef, useState } from "react";
-import { SortDirection, useOnClickOutside } from "@mendix/piw-utils-internal";
+import { createElement, Fragment, ReactElement, useCallback, useEffect, useRef, useState } from "react";
+import { SortDirection, useOnClickOutside, usePositionObserver } from "@mendix/piw-utils-internal";
 import classNames from "classnames";
+import { createPortal } from "react-dom";
 
 export interface SortOption {
     caption: string;
@@ -31,6 +32,9 @@ export function SortComponent(props: SortComponentProps): ReactElement {
     const [direction, setDirection] = useState(props.defaultDirection ?? "asc");
 
     const componentRef = useRef<HTMLDivElement>(null);
+    const optionsRef = useRef<HTMLUListElement>(null);
+
+    const [position, PositionObserver] = usePositionObserver(componentRef.current);
 
     const onClick = useCallback((option: SortOption) => {
         setValueInput(option.caption);
@@ -38,7 +42,7 @@ export function SortComponent(props: SortComponentProps): ReactElement {
         setShow(false);
     }, []);
 
-    useOnClickOutside(componentRef, () => setShow(false));
+    useOnClickOutside([componentRef, optionsRef], () => setShow(false));
 
     useEffect(() => {
         if (selectedSort) {
@@ -48,6 +52,53 @@ export function SortComponent(props: SortComponentProps): ReactElement {
 
     const showPlaceholder = !selectedSort || valueInput === props.emptyOptionCaption;
 
+    const optionsComponent = createPortal(
+        <Fragment>
+            <ul
+                ref={optionsRef}
+                id={`${props.name}-dropdown-list`}
+                className="dropdown-list"
+                role="menu"
+                data-focusindex={0}
+                style={{ position: "fixed", width: dropdownWidth, top: position?.bottom, left: position?.left }}
+            >
+                {props.options.map((option, index) => (
+                    <li
+                        className={classNames({
+                            "filter-selected": selectedSort?.value === option.value
+                        })}
+                        key={index}
+                        onClick={e => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            onClick(option);
+                        }}
+                        onKeyDown={e => {
+                            if (e.key === "Enter" || e.key === " ") {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                onClick(option);
+                            }
+                        }}
+                        role="menuitem"
+                        tabIndex={0}
+                    >
+                        <div className="filter-label">{option.caption}</div>
+                    </li>
+                ))}
+            </ul>
+            {PositionObserver}
+        </Fragment>,
+        document.body
+    );
+
+    const containerClick = useCallback(() => {
+        setShow(true);
+        setTimeout(() => {
+            (optionsRef.current?.querySelector("li.filter-selected") as HTMLElement)?.focus();
+        }, 10);
+    }, []);
+
     return (
         <div className="dropdown-container" data-focusindex={props.tabIndex ?? 0} ref={componentRef}>
             <div className="dropdown-triggerer-wrapper">
@@ -55,8 +106,14 @@ export function SortComponent(props: SortComponentProps): ReactElement {
                     value={showPlaceholder ? "" : valueInput}
                     placeholder={showPlaceholder ? props.emptyOptionCaption : undefined}
                     className="form-control dropdown-triggerer"
-                    onClick={() => setShow(true)}
-                    onFocus={() => setShow(true)}
+                    onClick={() => containerClick()}
+                    onKeyDown={e => {
+                        if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            containerClick();
+                        }
+                    }}
                     aria-haspopup
                     ref={inputRef => {
                         if (inputRef && inputRef.clientWidth) {
@@ -75,35 +132,7 @@ export function SortComponent(props: SortComponentProps): ReactElement {
                     onClick={() => setDirection(prev => (prev === "asc" ? "desc" : "asc"))}
                 />
             </div>
-            {show && (
-                <ul
-                    id={`${props.name}-dropdown-list`}
-                    className="dropdown-list"
-                    style={{ width: dropdownWidth }}
-                    role="menu"
-                    data-focusindex={0}
-                >
-                    {props.options.map((option, index) => (
-                        <li
-                            className={classNames({
-                                "filter-selected": selectedSort?.value === option.value
-                            })}
-                            key={index}
-                            onClick={() => onClick(option)}
-                            onKeyDown={e => {
-                                if (e.key === "Enter" || e.key === " ") {
-                                    e.preventDefault();
-                                    onClick(option);
-                                }
-                            }}
-                            role="menuitem"
-                            tabIndex={0}
-                        >
-                            <div className="filter-label">{option.caption}</div>
-                        </li>
-                    ))}
-                </ul>
-            )}
+            {show && optionsComponent}
         </div>
     );
 }

--- a/packages/pluggableWidgets/dropdown-sort-web/src/components/__test__/SortComponent.spec.tsx
+++ b/packages/pluggableWidgets/dropdown-sort-web/src/components/__test__/SortComponent.spec.tsx
@@ -43,28 +43,30 @@ describe("Sort selector", () => {
 
     describe("when value changes", () => {
         it("calls updateFilters when value changes", () => {
+            const onClickProps = { preventDefault: jest.fn(), stopPropagation: jest.fn() };
             const updateSortHandler = jest.fn();
             const component = shallow(<SortComponent options={defaultOptions} updateSort={updateSortHandler} />);
 
             const input = component.find("input");
-            input.simulate("click");
+            input.simulate("click", onClickProps);
 
             const item = component.find("li").first();
-            item.simulate("click");
+            item.simulate("click", onClickProps);
 
             expect(updateSortHandler).toBeCalled();
         });
         it("shows selected option on input value", () => {
+            const onClickProps = { preventDefault: jest.fn(), stopPropagation: jest.fn() };
             const defaultOption = defaultOptions[1];
             const component = shallow(<SortComponent options={defaultOptions} defaultOption={defaultOption} />);
 
             const input = component.find("input");
-            input.simulate("click");
+            input.simulate("click", onClickProps);
 
             expect(component.find("input").first().prop("value")).toBe(defaultOption.caption);
 
             const item = component.find("li").last(); // [cap 3: val:_3]
-            item.simulate("click");
+            item.simulate("click", onClickProps);
 
             expect(component.find("input").first().prop("value")).toBe(defaultOptions[2].caption);
         });

--- a/packages/pluggableWidgets/dropdown-sort-web/src/components/__test__/SortComponent.spec.tsx
+++ b/packages/pluggableWidgets/dropdown-sort-web/src/components/__test__/SortComponent.spec.tsx
@@ -1,11 +1,12 @@
 import { render, shallow } from "enzyme";
 import { createElement } from "react";
-import { render as renderTestingLib, fireEvent } from "@testing-library/react";
+import { SortComponent, SortOption } from "../SortComponent";
+import { render as renderTestingLib, fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
-import { SortComponent, SortOption } from "../SortComponent";
 
 const defaultOptions: SortOption[] = [
+    { caption: "Empty option", value: "" },
     { caption: "1", value: "_1" },
     { caption: "2", value: "_2" },
     { caption: "3", value: "_3" }
@@ -73,7 +74,7 @@ describe("Sort selector", () => {
             const item = component.find("li").last(); // [cap 3: val:_3]
             item.simulate("click", onClickProps);
 
-            expect(component.find("input").first().prop("value")).toBe(defaultOptions[2].caption);
+            expect(component.find("input").first().prop("value")).toBe(defaultOptions[3].caption);
         });
     });
 
@@ -81,35 +82,31 @@ describe("Sort selector", () => {
         beforeEach(() => (document.body.innerHTML = ""));
 
         it("changes focused element when pressing the input", () => {
-            const component = renderTestingLib(
-                <SortComponent options={defaultOptions} emptyOptionCaption="Click me" />
-            );
+            renderTestingLib(<SortComponent options={defaultOptions} emptyOptionCaption="Click me" />);
 
             expect(document.body).toHaveFocus();
-            const input = component.getByPlaceholderText("Click me");
+            const input = screen.getByPlaceholderText("Click me");
             expect(input).toBeDefined();
             fireEvent.click(input);
 
             jest.advanceTimersByTime(10);
 
-            const items = component.getAllByRole("menuitem");
+            const items = screen.getAllByRole("menuitem");
             expect(items[0]).toHaveFocus();
         });
 
         it("changes focused element back to the input when pressing shift+tab in the first element", () => {
-            const component = renderTestingLib(
-                <SortComponent options={defaultOptions} emptyOptionCaption="Click me" />
-            );
+            renderTestingLib(<SortComponent options={defaultOptions} emptyOptionCaption="Click me" />);
 
             expect(document.body).toHaveFocus();
 
-            const input = component.getByPlaceholderText("Click me");
+            const input = screen.getByPlaceholderText("Click me");
             expect(input).toBeDefined();
             fireEvent.click(input);
 
             jest.advanceTimersByTime(10);
 
-            const items = component.getAllByRole("menuitem");
+            const items = screen.getAllByRole("menuitem");
             expect(items[0]).toHaveFocus();
 
             userEvent.tab({ shift: true });
@@ -120,18 +117,24 @@ describe("Sort selector", () => {
         });
 
         it("changes focused element back to the input when pressing tab on the last item", () => {
-            const component = renderTestingLib(
-                <SortComponent options={[{ caption: "1", value: "_1" }]} emptyOptionCaption="Click me" />
+            renderTestingLib(
+                <SortComponent
+                    options={[
+                        { caption: "Click me", value: "" },
+                        { caption: "1", value: "_1" }
+                    ]}
+                    emptyOptionCaption="Click me"
+                />
             );
 
             expect(document.body).toHaveFocus();
 
-            const input = component.getByPlaceholderText("Click me");
+            const input = screen.getByPlaceholderText("Click me");
             fireEvent.click(input);
 
             jest.advanceTimersByTime(10);
 
-            const items = component.getAllByRole("menuitem");
+            const items = screen.getAllByRole("menuitem");
             expect(items[0]).toHaveFocus();
 
             userEvent.tab();
@@ -140,22 +143,32 @@ describe("Sort selector", () => {
 
             jest.advanceTimersByTime(10);
 
-            expect(input).toHaveFocus();
+            const button = screen.getByRole("button");
+
+            expect(button).toHaveFocus();
         });
 
-        it("changes focused element back to the input when pressing escape on the last item", () => {
-            const component = renderTestingLib(
-                <SortComponent options={[{ caption: "1", value: "_1" }]} emptyOptionCaption="Click me" />
+        it("changes focused element back to the input when pressing escape on any item", () => {
+            renderTestingLib(
+                <SortComponent
+                    options={[
+                        { caption: "Click me", value: "" },
+                        { caption: "1", value: "_1" },
+                        { caption: "2", value: "_2" }
+                    ]}
+                    emptyOptionCaption="Click me"
+                />
             );
 
             expect(document.body).toHaveFocus();
 
-            const input = component.getByPlaceholderText("Click me");
+            const input = screen.getByPlaceholderText("Click me");
             fireEvent.click(input);
 
             jest.advanceTimersByTime(10);
 
-            const items = component.getAllByRole("menuitem");
+            const items = screen.getAllByRole("menuitem");
+            expect(items).toHaveLength(3);
             expect(items[0]).toHaveFocus();
 
             userEvent.tab();

--- a/packages/pluggableWidgets/dropdown-sort-web/src/components/__test__/SortComponent.spec.tsx
+++ b/packages/pluggableWidgets/dropdown-sort-web/src/components/__test__/SortComponent.spec.tsx
@@ -1,5 +1,8 @@
 import { render, shallow } from "enzyme";
 import { createElement } from "react";
+import { render as renderTestingLib, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
 import { SortComponent, SortOption } from "../SortComponent";
 
 const defaultOptions: SortOption[] = [
@@ -7,6 +10,8 @@ const defaultOptions: SortOption[] = [
     { caption: "2", value: "_2" },
     { caption: "3", value: "_3" }
 ];
+
+jest.useFakeTimers();
 
 describe("Sort selector", () => {
     describe("renders correctly", () => {
@@ -69,6 +74,99 @@ describe("Sort selector", () => {
             item.simulate("click", onClickProps);
 
             expect(component.find("input").first().prop("value")).toBe(defaultOptions[2].caption);
+        });
+    });
+
+    describe("focus", () => {
+        beforeEach(() => (document.body.innerHTML = ""));
+
+        it("changes focused element when pressing the input", () => {
+            const component = renderTestingLib(
+                <SortComponent options={defaultOptions} emptyOptionCaption="Click me" />
+            );
+
+            expect(document.body).toHaveFocus();
+            const input = component.getByPlaceholderText("Click me");
+            expect(input).toBeDefined();
+            fireEvent.click(input);
+
+            jest.advanceTimersByTime(10);
+
+            const items = component.getAllByRole("menuitem");
+            expect(items[0]).toHaveFocus();
+        });
+
+        it("changes focused element back to the input when pressing shift+tab in the first element", () => {
+            const component = renderTestingLib(
+                <SortComponent options={defaultOptions} emptyOptionCaption="Click me" />
+            );
+
+            expect(document.body).toHaveFocus();
+
+            const input = component.getByPlaceholderText("Click me");
+            expect(input).toBeDefined();
+            fireEvent.click(input);
+
+            jest.advanceTimersByTime(10);
+
+            const items = component.getAllByRole("menuitem");
+            expect(items[0]).toHaveFocus();
+
+            userEvent.tab({ shift: true });
+
+            jest.advanceTimersByTime(10);
+
+            expect(input).toHaveFocus();
+        });
+
+        it("changes focused element back to the input when pressing tab on the last item", () => {
+            const component = renderTestingLib(
+                <SortComponent options={[{ caption: "1", value: "_1" }]} emptyOptionCaption="Click me" />
+            );
+
+            expect(document.body).toHaveFocus();
+
+            const input = component.getByPlaceholderText("Click me");
+            fireEvent.click(input);
+
+            jest.advanceTimersByTime(10);
+
+            const items = component.getAllByRole("menuitem");
+            expect(items[0]).toHaveFocus();
+
+            userEvent.tab();
+            expect(items[1]).toHaveFocus();
+            userEvent.tab();
+
+            jest.advanceTimersByTime(10);
+
+            expect(input).toHaveFocus();
+        });
+
+        it("changes focused element back to the input when pressing escape on the last item", () => {
+            const component = renderTestingLib(
+                <SortComponent options={[{ caption: "1", value: "_1" }]} emptyOptionCaption="Click me" />
+            );
+
+            expect(document.body).toHaveFocus();
+
+            const input = component.getByPlaceholderText("Click me");
+            fireEvent.click(input);
+
+            jest.advanceTimersByTime(10);
+
+            const items = component.getAllByRole("menuitem");
+            expect(items[0]).toHaveFocus();
+
+            userEvent.tab();
+
+            expect(items[1]).toHaveFocus();
+
+            userEvent.keyboard("{esc}");
+
+            jest.advanceTimersByTime(10);
+
+            expect(input).toHaveFocus();
         });
     });
 });

--- a/packages/tools/piw-utils-internal/src/utils/dom.ts
+++ b/packages/tools/piw-utils-internal/src/utils/dom.ts
@@ -1,9 +1,16 @@
 import { RefObject, useEffect } from "react";
 
-export function useOnClickOutside(ref: RefObject<HTMLElement>, handler: () => void): void {
+export function useOnClickOutside(
+    ref: RefObject<HTMLElement> | Array<RefObject<HTMLElement>>,
+    handler: () => void
+): void {
     useEffect(() => {
         const listener = (event: MouseEvent & { target: Node | null }): void => {
-            if (!ref.current || ref.current.contains(event.target)) {
+            if (Array.isArray(ref)) {
+                if (ref.some(r => !r.current || r.current.contains(event.target))) {
+                    return;
+                }
+            } else if (!ref.current || ref.current.contains(event.target)) {
                 return;
             }
             handler();

--- a/packages/tools/piw-utils-internal/src/widgets/FilterSelector.tsx
+++ b/packages/tools/piw-utils-internal/src/widgets/FilterSelector.tsx
@@ -1,6 +1,8 @@
-import { createElement, ReactElement, useCallback, useEffect, useRef, useState } from "react";
+import { createElement, Fragment, ReactElement, useCallback, useEffect, useRef, useState } from "react";
 import classNames from "classnames";
 import { useOnClickOutside } from "../utils";
+import { createPortal } from "react-dom";
+import { usePositionObserver } from "./usePositionObserver";
 
 interface FilterSelectorProps<T> {
     ariaLabel?: string;
@@ -14,7 +16,9 @@ export function FilterSelector<T>(props: FilterSelectorProps<T>): ReactElement {
     const [value, setValue] = useState(props.defaultFilter);
     const [show, setShow] = useState(false);
     const componentRef = useRef<HTMLDivElement>(null);
-    useOnClickOutside(componentRef, () => setShow(false));
+    const filterSelectorsRef = useRef<HTMLUListElement>(null);
+    useOnClickOutside([componentRef, filterSelectorsRef], () => setShow(false));
+    const [position, PositionObserver] = usePositionObserver(componentRef.current);
 
     const onClick = useCallback(
         (value: T) => {
@@ -30,6 +34,45 @@ export function FilterSelector<T>(props: FilterSelectorProps<T>): ReactElement {
         props.onChange(props.defaultFilter);
     }, [props.defaultFilter, props.onChange]);
 
+    const filterSelectors = createPortal(
+        <Fragment>
+            <ul
+                ref={filterSelectorsRef}
+                id={`${props.name}-filter-selectors`}
+                className="filter-selectors"
+                role="menu"
+                data-focusindex={0}
+                style={{ position: "fixed", top: position?.bottom, left: position?.left }}
+            >
+                {props.options.map((option, index) => (
+                    <li
+                        className={classNames({ "filter-selected": value === option.value })}
+                        key={index}
+                        onClick={e => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            onClick(option.value);
+                        }}
+                        onKeyDown={e => {
+                            if (e.key === "Enter" || e.key === " ") {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                onClick(option.value);
+                            }
+                        }}
+                        role="menuitem"
+                        tabIndex={0}
+                    >
+                        <div className={classNames("filter-icon", option.value)} aria-hidden />
+                        <div className="filter-label">{option.label}</div>
+                    </li>
+                ))}
+            </ul>
+            {PositionObserver}
+        </Fragment>,
+        document.body
+    );
+
     return (
         <div className="filter-selector">
             <div className="filter-selector-content" ref={componentRef}>
@@ -39,37 +82,21 @@ export function FilterSelector<T>(props: FilterSelectorProps<T>): ReactElement {
                     aria-haspopup
                     aria-label={props.ariaLabel}
                     className={classNames("btn btn-default filter-selector-button button-icon", value)}
-                    onClick={() => setShow(show => !show)}
+                    onClick={() => {
+                        setShow(show => !show);
+
+                        setTimeout(() => {
+                            if (show) {
+                                (filterSelectorsRef.current?.querySelector(
+                                    "li.filter-selected"
+                                ) as HTMLElement)?.focus();
+                            }
+                        }, 10);
+                    }}
                 >
                     &nbsp;
                 </button>
-                {show && (
-                    <ul
-                        id={`${props.name}-filter-selectors`}
-                        className="filter-selectors"
-                        role="menu"
-                        data-focusindex={0}
-                    >
-                        {props.options.map((option, index) => (
-                            <li
-                                className={classNames({ "filter-selected": value === option.value })}
-                                key={index}
-                                onClick={() => onClick(option.value)}
-                                onKeyDown={e => {
-                                    if (e.key === "Enter" || e.key === " ") {
-                                        e.preventDefault();
-                                        onClick(option.value);
-                                    }
-                                }}
-                                role="menuitem"
-                                tabIndex={0}
-                            >
-                                <div className={classNames("filter-icon", option.value)} aria-hidden />
-                                <div className="filter-label">{option.label}</div>
-                            </li>
-                        ))}
-                    </ul>
-                )}
+                {show && filterSelectors}
             </div>
         </div>
     );

--- a/packages/tools/piw-utils-internal/src/widgets/FilterSelector.tsx
+++ b/packages/tools/piw-utils-internal/src/widgets/FilterSelector.tsx
@@ -57,6 +57,13 @@ export function FilterSelector<T>(props: FilterSelectorProps<T>): ReactElement {
                             e.preventDefault();
                             e.stopPropagation();
                             onClick(option.value);
+                        } else if (e.key === "Tab" && index + 1 === props.options.length) {
+                            e.preventDefault();
+                            onClick(value);
+                        } else if ((e.key === "Tab" && e.shiftKey && index === 0) || e.key === "Escape") {
+                            e.preventDefault();
+                            componentRef.current?.querySelector("button")?.focus();
+                            setShow(false);
                         }
                     }}
                     role="menuitem"

--- a/packages/tools/piw-utils-internal/src/widgets/FilterSelector.tsx
+++ b/packages/tools/piw-utils-internal/src/widgets/FilterSelector.tsx
@@ -18,7 +18,7 @@ export function FilterSelector<T>(props: FilterSelectorProps<T>): ReactElement {
     const componentRef = useRef<HTMLDivElement>(null);
     const filterSelectorsRef = useRef<HTMLUListElement>(null);
     useOnClickOutside([componentRef, filterSelectorsRef], () => setShow(false));
-    const [position, onAnimateFrameHandler] = usePositionObserver(componentRef.current);
+    const position = usePositionObserver(componentRef.current, show);
 
     const onClick = useCallback(
         (value: T) => {
@@ -33,14 +33,6 @@ export function FilterSelector<T>(props: FilterSelectorProps<T>): ReactElement {
         setValue(props.defaultFilter);
         props.onChange(props.defaultFilter);
     }, [props.defaultFilter, props.onChange]);
-
-    useEffect(() => {
-        let cleanup;
-        if (show) {
-            cleanup = onAnimateFrameHandler();
-        }
-        return cleanup;
-    }, [onAnimateFrameHandler, show]);
 
     const filterSelectors = createPortal(
         <ul

--- a/packages/tools/piw-utils-internal/src/widgets/__tests__/FilterSelector.spec.tsx
+++ b/packages/tools/piw-utils-internal/src/widgets/__tests__/FilterSelector.spec.tsx
@@ -23,6 +23,19 @@ describe("Filter selector", () => {
         expect(component).toMatchSnapshot();
     });
 
+    it("renders correctly with filter selectors open", () => {
+        const onClickProps = { preventDefault: jest.fn(), stopPropagation: jest.fn() };
+        const onChange = jest.fn();
+        const component = shallow(
+            <FilterSelector defaultFilter="contains" onChange={onChange} name="test" options={options} />
+        );
+
+        const button = component.find("button");
+        button.simulate("click", onClickProps);
+
+        expect(component).toMatchSnapshot();
+    });
+
     it("renders correctly with aria-label", () => {
         const component = shallow(
             <FilterSelector
@@ -46,22 +59,23 @@ describe("Filter selector", () => {
     });
 
     it("calls onChange when type changes", () => {
+        const onClickProps = { preventDefault: jest.fn(), stopPropagation: jest.fn() };
         const onChange = jest.fn();
         const component = shallow(
             <FilterSelector defaultFilter="contains" onChange={onChange} name="test" options={options} />
         );
 
         const button = component.find("button");
-        button.simulate("click");
+        button.simulate("click", onClickProps);
         const lis = component.find("li");
 
         expect(lis.at(0)).toBeDefined();
-        lis.at(0).simulate("click");
+        lis.at(0).simulate("click", onClickProps);
 
         expect(onChange).toBeCalled();
         expect(onChange).toBeCalledWith("contains");
 
-        lis.at(1).simulate("click");
+        lis.at(1).simulate("click", onClickProps);
         expect(onChange).toBeCalledWith("startsWith");
     });
 });

--- a/packages/tools/piw-utils-internal/src/widgets/__tests__/FilterSelector.spec.tsx
+++ b/packages/tools/piw-utils-internal/src/widgets/__tests__/FilterSelector.spec.tsx
@@ -1,5 +1,5 @@
 import { shallow } from "enzyme";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { createElement } from "react";
@@ -88,37 +88,33 @@ describe("Filter selector", () => {
         beforeEach(() => (document.body.innerHTML = ""));
 
         it("changes focused element when pressing filter selector button", () => {
-            const component = render(
-                <FilterSelector defaultFilter="contains" onChange={jest.fn()} name="test" options={options} />
-            );
+            render(<FilterSelector defaultFilter="contains" onChange={jest.fn()} name="test" options={options} />);
 
             expect(document.body).toHaveFocus();
 
-            const button = component.getByRole("button");
+            const button = screen.getByRole("button");
             expect(button).toBeDefined();
             fireEvent.click(button);
 
             jest.advanceTimersByTime(10);
 
-            const items = component.getAllByRole("menuitem");
+            const items = screen.getAllByRole("menuitem");
 
             expect(items[0]).toHaveFocus();
         });
 
         it("changes focused element back to the button when pressing shift+tab in the first element", () => {
-            const component = render(
-                <FilterSelector defaultFilter="contains" onChange={jest.fn()} name="test" options={options} />
-            );
+            render(<FilterSelector defaultFilter="contains" onChange={jest.fn()} name="test" options={options} />);
 
             expect(document.body).toHaveFocus();
 
-            const button = component.getByRole("button");
+            const button = screen.getByRole("button");
             expect(button).toBeDefined();
             fireEvent.click(button);
 
             jest.advanceTimersByTime(10);
 
-            const items = component.getAllByRole("menuitem");
+            const items = screen.getAllByRole("menuitem");
             expect(items[0]).toHaveFocus();
 
             userEvent.tab({ shift: true });
@@ -131,7 +127,7 @@ describe("Filter selector", () => {
         it("triggers onChange with previous value when pressing tab on the last item", () => {
             const onChange = jest.fn();
 
-            const component = render(
+            render(
                 <FilterSelector
                     defaultFilter="contains"
                     onChange={onChange}
@@ -145,13 +141,13 @@ describe("Filter selector", () => {
 
             expect(document.body).toHaveFocus();
 
-            const button = component.getByRole("button");
+            const button = screen.getByRole("button");
             expect(button).toBeDefined();
             fireEvent.click(button);
 
             jest.advanceTimersByTime(10);
 
-            const items = component.getAllByRole("menuitem");
+            const items = screen.getAllByRole("menuitem");
             expect(items[0]).toHaveFocus();
 
             userEvent.tab();
@@ -164,19 +160,17 @@ describe("Filter selector", () => {
         });
 
         it("changes focused element back to the button when pressing escape in any element", () => {
-            const component = render(
-                <FilterSelector defaultFilter="contains" onChange={jest.fn()} name="test" options={options} />
-            );
+            render(<FilterSelector defaultFilter="contains" onChange={jest.fn()} name="test" options={options} />);
 
             expect(document.body).toHaveFocus();
 
-            const button = component.getByRole("button");
+            const button = screen.getByRole("button");
             expect(button).toBeDefined();
             fireEvent.click(button);
 
             jest.advanceTimersByTime(10);
 
-            const items = component.getAllByRole("menuitem");
+            const items = screen.getAllByRole("menuitem");
             expect(items[0]).toHaveFocus();
 
             userEvent.tab();

--- a/packages/tools/piw-utils-internal/src/widgets/__tests__/__snapshots__/FilterSelector.spec.tsx.snap
+++ b/packages/tools/piw-utils-internal/src/widgets/__tests__/__snapshots__/FilterSelector.spec.tsx.snap
@@ -60,3 +60,206 @@ exports[`Filter selector renders correctly with aria-label 1`] = `
   </div>
 </div>
 `;
+
+exports[`Filter selector renders correctly with filter selectors open 1`] = `
+<div
+  className="filter-selector"
+>
+  <div
+    className="filter-selector-content"
+  >
+    <button
+      aria-controls="test-filter-selectors"
+      aria-expanded={true}
+      aria-haspopup={true}
+      className="btn btn-default filter-selector-button button-icon contains"
+      onClick={[Function]}
+    >
+       
+    </button>
+    <Portal
+      containerInfo={<body />}
+    >
+      <ul
+        className="filter-selectors"
+        data-focusindex={0}
+        id="test-filter-selectors"
+        role="menu"
+        style={
+          Object {
+            "left": undefined,
+            "position": "fixed",
+            "top": undefined,
+          }
+        }
+      >
+        <li
+          className="filter-selected"
+          key="0"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex={0}
+        >
+          <div
+            aria-hidden={true}
+            className="filter-icon contains"
+          />
+          <div
+            className="filter-label"
+          >
+            Contains
+          </div>
+        </li>
+        <li
+          className=""
+          key="1"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex={0}
+        >
+          <div
+            aria-hidden={true}
+            className="filter-icon startsWith"
+          />
+          <div
+            className="filter-label"
+          >
+            Starts with
+          </div>
+        </li>
+        <li
+          className=""
+          key="2"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex={0}
+        >
+          <div
+            aria-hidden={true}
+            className="filter-icon endsWith"
+          />
+          <div
+            className="filter-label"
+          >
+            Ends with
+          </div>
+        </li>
+        <li
+          className=""
+          key="3"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex={0}
+        >
+          <div
+            aria-hidden={true}
+            className="filter-icon greater"
+          />
+          <div
+            className="filter-label"
+          >
+            Greater than
+          </div>
+        </li>
+        <li
+          className=""
+          key="4"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex={0}
+        >
+          <div
+            aria-hidden={true}
+            className="filter-icon greaterEqual"
+          />
+          <div
+            className="filter-label"
+          >
+            Greater than or equal
+          </div>
+        </li>
+        <li
+          className=""
+          key="5"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex={0}
+        >
+          <div
+            aria-hidden={true}
+            className="filter-icon equal"
+          />
+          <div
+            className="filter-label"
+          >
+            Equal
+          </div>
+        </li>
+        <li
+          className=""
+          key="6"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex={0}
+        >
+          <div
+            aria-hidden={true}
+            className="filter-icon notEqual"
+          />
+          <div
+            className="filter-label"
+          >
+            Not equal
+          </div>
+        </li>
+        <li
+          className=""
+          key="7"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex={0}
+        >
+          <div
+            aria-hidden={true}
+            className="filter-icon smaller"
+          />
+          <div
+            className="filter-label"
+          >
+            Smaller than
+          </div>
+        </li>
+        <li
+          className=""
+          key="8"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex={0}
+        >
+          <div
+            aria-hidden={true}
+            className="filter-icon smallerEqual"
+          />
+          <div
+            className="filter-label"
+          >
+            Smaller than or equal
+          </div>
+        </li>
+      </ul>
+      <AnimationFrameHandler
+        callback={[Function]}
+      />
+    </Portal>
+  </div>
+</div>
+`;

--- a/packages/tools/piw-utils-internal/src/widgets/__tests__/__snapshots__/FilterSelector.spec.tsx.snap
+++ b/packages/tools/piw-utils-internal/src/widgets/__tests__/__snapshots__/FilterSelector.spec.tsx.snap
@@ -13,6 +13,7 @@ exports[`Filter selector renders correctly 1`] = `
       aria-haspopup={true}
       className="btn btn-default filter-selector-button button-icon contains"
       onClick={[Function]}
+      onKeyDown={[Function]}
     >
        
     </button>
@@ -33,6 +34,7 @@ exports[`Filter selector renders correctly with another default filter 1`] = `
       aria-haspopup={true}
       className="btn btn-default filter-selector-button button-icon equal"
       onClick={[Function]}
+      onKeyDown={[Function]}
     >
        
     </button>
@@ -54,6 +56,7 @@ exports[`Filter selector renders correctly with aria-label 1`] = `
       aria-label="my label"
       className="btn btn-default filter-selector-button button-icon contains"
       onClick={[Function]}
+      onKeyDown={[Function]}
     >
        
     </button>
@@ -74,6 +77,7 @@ exports[`Filter selector renders correctly with filter selectors open 1`] = `
       aria-haspopup={true}
       className="btn btn-default filter-selector-button button-icon contains"
       onClick={[Function]}
+      onKeyDown={[Function]}
     >
        
     </button>
@@ -256,9 +260,6 @@ exports[`Filter selector renders correctly with filter selectors open 1`] = `
           </div>
         </li>
       </ul>
-      <AnimationFrameHandler
-        callback={[Function]}
-      />
     </Portal>
   </div>
 </div>

--- a/packages/tools/piw-utils-internal/src/widgets/__tests__/usePositionObserver.spec.ts
+++ b/packages/tools/piw-utils-internal/src/widgets/__tests__/usePositionObserver.spec.ts
@@ -21,11 +21,9 @@ describe("Position Observer", () => {
             return 1;
         });
 
-        const { result } = renderHook(() => usePositionObserver(target));
+        const { result } = renderHook(() => usePositionObserver(target, true));
 
-        expect(result.current[0]).toStrictEqual({ top: 0, right: 0, bottom: 0, left: 0 });
-        expect(result.current[1]).toBeDefined();
-        result.current[1]();
+        expect(result.current).toStrictEqual({ top: 0, right: 0, bottom: 0, left: 0 });
         expect(setHookValue).toBeCalledWith({ top: 1, right: 2, bottom: 3, left: 4 });
     });
 });

--- a/packages/tools/piw-utils-internal/src/widgets/__tests__/usePositionObserver.spec.ts
+++ b/packages/tools/piw-utils-internal/src/widgets/__tests__/usePositionObserver.spec.ts
@@ -1,8 +1,6 @@
 import { renderHook } from "@testing-library/react-hooks";
 import { usePositionObserver } from "../usePositionObserver";
-import { act } from "react-test-renderer";
 import React from "react";
-import { shallow } from "enzyme";
 
 describe("Position Observer", () => {
     it("Defines the AnimationFrameHandler", () => {
@@ -24,12 +22,10 @@ describe("Position Observer", () => {
         });
 
         const { result } = renderHook(() => usePositionObserver(target));
-        act(() => {
-            const component = shallow(result.current[1]);
-            expect(component).toBeDefined();
-        });
 
-        expect(setHookValue).toBeCalledWith({ top: 1, right: 2, bottom: 3, left: 4 });
+        expect(result.current[0]).toStrictEqual({ top: 0, right: 0, bottom: 0, left: 0 });
         expect(result.current[1]).toBeDefined();
+        result.current[1]();
+        expect(setHookValue).toBeCalledWith({ top: 1, right: 2, bottom: 3, left: 4 });
     });
 });

--- a/packages/tools/piw-utils-internal/src/widgets/__tests__/usePositionObserver.spec.tsx
+++ b/packages/tools/piw-utils-internal/src/widgets/__tests__/usePositionObserver.spec.tsx
@@ -1,0 +1,35 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { usePositionObserver } from "../usePositionObserver";
+import { act } from "react-test-renderer";
+import React from "react";
+import { shallow } from "enzyme";
+
+describe("Position Observer", () => {
+    it("Defines the AnimationFrameHandler", () => {
+        const target = document.createElement("div");
+        let hookValue = { top: 0, right: 0, bottom: 0, left: 0 };
+        const setHookValue = jest.fn(value => (hookValue = value));
+
+        // @ts-ignore
+        jest.spyOn(target, "getBoundingClientRect").mockImplementation(() => ({
+            top: 1,
+            right: 2,
+            bottom: 3,
+            left: 4
+        }));
+        jest.spyOn(React, "useState").mockImplementation(() => [hookValue, setHookValue]);
+        jest.spyOn(window, "requestAnimationFrame").mockImplementation(() => {
+            setHookValue({ top: 1, right: 2, bottom: 3, left: 4 });
+            return 1;
+        });
+
+        const { result } = renderHook(() => usePositionObserver(target));
+        act(() => {
+            const component = shallow(result.current[1]);
+            expect(component).toBeDefined();
+        });
+
+        expect(setHookValue).toBeCalledWith({ top: 1, right: 2, bottom: 3, left: 4 });
+        expect(result.current[1]).toBeDefined();
+    });
+});

--- a/packages/tools/piw-utils-internal/src/widgets/index.ts
+++ b/packages/tools/piw-utils-internal/src/widgets/index.ts
@@ -1,3 +1,4 @@
 export * from "./FilterSelector";
 export * from "./InfiniteBody";
 export * from "./Pagination";
+export * from "./usePositionObserver";

--- a/packages/tools/piw-utils-internal/src/widgets/usePositionObserver.ts
+++ b/packages/tools/piw-utils-internal/src/widgets/usePositionObserver.ts
@@ -1,0 +1,59 @@
+import { createElement, FC, ReactElement, useCallback, useEffect, useMemo, useState } from "react";
+
+export function usePositionObserver(target: HTMLElement | null): [ClientRect | undefined, ReactElement] {
+    const [position, setPosition] = useState<ClientRect>();
+
+    const onAnimationFrameHandler = useCallback(() => {
+        if (!target) {
+            return;
+        }
+
+        const newPosition: ClientRect = target.getBoundingClientRect();
+
+        if (shouldUpdatePosition(newPosition, position)) {
+            setPosition(newPosition);
+        }
+    }, [position, target]);
+
+    const PositionObserver = useMemo(
+        () => createElement(AnimationFrameHandler, { callback: onAnimationFrameHandler }),
+        [onAnimationFrameHandler]
+    );
+
+    return [position, PositionObserver];
+}
+
+interface AnimationFrameHandlerProps {
+    callback: () => void;
+}
+
+const AnimationFrameHandler: FC<AnimationFrameHandlerProps> = props => {
+    const [requestId, setRequestId] = useState<number | undefined>(undefined);
+
+    const onAnimationFrame = useCallback(() => {
+        props.callback();
+        setRequestId(window.requestAnimationFrame(onAnimationFrame));
+    }, [props.callback]);
+
+    useEffect(() => {
+        setRequestId(window.requestAnimationFrame(onAnimationFrame));
+        return () => {
+            window.cancelAnimationFrame(requestId!);
+        };
+    }, []);
+
+    return null;
+};
+
+function shouldUpdatePosition(a?: ClientRect, b?: ClientRect): boolean {
+    return (
+        !a ||
+        !b ||
+        a.height !== b.height ||
+        a.width !== b.width ||
+        a.bottom !== b.bottom ||
+        a.top !== b.top ||
+        a.left !== b.left ||
+        a.right !== b.right
+    );
+}


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
When enabling virtual scrolling it adds a `overflow: hidden` into the main div of the data grid, which blocks the filters to appears outside the main div if there is no rows.

## Relevant changes
Added PositionObserver to allow usage of fixed positioning in the filter widgets + dropdown sort.

## What should be covered while testing?
Compatibility & accessibility, check general positioning issues.
