### PR TITLE
chore(pluggable-widgets-tools): improve prettifying functionality for web

### DIFF
--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- We added functionality so that widget TypeScript typings are prettified on creation for web.
+
+### Changed
+- We improved the formatting script for web by preventing prettifying MX test projects.
+
 ## [9.5.5] - 2021-09-23
 
 ### Fixed

--- a/packages/tools/pluggable-widgets-tools/bin/mx-scripts.js
+++ b/packages/tools/pluggable-widgets-tools/bin/mx-scripts.js
@@ -30,7 +30,7 @@ function getRealCommand(cmd, toolsRoot) {
     const eslintCommand = "eslint --config .eslintrc.js --ext .jsx,.js,.ts,.tsx src";
     const prettierConfigRootPath = join(__dirname, "../../../../prettier.config.js");
     const prettierConfigPath = existsSync(prettierConfigRootPath) ? prettierConfigRootPath : "prettier.config.js";
-    const prettierCommand = `prettier --config "${prettierConfigPath}" "{src,typings,tests}/**/*.{js,jsx,ts,tsx,scss}"`;
+    const prettierCommand = `prettier --config "${prettierConfigPath}" "{src,typings,tests/e2e}/**/*.{js,jsx,ts,tsx,scss}"`;
     const rollupCommandWeb = `rollup --config "${join(toolsRoot, "configs/rollup.config.js")}"`;
     const rollupCommandNative = `rollup --config "${join(toolsRoot, "configs/rollup.config.native.js")}"`;
 

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -223,13 +223,15 @@ export default async args => {
     function getClientComponentPlugins() {
         return [
             isTypescript ? widgetTyping({ sourceDir: join(sourcePath, "src") }) : null,
-            command(() => {
-                const prettierConfigRootPath = join(__dirname, "../../../../prettier.config.js");
-                const prettierConfigPath = existsSync(prettierConfigRootPath)
-                    ? prettierConfigRootPath
-                    : "prettier.config.js";
-                execSync(`prettier --write --config "${prettierConfigPath}" "typings/**/**(Props).ts"`);
-            }),
+            isTypescript
+                ? command(() => {
+                      const prettierConfigRootPath = join(__dirname, "../../../../prettier.config.js");
+                      const prettierConfigPath = existsSync(prettierConfigRootPath)
+                          ? prettierConfigRootPath
+                          : "prettier.config.js";
+                      execSync(`prettier --write --config "${prettierConfigPath}" "typings/**/**(Props).ts"`);
+                  })
+                : null,
             clear({ targets: [outDir, mpkDir] }),
             command([
                 () => {

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -1,3 +1,4 @@
+import { execSync } from "child_process";
 import { existsSync, mkdirSync } from "fs";
 import { join, relative } from "path";
 import alias from "@rollup/plugin-alias";
@@ -222,6 +223,13 @@ export default async args => {
     function getClientComponentPlugins() {
         return [
             isTypescript ? widgetTyping({ sourceDir: join(sourcePath, "src") }) : null,
+            command(() => {
+                const prettierConfigRootPath = join(__dirname, "../../../../prettier.config.js");
+                const prettierConfigPath = existsSync(prettierConfigRootPath)
+                    ? prettierConfigRootPath
+                    : "prettier.config.js";
+                execSync(`prettier --write --config "${prettierConfigPath}" "typings/**/**(Props).ts"`);
+            }),
             clear({ targets: [outDir, mpkDir] }),
             command([
                 () => {


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes  ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Improve prettifying functionality for web

## Relevant changes
- Prevent prettifying MX test projects when running `pluggable-widgets-tools format`.
- Prettify widget typings on creation.
