### PR TITLE
[WC-704] Fix navigationtree hover popup

### DIFF
--- a/packages/theming/atlas/src/themesource/atlas_core/web/layouts/_layout-atlas-responsive.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/layouts/_layout-atlas-responsive.scss
@@ -16,17 +16,18 @@
                 width: $navsidebar-width-closed !important;
 
                 .mx-scrollcontainer-wrapper > .mx-navigationtree ul li {
-                    &.mx-navigationtree-has-items:hover {
-                        ul {
-                            position: absolute;
-                            z-index: 100;
-                            top: 0;
-                            bottom: 0;
-                            left: $sidebar-icon-width;
-                            display: block;
-                            overflow-y: auto;
-                            min-width: auto;
-                            padding: $spacing-small 0;
+                    &.mx-navigationtree-has-items:hover > ul {
+                        position: absolute;
+                        z-index: 100;
+                        top: 0;
+                        bottom: 0;
+                        left: $sidebar-icon-width;
+                        display: block;
+                        min-width: auto;
+                        padding: $spacing-small 0;
+
+                        & > li.mx-navigationtree-has-items:hover > ul {
+                            left: 100%;
                         }
                     }
 

--- a/packages/theming/atlas/src/themesource/atlas_core/web/layouts/_layout-atlas-responsive.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/layouts/_layout-atlas-responsive.scss
@@ -16,6 +16,10 @@
                 width: $navsidebar-width-closed !important;
 
                 .mx-scrollcontainer-wrapper > .mx-navigationtree ul li {
+                    &.mx-navigationtree-has-items a {
+                        white-space: nowrap;
+                    }
+
                     &.mx-navigationtree-has-items:hover > ul {
                         position: absolute;
                         z-index: 100;


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ✅
- Compatible with: MX 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅ 
- Compatible with Studio ✅
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
- Fix overlapping and broken navigationtree expansion hover popup
- The problem was that the left offside was always set to 52px. This is fine for the second level as the first level is always that wide, but the second level is then visually restricted as the third level is only offset by 52px. For the third level, we now offset by 100% of the element, which lets the second level expand horizontally entirely.
- Also made sure that the third level is only opened when the second level is hovered, instead of showing all the levels 
