### PR TITLE
[WC-753] Advanced options widgets - Rename advanced property & remove its usage in browser executed code

### DIFF
--- a/packages/pluggableWidgets/accordion-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/accordion-web/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
+### Changed
+- We renamed the advanced options property to emphasize this property is about the advanced properties' activation.
+- We made some small code improvement.
+
 ## [1.1.1] - 2021-08-16
 
 ### Changed

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorPreview.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorPreview.tsx
@@ -64,7 +64,6 @@ export function preview(props: PreviewProps): ReactElement {
     const collapseIcon = mapPreviewIconToWebIcon(props.collapseIcon);
 
     const generateIcon = useIconGenerator(
-        props.advancedMode,
         props.animateIcon,
         {
             data: icon ?? undefined

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.tsx
@@ -11,7 +11,6 @@ export function Accordion(props: AccordionContainerProps): ReactElement | null {
     const groups: AccordionGroups | undefined = useMemo(() => translateGroups(props.groups), [props.groups]);
 
     const generateIcon = useIconGenerator(
-        props.advancedMode,
         props.animateIcon,
         { data: props.icon?.value, loading: props.icon?.status === ValueStatus.Loading },
         { data: props.expandIcon?.value, loading: props.expandIcon?.status === ValueStatus.Loading },

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.xml
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.xml
@@ -142,7 +142,7 @@
         </propertyGroup>
         <propertyGroup caption="Advanced">
             <property key="advancedMode" type="boolean" defaultValue="false">
-                <caption>Advanced options</caption>
+                <caption>Enable advanced options</caption>
                 <description/>
             </property>
         </propertyGroup>

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.xml
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.xml
@@ -9,6 +9,12 @@
     <studioCategory>Structure</studioCategory>
     <properties>
         <propertyGroup caption="General">
+            <propertyGroup caption="Advanced">
+                <property key="advancedMode" type="boolean" defaultValue="false">
+                    <caption>Enable advanced options</caption>
+                    <description/>
+                </property>
+            </propertyGroup>
             <propertyGroup caption="General">
                 <property key="groups" type="object" isList="true" required="true">
                     <caption>Groups</caption>
@@ -139,12 +145,6 @@
                     <description>Animate the icon when the group is collapsing or expanding.</description>
                 </property>
             </propertyGroup>
-        </propertyGroup>
-        <propertyGroup caption="Advanced">
-            <property key="advancedMode" type="boolean" defaultValue="false">
-                <caption>Enable advanced options</caption>
-                <description/>
-            </property>
         </propertyGroup>
     </properties>
 </widget>

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.xml
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.xml
@@ -9,13 +9,11 @@
     <studioCategory>Structure</studioCategory>
     <properties>
         <propertyGroup caption="General">
-            <propertyGroup caption="Advanced">
+            <propertyGroup caption="General">
                 <property key="advancedMode" type="boolean" defaultValue="false">
                     <caption>Enable advanced options</caption>
                     <description/>
                 </property>
-            </propertyGroup>
-            <propertyGroup caption="General">
                 <property key="groups" type="object" isList="true" required="true">
                     <caption>Groups</caption>
                     <description/>

--- a/packages/pluggableWidgets/accordion-web/src/utils/__tests__/__snapshots__/iconGenerator.spec.ts.snap
+++ b/packages/pluggableWidgets/accordion-web/src/utils/__tests__/__snapshots__/iconGenerator.spec.ts.snap
@@ -1,25 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`useIconGenerator returned function returns the default icon when not in advanced mode 1`] = `
-<Icon
-  animate={true}
-/>
-`;
-
-exports[`useIconGenerator returned function with advanced mode returns the collapse icon when expanded 1`] = `
-<Icon
-  animate={false}
-  data={
-    Object {
-      "iconClass": "collapse-icon-class",
-      "type": "glyph",
-    }
-  }
-  loading={false}
-/>
-`;
-
-exports[`useIconGenerator returned function with advanced mode returns the configured icon when icon is animated 1`] = `
+exports[`useIconGenerator returned function returns the icon when icon is animated 1`] = `
 <Icon
   animate={true}
   data={
@@ -32,7 +13,20 @@ exports[`useIconGenerator returned function with advanced mode returns the confi
 />
 `;
 
-exports[`useIconGenerator returned function with advanced mode returns the expand icon when collapsed 1`] = `
+exports[`useIconGenerator returned function without icon animated returns the collapse icon when expanded 1`] = `
+<Icon
+  animate={false}
+  data={
+    Object {
+      "iconClass": "collapse-icon-class",
+      "type": "glyph",
+    }
+  }
+  loading={false}
+/>
+`;
+
+exports[`useIconGenerator returned function without icon animated returns the expand icon when collapsed 1`] = `
 <Icon
   animate={false}
   data={

--- a/packages/pluggableWidgets/accordion-web/src/utils/__tests__/iconGenerator.spec.ts
+++ b/packages/pluggableWidgets/accordion-web/src/utils/__tests__/iconGenerator.spec.ts
@@ -5,7 +5,6 @@ import { useIconGenerator } from "../iconGenerator";
 import { ReactElement } from "react";
 
 interface HookProps {
-    advancedMode: AccordionContainerProps["advancedMode"];
     animateIcon: AccordionContainerProps["animateIcon"];
     icon: Omit<IconProps, "animate">;
     expandIcon: Omit<IconProps, "animate">;
@@ -14,7 +13,6 @@ interface HookProps {
 
 describe("useIconGenerator", () => {
     const defaultHookProps: HookProps = {
-        advancedMode: false,
         animateIcon: true,
         icon: { data: { type: "glyph", iconClass: "icon-class" }, loading: false },
         expandIcon: { data: { type: "glyph", iconClass: "expand-icon-class" }, loading: false },
@@ -26,19 +24,11 @@ describe("useIconGenerator", () => {
     ): RenderHookResult<HookProps, (collapsed: boolean) => ReactElement> =>
         renderHook(
             (props: {
-                advancedMode: AccordionContainerProps["advancedMode"];
                 animateIcon: AccordionContainerProps["animateIcon"];
                 icon: Omit<IconProps, "animate">;
                 expandIcon: Omit<IconProps, "animate">;
                 collapseIcon: Omit<IconProps, "animate">;
-            }) =>
-                useIconGenerator(
-                    props.advancedMode,
-                    props.animateIcon,
-                    props.icon,
-                    props.expandIcon,
-                    props.collapseIcon
-                ),
+            }) => useIconGenerator(props.animateIcon, props.icon, props.expandIcon, props.collapseIcon),
             {
                 initialProps
             }
@@ -60,20 +50,15 @@ describe("useIconGenerator", () => {
     });
 
     describe("returned function", () => {
-        it("returns the default icon when not in advanced mode", () => {
+        it("returns the icon when icon is animated", () => {
             const renderedHook = initUseIconGenerator({ ...defaultHookProps });
             expect(renderedHook.result.current(true)).toMatchSnapshot();
         });
 
-        describe("with advanced mode", () => {
-            it("returns the configured icon when icon is animated", () => {
-                const renderedHook = initUseIconGenerator({ ...defaultHookProps, advancedMode: true });
-                expect(renderedHook.result.current(true)).toMatchSnapshot();
-            });
+        describe("without icon animated", () => {
             it("returns the expand icon when collapsed", () => {
                 const renderedHook = initUseIconGenerator({
                     ...defaultHookProps,
-                    advancedMode: true,
                     animateIcon: false
                 });
                 expect(renderedHook.result.current(true)).toMatchSnapshot();
@@ -81,7 +66,6 @@ describe("useIconGenerator", () => {
             it("returns the collapse icon when expanded", () => {
                 const renderedHook = initUseIconGenerator({
                     ...defaultHookProps,
-                    advancedMode: true,
                     animateIcon: false
                 });
                 expect(renderedHook.result.current(false)).toMatchSnapshot();

--- a/packages/pluggableWidgets/accordion-web/src/utils/iconGenerator.tsx
+++ b/packages/pluggableWidgets/accordion-web/src/utils/iconGenerator.tsx
@@ -5,7 +5,6 @@ import { Icon, IconProps } from "../components/Icon";
 import { AccordionContainerProps } from "../../typings/AccordionProps";
 
 export function useIconGenerator(
-    advancedMode: AccordionContainerProps["advancedMode"],
     animateIcon: AccordionContainerProps["animateIcon"],
     icon: Omit<IconProps, "animate">,
     expandIcon: Omit<IconProps, "animate">,
@@ -13,20 +12,16 @@ export function useIconGenerator(
 ): (collapsed: boolean) => ReactElement {
     return useCallback(
         (collapsed: boolean): ReactElement => {
-            if (!advancedMode) {
-                return <Icon animate={animateIcon} />;
+            if (animateIcon) {
+                return <Icon {...icon} animate={animateIcon} />;
             } else {
-                if (animateIcon) {
-                    return <Icon {...icon} animate={animateIcon} />;
-                } else {
-                    return collapsed ? (
-                        <Icon {...expandIcon} animate={animateIcon} />
-                    ) : (
-                        <Icon {...collapseIcon} animate={animateIcon} />
-                    );
-                }
+                return collapsed ? (
+                    <Icon {...expandIcon} animate={animateIcon} />
+                ) : (
+                    <Icon {...collapseIcon} animate={animateIcon} />
+                );
             }
         },
-        [advancedMode, animateIcon, icon, expandIcon, collapseIcon]
+        [animateIcon, icon, expandIcon, collapseIcon]
     );
 }

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - We fixed the positioning of the filters when virtual scrolling was enabled and there was no data being presented.
+- We renamed the advanced settings property to emphasize this property is about the advanced properties' activation.
 
 ## [1.2.1] - 2021-07-01
 

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -46,7 +46,7 @@ export function getProperties(
         if (column.width !== "manual") {
             hidePropertyIn(defaultProperties, values, "columns", index, "size");
         }
-        if (platform === "web" && !values.advanced) {
+        if (!values.advanced) {
             hideNestedPropertiesIn(defaultProperties, values, "columns", index, [
                 "columnClass",
                 "sortable",
@@ -95,30 +95,30 @@ export function getProperties(
         },
         "columns"
     );
-    if (platform === "web") {
-        if (!values.advanced) {
-            hidePropertiesIn(defaultProperties, values, [
-                "pagination",
-                "pagingPosition",
-                "showEmptyPlaceholder",
-                "rowClass",
-                "columnsSortable",
-                "columnsDraggable",
-                "columnsResizable",
-                "columnsHidable",
-                "configurationAttribute",
-                "onConfigurationChange",
-                "showHeaderFilters",
-                "filterList",
-                "filtersPlaceholder",
-                "filterSectionTitle"
-            ]);
-        }
 
-        transformGroupsIntoTabs(defaultProperties);
-    } else {
-        hidePropertyIn(defaultProperties, values, "advanced");
+    if (!values.advanced) {
+        hidePropertiesIn(defaultProperties, values, [
+            "pagination",
+            "pagingPosition",
+            "showEmptyPlaceholder",
+            "rowClass",
+            "columnsSortable",
+            "columnsDraggable",
+            "columnsResizable",
+            "columnsHidable",
+            "configurationAttribute",
+            "onConfigurationChange",
+            "showHeaderFilters",
+            "filterList",
+            "filtersPlaceholder",
+            "filterSectionTitle"
+        ]);
     }
+
+    if (platform === "web") {
+        transformGroupsIntoTabs(defaultProperties);
+    }
+
     return defaultProperties;
 }
 

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -6,13 +6,11 @@
     <studioCategory>Data Containers</studioCategory>
     <properties>
         <propertyGroup caption="General">
-            <propertyGroup caption="Advanced">
+            <propertyGroup caption="General">
                 <property key="advanced" type="boolean" defaultValue="false">
                     <caption>Enable advanced options</caption>
                     <description />
                 </property>
-            </propertyGroup>
-            <propertyGroup caption="General">
                 <property key="datasource" type="datasource" isList="true">
                     <caption>Data source</caption>
                     <description/>

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -6,6 +6,12 @@
     <studioCategory>Data Containers</studioCategory>
     <properties>
         <propertyGroup caption="General">
+            <propertyGroup caption="Advanced">
+                <property key="advanced" type="boolean" defaultValue="false">
+                    <caption>Enable advanced options</caption>
+                    <description />
+                </property>
+            </propertyGroup>
             <propertyGroup caption="General">
                 <property key="datasource" type="datasource" isList="true">
                     <caption>Data source</caption>
@@ -235,14 +241,6 @@
                 <property key="filterSectionTitle" type="textTemplate" required="false">
                     <caption>Filter section title</caption>
                     <description>Assistive technology will read this upon reaching a filtering or sorting section.</description>
-                </property>
-            </propertyGroup>
-        </propertyGroup>
-        <propertyGroup caption="Advanced">
-            <propertyGroup caption="Advanced">
-                <property key="advanced" type="boolean" defaultValue="false">
-                    <caption>Advanced settings</caption>
-                    <description />
                 </property>
             </propertyGroup>
         </propertyGroup>

--- a/packages/pluggableWidgets/gallery-web/src/Gallery.editorConfig.ts
+++ b/packages/pluggableWidgets/gallery-web/src/Gallery.editorConfig.ts
@@ -28,24 +28,23 @@ export function getProperties(
         hidePropertyIn(defaultProperties, values, "filtersPlaceholder");
     }
 
+    if (!values.advanced) {
+        hidePropertiesIn(defaultProperties, values, [
+            "pagination",
+            "pagingPosition",
+            "showEmptyPlaceholder",
+            "emptyPlaceholder",
+            "itemClass",
+            "filtersPlaceholder",
+            "filterList",
+            "sortList",
+            "emptyMessageTitle",
+            "filterSectionTitle"
+        ]);
+    }
+
     if (platform === "web") {
-        if (!values.advanced) {
-            hidePropertiesIn(defaultProperties, values, [
-                "pagination",
-                "pagingPosition",
-                "showEmptyPlaceholder",
-                "emptyPlaceholder",
-                "itemClass",
-                "filtersPlaceholder",
-                "filterList",
-                "sortList",
-                "emptyMessageTitle",
-                "filterSectionTitle"
-            ]);
-        }
         transformGroupsIntoTabs(defaultProperties);
-    } else {
-        hidePropertyIn(defaultProperties, values, "advanced");
     }
 
     return defaultProperties;

--- a/packages/pluggableWidgets/gallery-web/src/Gallery.xml
+++ b/packages/pluggableWidgets/gallery-web/src/Gallery.xml
@@ -8,7 +8,7 @@
         <propertyGroup caption="General">
             <propertyGroup caption="Advanced">
                 <property key="advanced" type="boolean" defaultValue="false">
-                    <caption>Advanced</caption>
+                    <caption>Enable advanced options</caption>
                     <description />
                 </property>
             </propertyGroup>

--- a/packages/pluggableWidgets/gallery-web/src/Gallery.xml
+++ b/packages/pluggableWidgets/gallery-web/src/Gallery.xml
@@ -6,13 +6,11 @@
     <studioCategory>Data Containers</studioCategory>
     <properties>
         <propertyGroup caption="General">
-            <propertyGroup caption="Advanced">
+            <propertyGroup caption="General">
                 <property key="advanced" type="boolean" defaultValue="false">
                     <caption>Enable advanced options</caption>
                     <description />
                 </property>
-            </propertyGroup>
-            <propertyGroup caption="General">
                 <property key="datasource" type="datasource" isList="true">
                     <caption>Data source</caption>
                     <description/>

--- a/packages/pluggableWidgets/maps-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/maps-web/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
+### Changed
+- We renamed the advanced options property to emphasize this property is about the advanced properties' activation.
+- We made some small code improvement.
+
 ## [2.0.3] - 2021-08-04
 
 ## Changed

--- a/packages/pluggableWidgets/maps-web/src/Maps.tsx
+++ b/packages/pluggableWidgets/maps-web/src/Maps.tsx
@@ -14,9 +14,7 @@ export default function Maps(props: MapsContainerProps): ReactNode {
     const [locations] = useLocationResolver(
         props.markers,
         props.dynamicMarkers,
-        !props.advanced
-            ? props.apiKeyExp?.value ?? props.apiKey
-            : props.geodecodeApiKeyExp?.value ?? props.geodecodeApiKey
+        props.geodecodeApiKeyExp?.value ?? props.geodecodeApiKey ?? props.apiKeyExp?.value ?? props.apiKey
     );
     const [currentLocation, setCurrentLocation] = useState<Marker>();
 
@@ -26,7 +24,7 @@ export default function Maps(props: MapsContainerProps): ReactNode {
                 .then(setCurrentLocation)
                 .catch(e => console.error(e));
         }
-    }, []);
+    }, [props.showCurrentLocation]);
 
     return (
         <MapSwitcher

--- a/packages/pluggableWidgets/maps-web/src/Maps.tsx
+++ b/packages/pluggableWidgets/maps-web/src/Maps.tsx
@@ -14,7 +14,10 @@ export default function Maps(props: MapsContainerProps): ReactNode {
     const [locations] = useLocationResolver(
         props.markers,
         props.dynamicMarkers,
-        props.geodecodeApiKeyExp?.value ?? props.geodecodeApiKey ?? props.apiKeyExp?.value ?? props.apiKey
+        props.geodecodeApiKeyExp?.value ??
+            (props.geodecodeApiKey || undefined) ??
+            props.apiKeyExp?.value ??
+            props.apiKey
     );
     const [currentLocation, setCurrentLocation] = useState<Marker>();
 

--- a/packages/pluggableWidgets/maps-web/src/Maps.xml
+++ b/packages/pluggableWidgets/maps-web/src/Maps.xml
@@ -10,7 +10,7 @@
     <properties>
         <!-- Data source -->
         <propertyGroup caption="General">
-            <propertyGroup caption="Advanced">
+            <propertyGroup caption="General">
                 <property key="advanced" type="boolean" defaultValue="false">
                     <caption>Enable advanced options</caption>
                     <description/>

--- a/packages/pluggableWidgets/maps-web/src/Maps.xml
+++ b/packages/pluggableWidgets/maps-web/src/Maps.xml
@@ -12,7 +12,7 @@
         <propertyGroup caption="General">
             <propertyGroup caption="Advanced">
                 <property key="advanced" type="boolean" defaultValue="false">
-                    <caption>Show advanced</caption>
+                    <caption>Enable advanced options</caption>
                     <description/>
                 </property>
             </propertyGroup>

--- a/packages/pluggableWidgets/popup-menu-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/popup-menu-web/CHANGELOG.md
@@ -7,3 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+### Changed
+- We renamed the custom visualization property to enable advanced options.

--- a/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.editorConfig.ts
+++ b/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.editorConfig.ts
@@ -8,7 +8,8 @@ import {
     RowLayoutProps,
     SelectableProps,
     StructurePreviewProps,
-    TextProps
+    TextProps,
+    transformGroupsIntoTabs
 } from "@mendix/piw-utils-internal";
 import { BasicItemsPreviewType, PopupMenuPreviewProps } from "../typings/PopupMenuProps";
 
@@ -70,6 +71,11 @@ export function getProperties(
     } else {
         hidePropertyIn(defaultProperties, values, "basicItems");
     }
+
+    if (target === "web") {
+        transformGroupsIntoTabs(defaultProperties);
+    }
+
     return defaultProperties;
 }
 

--- a/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.xml
+++ b/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.xml
@@ -8,13 +8,11 @@
     <studioCategory>Menus</studioCategory>
     <properties>
         <propertyGroup caption="General">
-            <propertyGroup caption="Advanced">
+            <propertyGroup caption="General">
                 <property key="advancedMode" type="boolean" defaultValue="false">
                     <caption>Enable advanced options</caption>
                     <description />
                 </property>
-            </propertyGroup>
-            <propertyGroup caption="General">
                 <property key="menuTrigger" type="widgets" required="false">
                     <caption>The area to open or close the menu.</caption>
                     <description>Responsible for toggling the Pop-up menu.</description>

--- a/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.xml
+++ b/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.xml
@@ -8,6 +8,12 @@
     <studioCategory>Menus</studioCategory>
     <properties>
         <propertyGroup caption="General">
+            <propertyGroup caption="Advanced">
+                <property key="advancedMode" type="boolean" defaultValue="false">
+                    <caption>Enable advanced options</caption>
+                    <description />
+                </property>
+            </propertyGroup>
             <propertyGroup caption="General">
                 <property key="menuTrigger" type="widgets" required="false">
                     <caption>The area to open or close the menu.</caption>
@@ -85,10 +91,6 @@
                         <enumerationValue key="top">Top</enumerationValue>
                         <enumerationValue key="bottom">Bottom</enumerationValue>
                     </enumerationValues>
-                </property>
-                <property key="advancedMode" type="boolean" defaultValue="false">
-                    <caption>Custom Visualization</caption>
-                    <description>Create custom menu items.</description>
                 </property>
             </propertyGroup>
             <propertyGroup caption="Development">

--- a/packages/pluggableWidgets/tree-node-web/src/TreeNode.editorPreview.tsx
+++ b/packages/pluggableWidgets/tree-node-web/src/TreeNode.editorPreview.tsx
@@ -37,7 +37,7 @@ export function preview(props: TreeNodePreviewProps): ReactElement | null {
             ]}
             isUserDefinedLeafNode={!props.hasChildren}
             startExpanded
-            showCustomIcon={props.advancedMode && (Boolean(props.expandedIcon) || Boolean(props.collapsedIcon))}
+            showCustomIcon={Boolean(props.expandedIcon) || Boolean(props.collapsedIcon)}
             iconPlacement={props.showIcon}
             collapsedIcon={mapPreviewIconToWebIcon(props.collapsedIcon)}
             expandedIcon={mapPreviewIconToWebIcon(props.expandedIcon)}

--- a/packages/pluggableWidgets/tree-node-web/src/TreeNode.tsx
+++ b/packages/pluggableWidgets/tree-node-web/src/TreeNode.tsx
@@ -29,7 +29,7 @@ export function TreeNode(props: TreeNodeContainerProps): ReactElement {
             items={items}
             isUserDefinedLeafNode={!props.hasChildren}
             startExpanded={props.startExpanded}
-            showCustomIcon={props.advancedMode && (Boolean(props.expandedIcon) || Boolean(props.collapsedIcon))}
+            showCustomIcon={Boolean(props.expandedIcon) || Boolean(props.collapsedIcon)}
             iconPlacement={props.showIcon}
             expandedIcon={expandedIcon}
             collapsedIcon={collapsedIcon}

--- a/packages/pluggableWidgets/tree-node-web/src/TreeNode.xml
+++ b/packages/pluggableWidgets/tree-node-web/src/TreeNode.xml
@@ -8,13 +8,11 @@
     <studioCategory>Data Containers</studioCategory>
     <properties>
         <propertyGroup caption="General">
-            <propertyGroup caption="Advanced">
+            <propertyGroup caption="General">
                 <property key="advancedMode" type="boolean" defaultValue="false">
                     <caption>Enable advanced options</caption>
                     <description/>
                 </property>
-            </propertyGroup>
-            <propertyGroup caption="General">
                 <property key="datasource" type="datasource" isList="true">
                     <caption>Data source</caption>
                     <description/>

--- a/packages/pluggableWidgets/tree-node-web/src/TreeNode.xml
+++ b/packages/pluggableWidgets/tree-node-web/src/TreeNode.xml
@@ -8,6 +8,12 @@
     <studioCategory>Data Containers</studioCategory>
     <properties>
         <propertyGroup caption="General">
+            <propertyGroup caption="Advanced">
+                <property key="advancedMode" type="boolean" defaultValue="false">
+                    <caption>Enable advanced options</caption>
+                    <description/>
+                </property>
+            </propertyGroup>
             <propertyGroup caption="General">
                 <property key="datasource" type="datasource" isList="true">
                     <caption>Data source</caption>
@@ -71,12 +77,6 @@
                     <description>Animate the icon when the group is collapsing or expanding.</description>
                 </property>
             </propertyGroup>
-        </propertyGroup>
-        <propertyGroup caption="Advanced">
-            <property key="advancedMode" type="boolean" defaultValue="false">
-                <caption>Enable advanced options</caption>
-                <description/>
-            </property>
         </propertyGroup>
     </properties>
 </widget>

--- a/packages/pluggableWidgets/tree-node-web/src/TreeNode.xml
+++ b/packages/pluggableWidgets/tree-node-web/src/TreeNode.xml
@@ -74,7 +74,7 @@
         </propertyGroup>
         <propertyGroup caption="Advanced">
             <property key="advancedMode" type="boolean" defaultValue="false">
-                <caption>Advanced options</caption>
+                <caption>Enable advanced options</caption>
                 <description/>
             </property>
         </propertyGroup>


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Compatible with Studio ✅ 

#### Feature specific
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Rename advanced property & remove its usage in browser executed code. Also align advanced mode properties across widgets and move property group to tabs for popup menu in Studio.

## What should be covered while testing?
Verify advanced mode properties work.
Accordion / Tree node: icon behaviour in advanced and not advanced mode
Maps: test whether API keys still work and show current location feature.
