### PR TITLE
[WC-773] Add help-url to Web Pluggable Widgets

### DIFF
--- a/packages/pluggableWidgets/accessibility-helper-web/src/AccessibilityHelper.xml
+++ b/packages/pluggableWidgets/accessibility-helper-web/src/AccessibilityHelper.xml
@@ -2,13 +2,13 @@
 <widget id="com.mendix.widget.web.accessibilityhelper.AccessibilityHelper" pluginWidget="true" needsEntityContext="true" offlineCapable="true"
         supportedPlatform="Web"
         xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../../node_modules/mendix/custom_widget.xsd">
     <name>Accessibility helper</name>
     <description/>
     <studioProCategory>Input elements</studioProCategory>
     <studioCategory>Input Elements</studioCategory>
     <helpUrl>https://docs.mendix.com/appstore/widgets/accessibility-helper</helpUrl>
-        <properties>
+    <properties>
         <propertyGroup caption="General">
             <property key="targetSelector" type="string">
                 <caption>Target selector</caption>

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.xml
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.xml
@@ -2,11 +2,12 @@
 <widget id="com.mendix.widget.web.accordion.Accordion" needsEntityContext="true" offlineCapable="true"
         pluginWidget="true"
         xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd">
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../../node_modules/mendix/custom_widget.xsd">
     <name>Accordion</name>
     <description>Toggle the display of sections of content.</description>
     <studioProCategory>Structure</studioProCategory>
     <studioCategory>Structure</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/widgets/accordion</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="General">

--- a/packages/pluggableWidgets/badge-button-web/src/BadgeButton.xml
+++ b/packages/pluggableWidgets/badge-button-web/src/BadgeButton.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <widget id="com.mendix.widget.custom.badgebutton.BadgeButton" pluginWidget="true" offlineCapable="true"
         xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd">
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../../node_modules/mendix/custom_widget.xsd">
     <name>Badge button</name>
     <description/>
     <studioProCategory>Buttons</studioProCategory>
     <studioCategory>Buttons</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/widgets/badge-button</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="General">

--- a/packages/pluggableWidgets/badge-web/src/Badge.xml
+++ b/packages/pluggableWidgets/badge-web/src/Badge.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<widget id="com.mendix.widget.custom.badge.Badge" pluginWidget="true" offlineCapable="true" xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../node_modules/mendix/custom_widget.xsd">
+<widget id="com.mendix.widget.custom.badge.Badge" pluginWidget="true" offlineCapable="true" xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../../node_modules/mendix/custom_widget.xsd">
     <name>Badge</name>
     <description />
     <studioProCategory>Display</studioProCategory>
     <studioCategory>Display</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/widgets/badge</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="General">

--- a/packages/pluggableWidgets/barcode-scanner-web/src/BarcodeScanner.xml
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/BarcodeScanner.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <widget id="com.mendix.widget.web.barcodescanner.BarcodeScanner" offlineCapable="true"
     xmlns="http://www.mendix.com/widget/1.0/"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd" pluginWidget="true">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../../node_modules/mendix/custom_widget.xsd" pluginWidget="true">
     <name>Barcode Scanner</name>
     <description>The widget lets you scan a barcode</description>
     <studioProCategory>Add-ons</studioProCategory>
     <studioCategory>Add-ons</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/widgets/barcode-scanner</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="General">

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/DatagridDateFilter.xml
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/DatagridDateFilter.xml
@@ -6,6 +6,7 @@
     <description/>
     <studioProCategory>Data controls</studioProCategory>
     <studioCategory>Data Controls</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/modules/data-grid-2#7-1-date-filter</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="General">

--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/DatagridDropdownFilter.xml
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/DatagridDropdownFilter.xml
@@ -6,6 +6,7 @@
     <description/>
     <studioProCategory>Data controls</studioProCategory>
     <studioCategory>Data Controls</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/modules/data-grid-2#7-2-drop-down-filter</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="General">

--- a/packages/pluggableWidgets/datagrid-number-filter-web/src/DatagridNumberFilter.xml
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/src/DatagridNumberFilter.xml
@@ -6,6 +6,7 @@
     <description/>
     <studioProCategory>Data controls</studioProCategory>
     <studioCategory>Data Controls</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/modules/data-grid-2#7-3-number-filter</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="General">

--- a/packages/pluggableWidgets/datagrid-text-filter-web/src/DatagridTextFilter.xml
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/src/DatagridTextFilter.xml
@@ -6,6 +6,7 @@
     <description/>
     <studioProCategory>Data controls</studioProCategory>
     <studioCategory>Data Controls</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/modules/data-grid-2#7-4-text-filter</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="General">

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -4,6 +4,7 @@
     <description/>
     <studioProCategory>Data containers</studioProCategory>
     <studioCategory>Data Containers</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/modules/data-grid-2</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="General">

--- a/packages/pluggableWidgets/dropdown-sort-web/src/DropdownSort.xml
+++ b/packages/pluggableWidgets/dropdown-sort-web/src/DropdownSort.xml
@@ -6,6 +6,7 @@
     <description/>
     <studioProCategory>Data controls</studioProCategory>
     <studioCategory>Data Controls</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/modules/gallery#4-1-drop-down-sort</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="General">

--- a/packages/pluggableWidgets/fieldset-web/src/Fieldset.xml
+++ b/packages/pluggableWidgets/fieldset-web/src/Fieldset.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<widget id="com.mendix.widget.web.fieldset.Fieldset" pluginWidget="true" offlineCapable="true" xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd">
+<widget id="com.mendix.widget.web.fieldset.Fieldset" pluginWidget="true" offlineCapable="true" xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../../node_modules/mendix/custom_widget.xsd">
     <name>Fieldset</name>
     <description />
     <studioProCategory>Input elements</studioProCategory>
     <studioCategory>Input Elements</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/widgets/fieldset</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="General">

--- a/packages/pluggableWidgets/gallery-web/src/Gallery.xml
+++ b/packages/pluggableWidgets/gallery-web/src/Gallery.xml
@@ -4,6 +4,7 @@
     <description/>
     <studioProCategory>Data containers</studioProCategory>
     <studioCategory>Data Containers</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/modules/gallery</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="General">

--- a/packages/pluggableWidgets/image-web/src/Image.xml
+++ b/packages/pluggableWidgets/image-web/src/Image.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<widget id="com.mendix.widget.web.image.Image" needsEntityContext="false" offlineCapable="true" xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd" pluginWidget="true">
+<widget id="com.mendix.widget.web.image.Image" needsEntityContext="false" offlineCapable="true" xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../../node_modules/mendix/custom_widget.xsd" pluginWidget="true">
     <name>Image</name>
     <description>Display an image and enlarge it on click.</description>
     <studioProCategory>Images, videos &amp; files</studioProCategory>
     <studioCategory>Images, Videos &amp; Files</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/widgets/image</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="Data source">

--- a/packages/pluggableWidgets/maps-web/src/Maps.xml
+++ b/packages/pluggableWidgets/maps-web/src/Maps.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <widget id="com.mendix.widget.custom.Maps.Maps" pluginWidget="true" offlineCapable="true"
     xmlns="http://www.mendix.com/widget/1.0/"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../../node_modules/mendix/custom_widget.xsd">
     <name>Maps</name>
     <description>Custom description please</description>
     <studioProCategory>Display</studioProCategory>

--- a/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.xml
+++ b/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <widget id="com.mendix.widget.web.popupmenu.PopupMenu" pluginWidget="true" offlineCapable="true"
         xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../node_modules/mendix/custom_widget.xsd">
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../../node_modules/mendix/custom_widget.xsd">
     <name>Pop-up menu</name>
     <description>Displays a set of pre-defined items within the Pop-up menu</description>
     <studioProCategory>Menus &amp; navigation</studioProCategory>
     <studioCategory>Menus</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/widgets/popup-menu</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="General">

--- a/packages/pluggableWidgets/progress-bar-web/src/ProgressBar.xml
+++ b/packages/pluggableWidgets/progress-bar-web/src/ProgressBar.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <widget id="com.mendix.widget.custom.progressbar.ProgressBar" offlineCapable="true"
     xmlns="http://www.mendix.com/widget/1.0/"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd" pluginWidget="true">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../../node_modules/mendix/custom_widget.xsd" pluginWidget="true">
     <name>Progress Bar</name>
     <description>The widget lets you display a percentage as a bar</description>
     <studioProCategory>Display</studioProCategory>
     <studioCategory>Display</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/widgets/progress-bar</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="General">

--- a/packages/pluggableWidgets/progress-circle-web/src/ProgressCircle.xml
+++ b/packages/pluggableWidgets/progress-circle-web/src/ProgressCircle.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <widget id="com.mendix.widget.custom.progresscircle.ProgressCircle" offlineCapable="true"
     xmlns="http://www.mendix.com/widget/1.0/"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd" pluginWidget="true">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../../node_modules/mendix/custom_widget.xsd" pluginWidget="true">
     <name>Progress circle</name>
     <description>Displays a progress in a circle</description>
     <studioProCategory>Display</studioProCategory>
     <studioCategory>Display</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/widgets/progress-circle</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="General">

--- a/packages/pluggableWidgets/switch-web/src/Switch.xml
+++ b/packages/pluggableWidgets/switch-web/src/Switch.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <widget id="com.mendix.widget.custom.switch.Switch" needsEntityContext="true" offlineCapable="true" pluginWidget="true"
         xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd">
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../../node_modules/mendix/custom_widget.xsd">
     <name>Switch</name>
     <description>Toggle a boolean attribute</description>
     <studioProCategory>Input elements</studioProCategory>
     <studioCategory>Input Elements</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/widgets/switch</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="Data source">

--- a/packages/pluggableWidgets/timeline-web/src/Timeline.xml
+++ b/packages/pluggableWidgets/timeline-web/src/Timeline.xml
@@ -7,6 +7,7 @@
     <description>Shows vertical timeline with events</description>
     <studioProCategory>Display</studioProCategory>
     <studioCategory>Display</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/widgets/timeline</helpUrl>
     <properties>
         <propertyGroup caption="Data Source">
             <propertyGroup caption="Data source">

--- a/packages/pluggableWidgets/tree-node-web/src/TreeNode.xml
+++ b/packages/pluggableWidgets/tree-node-web/src/TreeNode.xml
@@ -6,6 +6,7 @@
     <description>Display a tree view structure</description>
     <studioProCategory>Data containers</studioProCategory>
     <studioCategory>Data Containers</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/modules/tree-node</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="General">

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
@@ -4,6 +4,7 @@
     <description>Shows a video from YouTube, Vimeo, Dailymotion and Mp4</description>
     <studioProCategory>Images, videos &amp; files</studioProCategory>
     <studioCategory>Images, Videos &amp; Files</studioCategory>
+    <helpUrl>https://docs.mendix.com/appstore/widgets/video-player</helpUrl>
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="Data source">


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Add help URL in order to redirect the user to the correct documentation when clicking the `?` button in the bottom of the widgets or pressing F1.

## Relevant changes
Added helpUrl property to the missing widgets.

## What should be covered while testing?
Trigger in the `?` button and pressing F1. In studio it should appear only the `?` button.
