### PR TITLE
Added design property for hide empty class on listviews

### DIFF
--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_list-view.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_list-view.scss
@@ -59,6 +59,13 @@
         }
     }
 
+    // Hides the 'no items found' text on empty lists
+    .listview-hide-empty.mx-listview {
+        .mx-listview-empty {
+            display: none;
+        }
+    }
+
     // Remove all styling - deprecated
     .listview-stylingless.mx-listview {
         & > ul > li {

--- a/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
@@ -399,6 +399,12 @@
                     "class": "listview-lg"
                 }
             ]
+        },
+        {
+            "name": "Hide empty",
+            "type": "Toggle",
+            "description": "Hides the 'no items found' in empty lists.",
+            "class": "listview-hide-empty"
         }
     ],
     "DataGrid": [


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes  ❌
- Contains Atlas changes ✅ 
- Compatible with: MX 7️⃣, 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests  ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
To add a new design property to hide the empty text on listviews

## Relevant changes
I'm adding this class on basically every Mendix project that I'm working on. I think it makes sense to include it as a default design property. 

## What should be covered while testing?
Check if the toggle is working and the empty text is successfully hidden on empty lists
