### PR TITLE
[NC/WC] Fix rollup bundling issues

### DIFF
--- a/packages/jsActions/mobile-resources-native/CHANGELOG.md
+++ b/packages/jsActions/mobile-resources-native/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- We fixed an issue with our widget bundles erroneously including react-dom and thus were very large.
+
 ## [3.1.0] - 2021-08-26
 ### Notifications widget
 #### Added

--- a/packages/jsActions/mobile-resources-native/package.json
+++ b/packages/jsActions/mobile-resources-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile-resources-native",
   "moduleName": "Native Mobile Resources",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2021. All rights reserved.",
   "repository": {

--- a/packages/theming/atlas/package.json
+++ b/packages/theming/atlas/package.json
@@ -28,7 +28,6 @@
   "author": "Mendix",
   "license": "MIT",
   "devDependencies": {
-    "@mendix/piw-utils-internal": "^1.0.0",
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "chokidar": "^3.5.2",
     "copy-and-watch": "^0.1.5",

--- a/packages/theming/atlas/scripts/build.js
+++ b/packages/theming/atlas/scripts/build.js
@@ -4,8 +4,6 @@ const sass = require("sass");
 const { join } = require("path");
 const { rm, mkdir } = require("shelljs");
 
-const { debounce } = require("@mendix/piw-utils-internal");
-
 main().catch(e => {
     console.error(e);
     process.exit(-1);
@@ -75,6 +73,18 @@ async function main() {
         }
         await buildAndCopyAtlas(false, outputDir);
     }
+}
+
+function debounce(func, waitFor) {
+    let timeout = null;
+
+    return (...args) => {
+        if (timeout !== null) {
+            clearTimeout(timeout);
+            timeout = null;
+        }
+        timeout = setTimeout(() => func(...args), waitFor);
+    };
 }
 
 function closeOnSigint(watcher) {

--- a/packages/tools/piw-utils-internal/tsconfig.json
+++ b/packages/tools/piw-utils-internal/tsconfig.json
@@ -3,7 +3,6 @@
     "baseUrl": "./",
     "include": ["./src"],
     "compilerOptions": {
-        "module": "CommonJS",
         "types": ["mendix-client", "big.js", "react-native", "jest"],
         "noImplicitAny": true,
         "noImplicitReturns": true,

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -162,6 +162,7 @@ export default async args => {
                 file: join(outDir, `${widgetName}.editorConfig.js`),
                 sourcemap: false
             },
+            external: editorConfigExternal,
             treeshake: { moduleSideEffects: false },
             plugins: [
                 url({ include: ["**/*.svg"], limit: 102400 }), // SVG file size limit of 100 kB
@@ -169,7 +170,8 @@ export default async args => {
                     sourceMaps: false,
                     extensions: webExtensions,
                     transpile: true,
-                    babelConfig: { presets: [["@babel/preset-env", { targets: { ie: "11" } }]] }
+                    babelConfig: { presets: [["@babel/preset-env", { targets: { ie: "11" } }]] },
+                    external: editorConfigExternal
                 })
             ],
             onwarn
@@ -326,9 +328,12 @@ const webExternal = [/^mendix($|\/)/, /^react($|\/)/, /^react-dom($|\/)/, /^big.
 
 const editorPreviewExternal = [/^mendix($|\/)/, /^react($|\/)/, /^react-dom($|\/)/];
 
+const editorConfigExternal = [/^mendix($|\/)/, /^react($|\/)/, /^react-dom($|\/)/];
+
 const nativeExternal = [
     /^mendix($|\/)/,
     /^react-native($|\/)/,
+    /^react-dom($|\/)/,
     /^big.js$/,
     /^react($|\/)/,
     /^react-native-gesture-handler($|\/)/,


### PR DESCRIPTION
## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
1. Revert piw-utils-internal TS output change as it breaks Preview.
2. Define certain dependencies as external; we ran into a scenario whereby our common module `piw-utils-internal` exports the FilterSelector component which imports `react-dom`. Rollup doesn't seem to shake this off. For now we decided this is an appropriate solution. Going forward, we may split `piw-utils-internal` to platform agnostic code, to avoid this issue. 
