### PR TITLE
[WC-812] Disable Jest collect code coverage on CI

### DIFF
--- a/packages/tools/pluggable-widgets-tools/test-config/jest.config.js
+++ b/packages/tools/pluggable-widgets-tools/test-config/jest.config.js
@@ -24,6 +24,6 @@ module.exports = {
         "mendix/filters/builders": join(__dirname, "__mocks__/FilterBuilders"),
         "\\.png$": join(__dirname, "assetsTransformer.js")
     },
-    collectCoverage: true,
+    collectCoverage: !process.env.CI,
     coverageDirectory: "<rootDir>/../dist/coverage"
 };

--- a/packages/tools/pluggable-widgets-tools/test-config/jest.native.config.js
+++ b/packages/tools/pluggable-widgets-tools/test-config/jest.native.config.js
@@ -28,7 +28,7 @@ module.exports = {
         "mendix/components/native/Image": join(__dirname, "__mocks__/NativeImage"),
         "mendix/filters/builders": join(__dirname, "__mocks__/FilterBuilders")
     },
-    collectCoverage: true,
+    collectCoverage: !process.env.CI,
     coverageDirectory: "<rootDir>/../dist/coverage"
 };
 


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ❌
- Contains Atlas changes ❌

#### Web specific
- Contains e2e tests ❌
- Is accessible  ❌
- Compatible with Studio ❌
- Cross-browser compatible ❌

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (unit test)

## What is the purpose of this PR?
We're not using the code coverage data in the CI, so we don't need to collect that data when running our unit tests on CI, because that's impacting directly in time of the execution.

## Relevant changes
Changed jest config to check when it's running on CI or local environment.

## What should be covered while testing?
Unit tests should pass without code coverage report.

## Extra comments (optional)
Locally the unit tests commands will work the same way generating code coverage data in the results.
