### PR TITLE
[NC] Update NMR release script with version file change

### DIFF
--- a/packages/jsActions/mobile-resources-native/CHANGELOG.md
+++ b/packages/jsActions/mobile-resources-native/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+- The version of Native Mobile Resources is now stored in `themesource` directory in a file named `.version`. When this module is added to your Mendix project, the `.version` file will appear in `themesource/nativemobileresources` directory. Previously, the version was stored in a constant, seen in Studio Pro's Project Explorer. 
+
 ### Fixed
 - We fixed an issue with our widget bundles erroneously including react-dom and thus were very large.
 

--- a/scripts/release/createNativeModules.js
+++ b/scripts/release/createNativeModules.js
@@ -156,7 +156,7 @@ async function bumpVersionInPackageJson(NMRFolder, moduleVersionOld) {
     }
 }
 
-// Update test project with latest changes
+// Update test project with latest changes and update version in themesource
 async function updateTestProject(tmpFolder, nativeWidgetFolders, githubUrl) {
     const jsActionsPath = join(process.cwd(), "packages/jsActions/mobile-resources-native/dist");
     const jsActions = await getFiles(jsActionsPath);
@@ -185,6 +185,10 @@ async function updateTestProject(tmpFolder, nativeWidgetFolders, githubUrl) {
             await copyFile(file, dest);
         })
     ]);
+    await execShellCommand(
+        `echo ${process.env.TAG.split("-v")[1]} > themesource/nativemobileresources/.version`,
+        tmpFolder
+    );
     const gitOutput = await execShellCommand(`cd ${tmpFolder} && git status`);
     if (!/nothing to commit/i.test(gitOutput)) {
         await execShellCommand(


### PR DESCRIPTION
## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
In NMR we use to have a version constant to indicate the version of the module. We identified that it is impossible to use `modellib` to bump this version constant, and that using `modelsdk` creates unnecessary complexity by requiring SVN; we decided to use a file stored in `themesource` to indicate the version. 

## Relevant changes
Update automation to set the version in the `.version` file.

I will update docs.mendix.com to reflect this change: https://github.com/mendix/docs/pull/3705/files
