### PR TITLE
Create NPM script for github information release information for lerna

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prettier": "prettier --config \"./prettier.config.js\" --write \"**/{src,script,typings,test}/**/*.{js,jsx,ts,tsx,scss,html}\"",
     "format": "pretty-quick --staged --config \"./prettier.config.js\" --pattern \"**/{src,script,typings,test}/**/*.{js,jsx,ts,tsx,scss,html}\"",
     "clean-all-screenshots-mac": "find . -name 'screenshot-baseline' -type d -prune -exec rm -rf '{}' +",
+    "information:githubrelease": "lerna run information:githubrelease",
     "lint": "npm run lint:src && lerna run lint --stream",
     "lint:src": "eslint --config .eslintrc.js --ext .jsx,.js,.ts,.tsx packages/*/*/src --no-error-on-unmatched-pattern",
     "lint:scripts": "eslint --fix --config .eslintrc.js --ext .jsx,.js,.ts,.tsx scripts",


### PR DESCRIPTION
## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
By mistake I made one of the commands in the a `CreateWidgetRelease.yml` the following: `npm run information:githubrelease -- --scope '${{ github.event.inputs.widget-name }}'` which isn't possible because such a npm script doesn't exist. To keep it the same with the others, I will just create a NPM script for it