### PR TITLE
Revert "Remove ESLint validation for typings"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,5 @@ module.exports = deepmerge(base, {
         "no-unused-expressions": "off",
         "@typescript-eslint/no-unused-expressions": "error",
         "no-undef": "off"
-    },
-    ignorePatterns: ["packages/pluggableWidgets/*/typings"]
+    }
 });


### PR DESCRIPTION
Reverts mendix/widgets-resources#936

This change isn't necessary, because prettifying is covered in the git pre-commit hooks. Simply disabling the analyse code feature in WebStorm lets the pre-commit hook do its work.