### PR TITLE
[NC-481] Handle optional transitive dependencies

### DIFF
--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [9.5.3] - 2021-09-09
+
+### Fixed
+- We fixed an issue where optional dependencies would cause a build error if not present. 
+
 ## [9.5.2] - 2021-09-08
 
 ### Changed

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.5.2",
+  "version": "9.5.3",
   "description": "Mendix Pluggable Widgets Tools",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2021. All rights reserved.",


### PR DESCRIPTION
## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Certain transitive dependencies can be optional, as described in a dependencies `package.json`. This updates the rollup plugin to ignore throwing an error if it cant find an optional dependency.


## What should be covered while testing?
N/A. I tested this on Windows, and it worked.
