### PR TITLE
[NC-438] Don't mangle native in production

### DIFF
--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -241,7 +241,7 @@ export default async args => {
                   })
                 : null,
             image(),
-            production ? terser() : null,
+            production ? terser(platform === "native" ? { mangle: false } : undefined) : null,
             // We need to create .mpk and copy results to test project after bundling is finished.
             // In case of a regular build is it is on `writeBundle` of the last config we define
             // (since rollup processes configs sequentially). But in watch mode rollup re-bundles only


### PR DESCRIPTION
## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Some recent changes (undetermined) have caused terser's `mangle` functionality to cause runtime JS errors. 

Until we have figured this out, disable manging for native production builds.

NMR `.mpk` size:
- with mangling: 17,074KB
- without mangling: 17,333KB

JIRA to pick up later: https://mendix.atlassian.net/browse/NC-501

## What should be covered while testing?
NMR should behave as expected.

