### PR TITLE
[NC-481] Ignore throwing for missing optional peer dependencies

### DIFF
--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - We fixed an issue where the e2e test script overrides a local test project by default. To override the existing local test project, supply the following argument when calling the script: `--update-test-project`.
 - We improved error handling for e2e testing.
 
+### Fixed
+- We fixed an issue where optional peer dependencies would cause a build error if not present. 
+
 ## [9.5.1] - 2021-09-02
 
 ### Changed

--- a/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
@@ -151,5 +151,9 @@ async function asyncWhere(array, filter) {
 function isPeerDependencyOptional(name, map = {}) {
     // certain peerDependencies can be optionally available, described in package.json `peerDependencyMeta`.
     // https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta
-    return !!map[name]?.optional;
+    if (map[name]) {
+        return !!map[name].optional;
+    }
+
+    return false;
 }

--- a/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
@@ -62,7 +62,7 @@ export function collectDependencies({ onlyNative, outputDir, widgetName }) {
     };
 }
 
-async function resolvePackage(target, sourceDir) {
+async function resolvePackage(target, sourceDir, optional = false) {
     const targetParts = target.split("/");
     const targetPackage = targetParts[0].startsWith("@") ? `${targetParts[0]}/${targetParts[1]}` : targetParts[0];
     try {
@@ -71,7 +71,8 @@ async function resolvePackage(target, sourceDir) {
         if (
             e.message.includes("Cannot find module") &&
             !/\.((j|t)sx?)|json|(pn|jpe?|sv)g|(tif|gi)f$/g.test(targetPackage) &&
-            !/configs\/jsActions/i.test(__dirname)                                 // Ignore errors about missing package.json in 'jsActions/**/src/*' folders
+            !/configs\/jsActions/i.test(__dirname) && // Ignore errors about missing package.json in 'jsActions/**/src/*' folders
+            !optional // Certain peerDependencies can be optional, ignore throwing an error if an optional peerDependency is considered missing.
         ) {
             throw e;
         }
@@ -98,7 +99,11 @@ async function getTransitiveDependencies(packagePath, isExternal) {
             packageJson.peerDependencies ? Object.keys(packageJson.peerDependencies) : []
         );
         for (const dependency of dependencies) {
-            const resolvedPackagePath = await resolvePackage(dependency, nextPath);
+            const resolvedPackagePath = await resolvePackage(
+                dependency,
+                nextPath,
+                isPeerDependencyOptional(dependency, packageJson.peerDependenciesMeta)
+            );
             if (isExternal(dependency) || !resolvedPackagePath) {
                 continue;
             }
@@ -141,4 +146,10 @@ async function writeNativeDependenciesJson(nativeDependencies, outputDir, widget
 
 async function asyncWhere(array, filter) {
     return (await Promise.all(array.map(async el => ((await filter(el)) ? [el] : [])))).flat();
+}
+
+function isPeerDependencyOptional(name, map = {}) {
+    // certain peerDependencies can be optionally available, described in package.json `peerDependencyMeta`.
+    // https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta
+    return !!map[name]?.optional;
 }

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.5.1",
+  "version": "9.5.2",
   "description": "Mendix Pluggable Widgets Tools",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2021. All rights reserved.",


### PR DESCRIPTION
## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
During native build, rollup statically analyses source code and import tree source code for `requires`, building up a list of dependencies. Sometimes a dependency is conditional; and in the case of this ticket, the conditional dependency was defined in the `peerDependencyMeta`: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta

## What should be covered while testing?
No regression of building tooling. Any optional peerDependency should not throw an error.
