### PR TITLE
[WC-749] Pluggable widgets tools - Fix dangerous test project override

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ See [CONTRIBUTING.md](https://github.com/mendix/widgets-resources/blob/master/CO
 -   Run `npm run pretest:e2e` to initialize Mendix project.
 -   Run `npm run build` on a desired widget folder. For ex: `packages/pluggableWidgets/badge-web`. This will build and copy the mpk to
     each Mendix project's correct widget folder.
--   Open and run the project in `<widgetName>/tests/testProject` with Mendix Studio
--   If you don't want to override your test project use the flag `--no-update-testProject` in test:e2e npm script
+-   Open and run the project in `<widgetName>/tests/testProject` with Mendix Studio.
+-   If you want to override your local test project with a test project from GitHub, execute the `test:e2e` npm script with the following command: `npm run test:e2e -- --update-test-project`.
 
 #### Adding new test project to the repo
 

--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+- We fixed an issue where the e2e test script overrides a local test project by default. To override the existing local test project, supply the following argument when calling the script: `--update-test-project`.
+- We improved error handling for e2e testing.
+
 ## [9.5.1] - 2021-09-02
 
 ### Changed


### PR DESCRIPTION
## Checklist
- Contains breaking changes ✅ 

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fix dangerous test project override in pluggable widgets tools.

## Relevant changes
- A users needs to explicitly override a test project.
- Output a more detailed error message when github info is missing.
- Check if downloaded GitHub test project is valid test project.

## What should be covered while testing?
x
