### PR TITLE
chore(atlas-ui): reuse piw-utils-internal debounce in build script

### DIFF
--- a/packages/theming/atlas/package.json
+++ b/packages/theming/atlas/package.json
@@ -28,6 +28,7 @@
   "author": "Mendix",
   "license": "MIT",
   "devDependencies": {
+    "@mendix/piw-utils-internal": "^1.0.0",
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "chokidar": "^3.5.2",
     "copy-and-watch": "^0.1.5",

--- a/packages/theming/atlas/scripts/build.js
+++ b/packages/theming/atlas/scripts/build.js
@@ -4,6 +4,8 @@ const sass = require("sass");
 const { join } = require("path");
 const { rm, mkdir } = require("shelljs");
 
+const { debounce } = require("@mendix/piw-utils-internal");
+
 main().catch(e => {
     console.error(e);
     process.exit(-1);
@@ -73,18 +75,6 @@ async function main() {
         }
         await buildAndCopyAtlas(false, outputDir);
     }
-}
-
-function debounce(func, waitFor) {
-    let timeout = null;
-
-    return (...args) => {
-        if (timeout !== null) {
-            clearTimeout(timeout);
-            timeout = null;
-        }
-        timeout = setTimeout(() => func(...args), waitFor);
-    };
 }
 
 function closeOnSigint(watcher) {

--- a/packages/tools/piw-utils-internal/tsconfig.json
+++ b/packages/tools/piw-utils-internal/tsconfig.json
@@ -3,6 +3,7 @@
     "baseUrl": "./",
     "include": ["./src"],
     "compilerOptions": {
+        "module": "CommonJS",
         "types": ["mendix-client", "big.js", "react-native", "jest"],
         "noImplicitAny": true,
         "noImplicitReturns": true,


### PR DESCRIPTION
## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (describe)

## What is the purpose of this PR?
Reuse debounce function from `piw-utils-internal` in Atlas build script to prevent duplicate implementations.