### PR TITLE
feat(): fix bumpVersion script and add feature for major/minor/patch

### DIFF
--- a/scripts/release/BumpVersion.ts
+++ b/scripts/release/BumpVersion.ts
@@ -2,29 +2,55 @@ import { promises as fs } from "fs";
 import { join } from "path";
 import { spawnSync } from "child_process";
 
-// const cwd = process.cwd();
-// const actionsDir = join(cwd, "dist/babel/");
-// const testProjectDir = join(cwd, "dist/mxproject/javascriptsource/nanoflowcommons/actions/");
-
 // eslint-disable-next-line no-console
 main().catch(console.error);
+
+type BumpVersionType = "patch" | "minor" | "major" | string;
 
 async function main(): Promise<void> {
     const args = process.argv.slice(2);
     const target = args[0];
-    const version = args[1];
-    const packages = ["packages-common", "packages-native", "packages-web", "packages-hybrid"];
-    // await fs.mkdir(testProjectDir, { recursive: true });
-    // eslint-disable-next-line no-console
-    console.log("Target", target, "Version", version);
-
+    const bumpVersionType: BumpVersionType = args[1];
+    const packages = ["packages/pluggableWidgets"];
     const path = await findPath(packages, target);
+    const currentVersion = await getCurrentVersion(path);
+    const newVersion = getNewVersion(bumpVersionType, currentVersion);
 
+    console.log("Target:", target);
+    console.log("Current version:", currentVersion);
+    console.log("New version:", newVersion, "\n");
+
+    console.log("Bumping package.json version...");
+    bumpPackageJson(path, newVersion);
+
+    console.log("Bumping XML version...");
+    await bumpXml(path, newVersion);
+
+    console.log("Done.");
+}
+
+function getNewVersion(bumpVersionType: BumpVersionType, currentVersion: string): string {
+    const [major, minor, patch] = currentVersion.split(".");
+    switch (bumpVersionType) {
+        case "patch":
+            return [major, minor, Number(patch) + 1].join(".");
+        case "minor":
+            return [major, Number(minor) + 1, patch].join(".");
+        case "major":
+            return [Number(major) + 1, minor, patch].join(".");
+        default:
+            return bumpVersionType;
+    }
+}
+
+async function getCurrentVersion(path: string): Promise<string> {
+    const contentBuffer = await fs.readFile(join(path, "package.json"));
+    const content = JSON.parse(contentBuffer.toString());
+    return content.version;
+}
+
+function bumpPackageJson(path: string, version: string): void {
     spawnSync("npm", ["version", version], { cwd: path });
-    await bumpXml(path, version);
-
-    // eslint-disable-next-line no-console
-    console.log("Version bumped to ", version);
 }
 
 async function findPath(packages: string[], target: string): Promise<string> {


### PR DESCRIPTION
## This PR contains
- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fix the bump version script

## Relevant changes
- Make the script adhere to `packages/pluggableWidgets` package
- Instead of doing `npm run version image-web 2.0.0`, you can also do `npm run version image-web [minor|major|patch]` and it will bump automatically based on the existing version
