### PR TITLE
[WC-501] fix thumbnail url for design preview and thumbnail className

### DIFF
--- a/packages/pluggableWidgets/image-web/src/components/Image/index.tsx
+++ b/packages/pluggableWidgets/image-web/src/components/Image/index.tsx
@@ -5,6 +5,7 @@ import { ImageUi, ImageContentProps } from "./ui";
 import { Lightbox, LightboxProps } from "../Lightbox";
 
 import "../../ui/Image.scss";
+import classNames from "classnames";
 
 export type ImageType = {
     type: "image" | "icon";
@@ -89,7 +90,8 @@ export const Image: FunctionComponent<ImageProps> = ({
     const content =
         type === "image" ? (
             <ImageUi.ContentImage
-                image={processImageLink(image, displayAs)}
+                className={classNames({ "img-thumbnail": displayAs === "thumbnail" })}
+                image={previewMode ? image : processImageLink(image, displayAs)}
                 height={height}
                 heightUnit={heightUnit}
                 width={width}

--- a/packages/pluggableWidgets/image-web/src/components/Image/ui.tsx
+++ b/packages/pluggableWidgets/image-web/src/components/Image/ui.tsx
@@ -76,7 +76,7 @@ export interface ImageContentImage extends ImageContentProps {
     heightUnit: HeightUnitEnum;
     width: number;
     widthUnit: WidthUnitEnum;
-    className: string;
+    className?: string;
 }
 
 function ContentImage(props: ImageContentImage): ReactElement {
@@ -113,7 +113,6 @@ function getImageContentOnClickProps(onClick: ImageContentProps["onClick"]): HTM
 }
 
 interface BackgroundImageProps extends ImageContentImage {
-    className?: string;
     children: ReactNode;
 }
 

--- a/packages/pluggableWidgets/image-web/src/components/Image/ui.tsx
+++ b/packages/pluggableWidgets/image-web/src/components/Image/ui.tsx
@@ -76,12 +76,14 @@ export interface ImageContentImage extends ImageContentProps {
     heightUnit: HeightUnitEnum;
     width: number;
     widthUnit: WidthUnitEnum;
+    className: string;
 }
 
 function ContentImage(props: ImageContentImage): ReactElement {
     const onClickProps = getImageContentOnClickProps(props.onClick);
     return (
         <img
+            className={props.className}
             src={props.image}
             style={{
                 ...props.style,

--- a/packages/pluggableWidgets/image-web/src/components/__tests__/__snapshots__/Image.spec.tsx.snap
+++ b/packages/pluggableWidgets/image-web/src/components/__tests__/__snapshots__/Image.spec.tsx.snap
@@ -27,6 +27,7 @@ exports[`Image renders the structure with an image 1`] = `
   class="mx-image-viewer mx-image-viewer-responsive"
 >
   <img
+    class=""
     src="https://pbs.twimg.com/profile_images/1905729715/llamas_1_.jpg"
     style="height:300px;width:300px"
   />
@@ -38,6 +39,7 @@ exports[`Image renders the structure with an image and percentage dimensions 1`]
   class="mx-image-viewer mx-image-viewer-responsive"
 >
   <img
+    class=""
     src="https://pbs.twimg.com/profile_images/1905729715/llamas_1_.jpg"
     style="height:;width:100%"
   />


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

**_Please remove unnecessary emojis and sections and this comment before proceeding_**

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
- Aligning with the previous implementation of static and dynamic image, adding the `img-thumbnail` classname to the image to load the appropriate stylings.
- Also fix the URL parsing in design preview, since there it doesn't get a proper URL.
