### PR TITLE
Changed function to light/dark variables

### DIFF
--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_date-picker.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_date-picker.scss
@@ -94,7 +94,7 @@
         .mx-calendar-year-switcher {
             text-align: center;
             margin-top: 10px;
-            color: lighten($brand-primary, 30%);
+            color: $color-primary-light;
 
             span.mx-calendar-year-selected {
                 color: $brand-primary;

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_switch.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_switch.scss
@@ -107,7 +107,7 @@ $default-ios-color: rgb(100, 189, 99);
             }
 
             &.widget-switch-btn-wrapper-primary {
-                @include bootstrap-style-android($brand-primary);
+                background-color: $color-primary-light;
 
                 .widget-switch-btn {
                     background: $brand-primary;

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_tab-container.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_tab-container.scss
@@ -91,7 +91,7 @@
                     color: #ffffff;
                     border-style: none;
                     border-radius: 0;
-                    background-color: mix($brand-primary, #000000, 80%);
+                    background-color: $color-primary-darker;
                 }
             }
         }


### PR DESCRIPTION
## Checklist
- Contains unit tests  ❌
- Contains breaking changes  ❌
- Contains Atlas changes ✅ 
- Compatible with: MX 7️⃣, 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ❌
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Native specific
- Works in Android ✅ 
- Works in iOS ✅ 
- Works in Tablet ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ x ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Remove $brand-primary scss function calls

## Relevant changes
I have a project in which I have various labels. A label is a subgroup of a corporate section. Each label has their own styling. 
Therefore I wanted to use css variables instead of scss variables, so I could change the $brand-primary variable to var(--brand-primary). That way, I could simply change the var(--brand-primary) color with dynamically loading a css sheet containing the css variables. Then, all my colors would adjust to a label that I was using at that moment. 
However, I was blocked by core styling that wanted to use the scss variables in some lighten and darken functions. This doesn't work with css variables. So to be able to use css variables instead of scss variables, I had to remove those functions. There are already variables available for lighter and darker primary colors anyway, so you might as well use those. 

In summary, I wanted to use a css variable instead of scss variable for $brand-primary, so I removed function calls so that the scss compilation doesn't crash

## What should be covered while testing?
Date picker
Android Switch widget
.tab-mobile

## Extra comments (optional)
I have only done this for $brand-primary. I think it would be a good idea to do this for all $brand variables, to allow developers to use css variables.
