### PR TITLE
[NC] Revert format functionality in rollup (native)

### DIFF
--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [9.5.5] - 2021-09-23
+
+### Fixed
+- We reverted the feature introduced in 9.5.4 that automatically formatted each build as this caused builds to stall in certain cases.
+
 ## [9.5.4] - 2021-09-21
 
 ### Added

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -33,7 +33,6 @@ import {
     widgetVersion
 } from "./shared";
 import image from "@rollup/plugin-image";
-import { execSync } from "child_process";
 
 const outDir = join(sourcePath, "/dist/tmp/widgets/");
 const outWidgetFile = join(widgetPackage.replace(/\./g, "/"), widgetName.toLowerCase(), `${widgetName}`);
@@ -270,14 +269,6 @@ export default async args => {
     function getClientComponentPlugins(platform) {
         return [
             isTypescript ? widgetTyping({ sourceDir: join(sourcePath, "src") }) : null,
-            platform === "native" && !args.watch
-                ? command(() =>
-                      execSync(`npx pluggable-widgets-tools format`, {
-                          stdio: "inherit",
-                          input: `--prefix ${sourcePath}`
-                      })
-                  )
-                : null,
             clear({ targets: [outDir, mpkDir] }),
             command([
                 () => {


### PR DESCRIPTION
## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Running build:native stalls on certain widgets. For now, since this is an unknown root cause, revert this functionality.
