### PR TITLE
[WC-810] Fix custom widgets missing permission

### DIFF
--- a/.github/workflows/WebAutomatedTests.yml
+++ b/.github/workflows/WebAutomatedTests.yml
@@ -66,8 +66,10 @@ jobs:
               if: failure()
               run: |
                   sudo find ${{ github.workspace }}/packages/pluggableWidgets -type d -exec chmod 755 {} \;
+                  sudo find ${{ github.workspace }}/packages/customWidgets -type d -exec chmod 755 {} \;
                   sudo find ${{ github.workspace }}/packages/theming -type d -exec chmod 755 {} \;
                   sudo find ${{ github.workspace }}/packages/pluggableWidgets -type f -exec chmod 644 {} \;
+                  sudo find ${{ github.workspace }}/packages/customWidgets -type f -exec chmod 644 {} \;
                   sudo find ${{ github.workspace }}/packages/theming -type f -exec chmod 644 {} \;
             - name: "Archive test screenshot diff results"
               uses: actions/upload-artifact@v2

--- a/.github/workflows/WebAutomatedTests.yml
+++ b/.github/workflows/WebAutomatedTests.yml
@@ -65,12 +65,8 @@ jobs:
             - name: "Fixing files permissions"
               if: failure()
               run: |
-                  sudo find ${{ github.workspace }}/packages/pluggableWidgets -type d -exec chmod 755 {} \;
-                  sudo find ${{ github.workspace }}/packages/customWidgets -type d -exec chmod 755 {} \;
-                  sudo find ${{ github.workspace }}/packages/theming -type d -exec chmod 755 {} \;
-                  sudo find ${{ github.workspace }}/packages/pluggableWidgets -type f -exec chmod 644 {} \;
-                  sudo find ${{ github.workspace }}/packages/customWidgets -type f -exec chmod 644 {} \;
-                  sudo find ${{ github.workspace }}/packages/theming -type f -exec chmod 644 {} \;
+                  sudo find ${{ github.workspace }}/packages/* -type d -exec chmod 755 {} \;
+                  sudo find ${{ github.workspace }}/packages/* -type f -exec chmod 644 {} \;
             - name: "Archive test screenshot diff results"
               uses: actions/upload-artifact@v2
               if: failure()


### PR DESCRIPTION
#### Web specific
- Contains e2e tests  ❌
- Is accessible ❌
- Compatible with Studio ❌
- Cross-browser compatible ❌

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (Github Action)

## What is the purpose of this PR?
Fix missing permission in the custom widgets directory when it's trying to save an artifact.

## Relevant changes
Added custom widgets directory in the permission step.

## What should be covered while testing?
Automation should pass.

