### PR TITLE
Remove ESLint validation for typings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,5 +10,6 @@ module.exports = deepmerge(base, {
         "no-unused-expressions": "off",
         "@typescript-eslint/no-unused-expressions": "error",
         "no-undef": "off"
-    }
+    },
+    ignorePatterns: ["packages/pluggableWidgets/*/typings"]
 });


### PR DESCRIPTION
## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (describe)

## What is the purpose of this PR?
WebStorm uses the eslint rc to lint project files. It also lints typing files. These files, generated by PIW-tools, don't adhere to the prettier convention, which causes ESLint errors to appear when changing the file. This PR stops linting these files to prevent errors showing up when commiting.

## Relevant changes
- Add ignore pattern to eslint rc.
