### PR TITLE
[NC] Add git credentials to module release script

### DIFF
--- a/scripts/release/createNativeModules.js
+++ b/scripts/release/createNativeModules.js
@@ -38,6 +38,8 @@ async function createNMRModule() {
         testProject: { githubUrl, branchName },
         repository: { url }
     } = require(pkgPath);
+    await execShellCommand('git config user.name "Native Content Automation"');
+    await execShellCommand('git config user.email "widgets@mendix.com"');
     await execShellCommand(
         `git remote set-url origin https://${process.env.GH_USERNAME}:${process.env.GH_PAT}@${url.replace(
             "https://",


### PR DESCRIPTION
This reverts commit 815cdbaba7ff5b34c21210dbd1425fe4d0daeec0.

When trying to release script, an error occurred: https://github.com/mendix/widgets-resources/runs/3430771393?check_suite_focus=true

This MR adds the credetials