### PR TITLE
[WC-740] fix(pluggable-widgets-tools): path containing space

### DIFF
--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [9.5.1] - 2021-09-02
+
+### Changed
+- We fixed an issue with paths containing spaces on windows causing tests (unit and e2e) to throw `Could not find a config file based on provided values`.
+
 ## [9.5.0] - 2021-09-01
 
 ### Added

--- a/packages/tools/pluggable-widgets-tools/bin/mx-scripts.js
+++ b/packages/tools/pluggable-widgets-tools/bin/mx-scripts.js
@@ -67,17 +67,17 @@ function getRealCommand(cmd, toolsRoot) {
             return `${prettierCommand} --write`;
         case "test:unit":
         case "test:unit:web":
-            return `jest --projects ${join(toolsRoot, "test-config/jest.config.js")}`;
+            return `jest --projects "${join(toolsRoot, "test-config/jest.config.js")}"`;
         case "test:unit:native":
-            return `jest --projects ${join(toolsRoot, "test-config/jest.native.config.js")}`;
+            return `jest --projects "${join(toolsRoot, "test-config/jest.native.config.js")}"`;
         case "test:e2e":
         case "test:e2e:ts":
         case "test:e2e:js":
-            return `wdio ${join(toolsRoot, "test-config/wdio.conf.js")}`;
+            return `wdio "${join(toolsRoot, "test-config/wdio.conf.js")}"`;
         case "test:e2e:web:dev":
-            return `cross-env DEBUG=true wdio ${join(toolsRoot, "test-config/wdio.conf.js")}`;
+            return `cross-env DEBUG=true wdio "${join(toolsRoot, "test-config/wdio.conf.js")}"`;
         case "test:e2e:web":
-            return `node ${join(toolsRoot, "scripts/e2e.js")} $@`;
+            return `node "${join(toolsRoot, "scripts/e2e.js")}" $@`;
         case "start:js":
         case "start:ts":
             return "echo This command has no effect, use pluggable-widgets-tools start:web instead!";

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.5.0",
+  "version": "9.5.1",
   "description": "Mendix Pluggable Widgets Tools",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2021. All rights reserved.",

--- a/packages/tools/pluggable-widgets-tools/tests/commands.js
+++ b/packages/tools/pluggable-widgets-tools/tests/commands.js
@@ -49,14 +49,17 @@ async function main() {
     const workDirSemaphore = new Semaphore(PARALLELISM);
     const failures = (
         await Promise.all(
-            CONFIGS.map(async config => {
+            CONFIGS.map(async (config, index) => {
                 const [, release] = await workDirSemaphore.acquire();
                 let workDir;
                 try {
                     workDir = workDirs.pop();
                     if (!workDir) {
-                        workDir = join(tempdir(), `pwt_test_${Math.round(Math.random() * 10000)}`);
-                        mkdir(workDir);
+                        workDir = join(
+                            index === 0 ? join(tempdir(), "spaced folder") : tempdir(),
+                            `pwt_test_${Math.round(Math.random() * 10000)}`
+                        );
+                        mkdir("-p", workDir);
                     }
                     await runTest(workDir, ...config);
                     return undefined;


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX  9️⃣

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Correct script executions while using paths containing spaces.

## Relevant changes
Add a test to cover this in all platforms.

## What should be covered while testing?
Automation should be enough.
