### PR TITLE
[WC-578] Align design preview of pluggable widgets with proper typing for icon

### DIFF
--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorPreview.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorPreview.tsx
@@ -1,6 +1,6 @@
 import { parseStyle } from "@mendix/piw-utils-internal";
+import { mapPreviewIconToWebIcon } from "@mendix/piw-utils-internal/components/web";
 import { createElement, ReactElement } from "react";
-import { WebIcon } from "mendix";
 
 import { Accordion } from "./components/Accordion";
 import { useIconGenerator } from "./utils/iconGenerator";
@@ -59,10 +59,9 @@ export function preview(props: PreviewProps): ReactElement {
         dynamicClassName: group.dynamicClass.slice(1, -1) // expression result is surrounded by single quotes
     }));
 
-    // TODO: Remove these when preview typing for `icon` property is aligned properly by PageEditor
-    const icon: WebIcon | null = props.icon as any;
-    const expandIcon: WebIcon | null = props.expandIcon as any;
-    const collapseIcon: WebIcon | null = props.collapseIcon as any;
+    const icon = mapPreviewIconToWebIcon(props.icon);
+    const expandIcon = mapPreviewIconToWebIcon(props.expandIcon);
+    const collapseIcon = mapPreviewIconToWebIcon(props.collapseIcon);
 
     const generateIcon = useIconGenerator(
         props.advancedMode,

--- a/packages/pluggableWidgets/rating-web/src/StarRating.editorPreview.tsx
+++ b/packages/pluggableWidgets/rating-web/src/StarRating.editorPreview.tsx
@@ -1,22 +1,26 @@
 import { createElement, ReactElement } from "react";
 import { Rating as RatingComponent } from "./components/Rating";
 import { parseStyle } from "@mendix/piw-utils-internal";
-import { WebIcon } from "mendix";
+import { mapPreviewIconToWebIcon } from "@mendix/piw-utils-internal/components/web";
 import { StarRatingPreviewProps } from "../typings/StarRatingProps";
 import { Icon } from "./components/Icon";
 
-export function preview(props: StarRatingPreviewProps): ReactElement {
-    // TODO: The widget generator is out of sync with Studio Pro design mode. Change PIW preview props typing (class -> className) and readOnly generation to remove the ts-ignore below
-    // @ts-ignore
+// TODO: The widget generator is out of sync with Studio Pro design mode. Change PIW preview props typing (class -> className) and readOnly generation when updated.
+interface PreviewProps extends Omit<StarRatingPreviewProps, "class"> {
+    className: string;
+    readOnly?: boolean;
+}
+
+export function preview(props: PreviewProps): ReactElement {
     const { className, readOnly } = props;
 
     const emptyIcon = props.emptyIcon ? (
-        <Icon value={props.emptyIcon as WebIcon} empty />
+        <Icon value={mapPreviewIconToWebIcon(props.emptyIcon)} empty />
     ) : (
         <Icon value={{ type: "glyph", iconClass: "glyphicon-star-empty" }} empty />
     );
     const fullIcon = props.icon ? (
-        <Icon value={props.icon as WebIcon} full />
+        <Icon value={mapPreviewIconToWebIcon(props.icon)} full />
     ) : (
         <Icon value={{ type: "glyph", iconClass: "glyphicon-star" }} full />
     );

--- a/packages/pluggableWidgets/sidebar-toggle-web/src/SidebarToggle.editorPreview.tsx
+++ b/packages/pluggableWidgets/sidebar-toggle-web/src/SidebarToggle.editorPreview.tsx
@@ -2,15 +2,15 @@ import { createElement, ReactElement } from "react";
 
 import { SidebarTogglePreviewProps } from "../typings/SidebarToggleProps";
 import { Toggle } from "./components/Toggle";
-import { WebIcon } from "mendix";
 import { parseStyle } from "@mendix/piw-utils-internal";
+import { mapPreviewIconToWebIcon } from "@mendix/piw-utils-internal/components/web";
 
 export function preview(props: SidebarTogglePreviewProps): ReactElement | null {
     return (
         <Toggle
             caption={props.caption}
             className={props.class}
-            icon={props.icon as WebIcon}
+            icon={mapPreviewIconToWebIcon(props.icon)}
             render={props.renderMode}
             role={props.role}
             style={parseStyle(props.style)}

--- a/packages/pluggableWidgets/timeline-web/src/Timeline.editorPreview.tsx
+++ b/packages/pluggableWidgets/timeline-web/src/Timeline.editorPreview.tsx
@@ -7,6 +7,7 @@ import {
 import TimelineComponent from "./components/TimelineComponent";
 import { createElement } from "react";
 import { BasicItemType, CustomItemType, ItemType } from "./Timeline";
+import { mapPreviewIconToWebIcon } from "@mendix/piw-utils-internal/components/web";
 
 declare function require(name: string): string;
 
@@ -26,7 +27,7 @@ export function preview(props: TimelinePreviewProps) {
                         : "year"
                 );
                 constructedItem = {
-                    icon: props.icon,
+                    icon: mapPreviewIconToWebIcon(props.icon),
                     title: props.title === String.fromCharCode(160) ? "Title" : props.title,
                     eventDateTime:
                         props.timeIndication === String.fromCharCode(160) ? "Optional Time" : props.timeIndication,

--- a/packages/pluggableWidgets/tree-node-web/src/TreeNode.editorPreview.tsx
+++ b/packages/pluggableWidgets/tree-node-web/src/TreeNode.editorPreview.tsx
@@ -1,24 +1,9 @@
 import { parseStyle } from "@mendix/piw-utils-internal";
-import { GUID, WebIcon } from "mendix";
+import { mapPreviewIconToWebIcon } from "@mendix/piw-utils-internal/components/web";
+import { GUID } from "mendix";
 import { createElement, ReactElement } from "react";
 import { TreeNodePreviewProps } from "../typings/TreeNodeProps";
 import { TreeNode } from "./components/TreeNode";
-
-function mapIconToWebIcon(icon: TreeNodePreviewProps["expandedIcon"] | TreeNodePreviewProps["collapsedIcon"]): WebIcon {
-    if (icon) {
-        if (icon.type === "glyph") {
-            return {
-                type: "glyph",
-                iconClass: icon.iconClass
-            };
-        }
-        return {
-            type: "image",
-            iconUrl: icon.imageUrl
-        };
-    }
-    return undefined;
-}
 
 function renderTextTemplateWithFallback(textTemplateValue: string, placeholder: string): string {
     if (textTemplateValue.trim().length === 0) {
@@ -54,8 +39,8 @@ export function preview(props: TreeNodePreviewProps): ReactElement | null {
             startExpanded
             showCustomIcon={props.advancedMode && (Boolean(props.expandedIcon) || Boolean(props.collapsedIcon))}
             iconPlacement={props.showIcon}
-            expandedIcon={mapIconToWebIcon(props.expandedIcon)}
-            collapsedIcon={mapIconToWebIcon(props.collapsedIcon)}
+            collapsedIcon={mapPreviewIconToWebIcon(props.collapsedIcon)}
+            expandedIcon={mapPreviewIconToWebIcon(props.expandedIcon)}
             animateIcon={false}
             animateTreeNodeContent={false}
         />

--- a/packages/tools/piw-utils-internal/src/components/web/index.ts
+++ b/packages/tools/piw-utils-internal/src/components/web/index.ts
@@ -4,3 +4,4 @@ export * from "./InfiniteBody";
 export * from "./Pagination";
 export * from "./usePositionObserver";
 export * from "./utils";
+export * from "./preview";

--- a/packages/tools/piw-utils-internal/src/components/web/preview.ts
+++ b/packages/tools/piw-utils-internal/src/components/web/preview.ts
@@ -1,0 +1,19 @@
+import { WebIcon } from "mendix";
+
+export function mapPreviewIconToWebIcon(
+    icon?: { type: "glyph"; iconClass: string } | { type: "image"; imageUrl: string } | null
+): WebIcon {
+    if (icon) {
+        if (icon.type === "glyph") {
+            return {
+                type: "glyph",
+                iconClass: icon.iconClass
+            };
+        }
+        return {
+            type: "image",
+            iconUrl: icon.imageUrl
+        };
+    }
+    return undefined;
+}


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ❌
- Compatible with Studio ✅
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Update our side of typings for design preview icon based on PE changes.

## Relevant changes
_Please add a high level explanation of what was changed and how the initial problem was solved_

## What should be covered while testing?
Check all the custom icons are working for:
- accordion
- tree node
- rating
- sidebar toggle
- timeline

## Extra comments (optional)
Preview icon type doesn't have to be aligned with client's `Webicon` typing. As mentioned by Takuma in DMs:

> They don’t necessarily need to be aligned. [...] Thing is, they’re not the same, so you could argue for or against an alignment..
