### PR TITLE
[WC-204] Atlas - Validate Sass in CI

### DIFF
--- a/.github/workflows/AtlasBuildTest.yml
+++ b/.github/workflows/AtlasBuildTest.yml
@@ -34,4 +34,4 @@ jobs:
             - name: "Running Atlas build"
               run: |
                   cd packages/theming/atlas
-                  npm run build
+                  npm run build -- --validate-sass

--- a/package-lock.json
+++ b/package-lock.json
@@ -9630,18 +9630,43 @@
 			}
 		},
 		"chokidar": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-			"integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
 			"requires": {
-				"anymatch": "~3.1.1",
+				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
-				"fsevents": "~2.1.2",
-				"glob-parent": "~5.1.0",
+				"fsevents": "~2.3.2",
+				"glob-parent": "~5.1.2",
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",
 				"normalize-path": "~3.0.0",
-				"readdirp": "~3.5.0"
+				"readdirp": "~3.6.0"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+					"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+					"requires": {
+						"normalize-path": "^3.0.0",
+						"picomatch": "^2.0.4"
+					}
+				},
+				"fsevents": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+					"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+					"optional": true
+				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				}
 			}
 		},
 		"chownr": {
@@ -21338,9 +21363,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.20",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"lodash-es": {
 			"version": "4.17.15",
@@ -28004,9 +28029,9 @@
 			}
 		},
 		"readdirp": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-			"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
 			"requires": {
 				"picomatch": "^2.2.1"
 			}

--- a/packages/theming/atlas/package.json
+++ b/packages/theming/atlas/package.json
@@ -34,7 +34,6 @@
     "cross-env": "^7.0.2",
     "concurrently": "^5.3.0",
     "fast-xml-parser": "^3.17.5",
-    "lodash": "^4.17.21",
     "sass": "^1.28.0",
     "typescript": "~4.3.5"
   },

--- a/packages/theming/atlas/package.json
+++ b/packages/theming/atlas/package.json
@@ -29,10 +29,13 @@
   "license": "MIT",
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
+    "chokidar": "^3.5.2",
     "copy-and-watch": "^0.1.5",
     "cross-env": "^7.0.2",
     "concurrently": "^5.3.0",
     "fast-xml-parser": "^3.17.5",
+    "lodash": "^4.17.21",
+    "sass": "^1.28.0",
     "typescript": "~4.3.5"
   },
   "dependencies": {}

--- a/packages/theming/atlas/scripts/build.js
+++ b/packages/theming/atlas/scripts/build.js
@@ -50,20 +50,23 @@ async function main() {
 
     if (mode === "start") {
         if (process.argv.includes("--validate-sass")) {
-            const watcher = chokidar
-                .watch(join(__dirname, "../src/themesource/{atlas_core,atlas_web_content}/web/**/*.scss"))
-                .on(
-                    "all",
-                    debounce(
-                        () => {
-                            validateSass(mode === "start");
-                        },
-                        500,
-                        { maxWait: 1000 }
-                    )
-                );
+            await new Promise(resolve => {
+                const watcher = chokidar
+                    .watch(join(__dirname, "../src/themesource/{atlas_core,atlas_web_content}/web/**/*.scss"))
+                    .on(
+                        "all",
+                        debounce(
+                            () => {
+                                validateSass(mode === "start");
+                                resolve();
+                            },
+                            500,
+                            { maxWait: 2000 }
+                        )
+                    );
 
-            closeOnSigint(watcher);
+                closeOnSigint(watcher);
+            });
         }
 
         await buildAndCopyAtlas(true, outputDir);

--- a/packages/theming/atlas/scripts/build.js
+++ b/packages/theming/atlas/scripts/build.js
@@ -19,6 +19,8 @@ async function main() {
         mode = "release";
     }
 
+    const sassValidationEnabled = process.argv.includes("--validate-sass");
+
     let outputDir;
 
     if (mode === "build" || mode === "start") {
@@ -49,7 +51,7 @@ async function main() {
     mkdir("-p", join(outputDir, "themesource/atlas_nativemobile_content"));
 
     if (mode === "start") {
-        if (process.argv.includes("--validate-sass")) {
+        if (sassValidationEnabled) {
             await new Promise(resolve => {
                 const watcher = chokidar
                     .watch(join(__dirname, "../src/themesource/{atlas_core,atlas_web_content}/web/**/*.scss"))
@@ -71,7 +73,7 @@ async function main() {
 
         await buildAndCopyAtlas(true, outputDir);
     } else {
-        if (process.argv.includes("--validate-sass")) {
+        if (sassValidationEnabled) {
             validateSass(mode === "start");
         }
         await buildAndCopyAtlas(false, outputDir);
@@ -93,7 +95,9 @@ function closeOnSigint(watcher) {
     }
 
     process.on("SIGINT", () => {
-        rl?.close();
+        if (rl) {
+            rl.close();
+        }
         watcher.close();
     });
 }

--- a/packages/theming/atlas/scripts/build.js
+++ b/packages/theming/atlas/scripts/build.js
@@ -76,8 +76,10 @@ async function main() {
 }
 
 function closeOnSigint(watcher) {
+    let rl;
+
     if (process.platform === "win32") {
-        const rl = require("readline").createInterface({
+        rl = require("readline").createInterface({
             input: process.stdin,
             output: process.stdout
         });
@@ -88,6 +90,7 @@ function closeOnSigint(watcher) {
     }
 
     process.on("SIGINT", () => {
+        rl?.close();
         watcher.close();
     });
 }

--- a/packages/theming/atlas/scripts/build.js
+++ b/packages/theming/atlas/scripts/build.js
@@ -1,4 +1,7 @@
+const chokidar = require("chokidar");
 const concurrently = require("concurrently");
+const { debounce } = require("lodash");
+const sass = require("sass");
 const { join } = require("path");
 const { rm, mkdir } = require("shelljs");
 
@@ -8,7 +11,13 @@ main().catch(e => {
 });
 
 async function main() {
-    const mode = process.argv[2] || "build";
+    let mode = "build";
+
+    if (process.argv.includes("start")) {
+        mode = "start";
+    } else if (process.argv.includes("release")) {
+        mode = "release";
+    }
 
     let outputDir;
 
@@ -30,8 +39,6 @@ async function main() {
 
         rm("-rf", outputDir);
         console.info(`Ensured the directory ${outputDir} is removed`);
-    } else {
-        throw new Error(`Invalid mode: "${mode}"`);
     }
 
     // when targeting a networked windows drive, the cmds executed by concurrently run into a race condition when
@@ -41,7 +48,66 @@ async function main() {
     mkdir("-p", join(outputDir, "themesource/atlas_web_content"));
     mkdir("-p", join(outputDir, "themesource/atlas_nativemobile_content"));
 
-    await buildAndCopyAtlas(mode === "start", outputDir);
+    if (mode === "start") {
+        if (process.argv.includes("--validate-sass")) {
+            const watcher = chokidar
+                .watch(join(__dirname, "../src/themesource/{atlas_core,atlas_web_content}/web/**/*.scss"))
+                .on(
+                    "all",
+                    debounce(
+                        () => {
+                            validateSass(mode === "start");
+                        },
+                        500,
+                        { maxWait: 1000 }
+                    )
+                );
+
+            closeOnSigint(watcher);
+        }
+
+        await buildAndCopyAtlas(true, outputDir);
+    } else {
+        if (process.argv.includes("--validate-sass")) {
+            validateSass(mode === "start");
+        }
+        await buildAndCopyAtlas(false, outputDir);
+    }
+}
+
+function closeOnSigint(watcher) {
+    if (process.platform === "win32") {
+        const rl = require("readline").createInterface({
+            input: process.stdin,
+            output: process.stdout
+        });
+
+        rl.on("SIGINT", () => {
+            process.emit("SIGINT");
+        });
+    }
+
+    process.on("SIGINT", () => {
+        watcher.close();
+    });
+}
+
+function validateSass(watchMode) {
+    console.info(`Validating Sass...`);
+
+    try {
+        sass.renderSync({ file: join(__dirname, "../src/themesource/atlas_core/web/main.scss") });
+        sass.renderSync({ file: join(__dirname, "../src/themesource/atlas_web_content/web/main.scss") });
+    } catch (e) {
+        if (watchMode) {
+            console.error(`Sass validation failed: ${e.message}`);
+            return;
+        } else {
+            throw new Error(`Sass validation failed: ${e.message}`);
+        }
+    }
+
+    console.info("Sass validation succeeded");
 }
 
 async function buildAndCopyAtlas(watchMode, destination) {
@@ -65,8 +131,8 @@ async function buildAndCopyAtlas(watchMode, destination) {
                 {
                     name: "public-themesource-core",
                     command: `copy-and-watch ${watchArg} "src/themesource/atlas_core/public/**/*" "${join(
-                      destination,
-                      "themesource/atlas_core/public"
+                        destination,
+                        "themesource/atlas_core/public"
                     )}"`
                 },
                 {
@@ -79,8 +145,8 @@ async function buildAndCopyAtlas(watchMode, destination) {
                 {
                     name: "public-themesource-content",
                     command: `copy-and-watch ${watchArg} "src/themesource/atlas_web_content/public/**/*" "${join(
-                      destination,
-                      "themesource/atlas_web_content/public"
+                        destination,
+                        "themesource/atlas_web_content/public"
                     )}"`
                 },
                 {
@@ -97,16 +163,19 @@ async function buildAndCopyAtlas(watchMode, destination) {
                 {
                     name: "public-themesource-nativecontent",
                     command: `copy-and-watch ${watchArg} "src/themesource/atlas_nativemobile_content/public/**/*" "${join(
-                      destination,
-                      "themesource/atlas_nativemobile_content/public"
+                        destination,
+                        "themesource/atlas_nativemobile_content/public"
                     )}"`
-                },
+                }
             ],
             {
                 killOthers: ["failure"]
             }
         );
-        console.log("Building & copying Atlas has completed successfully");
+
+        if (!watchMode) {
+            console.log("Building & copying Atlas has completed successfully");
+        }
     } catch (commands) {
         const commandInfo = commands.map(command => `{ name: ${command.command.name}, exit code: ${command.exitCode}}`);
         throw new Error(`One or more commands failed:\n${commandInfo.join("\n")}`);

--- a/packages/theming/atlas/scripts/build.js
+++ b/packages/theming/atlas/scripts/build.js
@@ -1,6 +1,5 @@
 const chokidar = require("chokidar");
 const concurrently = require("concurrently");
-const { debounce } = require("lodash");
 const sass = require("sass");
 const { join } = require("path");
 const { rm, mkdir } = require("shelljs");
@@ -57,14 +56,10 @@ async function main() {
                     .watch(join(__dirname, "../src/themesource/{atlas_core,atlas_web_content}/web/**/*.scss"))
                     .on(
                         "all",
-                        debounce(
-                            () => {
-                                validateSass(mode === "start");
-                                resolve();
-                            },
-                            500,
-                            { maxWait: 2000 }
-                        )
+                        debounce(() => {
+                            validateSass(mode === "start");
+                            resolve();
+                        }, 500)
                     );
 
                 closeOnSigint(watcher);
@@ -78,6 +73,18 @@ async function main() {
         }
         await buildAndCopyAtlas(false, outputDir);
     }
+}
+
+function debounce(func, waitFor) {
+    let timeout = null;
+
+    return (...args) => {
+        if (timeout !== null) {
+            clearTimeout(timeout);
+            timeout = null;
+        }
+        timeout = setTimeout(() => func(...args), waitFor);
+    };
 }
 
 function closeOnSigint(watcher) {


### PR DESCRIPTION
## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (describe)

## What is the purpose of this PR?
This PR introduces Sass validation for Atlas in CI to catch Sass error before spinning up e2e tests.

## Relevant changes
- The build script can be executed with `--validate-sass`
 to validate sass in "build", "release" & "start" mode.
- Execute CI with `--validate-sass` argument for Atlas test.

## What should be covered while testing?
Test in Windows & MacOS in "build" and "start" mode.
