### PR TITLE
Update runtime docker file pyyaml package to specific version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:scripts": "lerna run test:scripts --stream",
     "test:scripts:cross-platform": "lerna run test:scripts:cross-platform --stream",
     "test:e2e": "lerna-parallelism run --ignore @mendix/custom-widgets-utils-internal --stream --concurrency 1 --split 3 test:e2e",
+    "test:e2e:local": "lerna run test:e2e --ignore @mendix/custom-widgets-utils-internal --stream --concurrency 1 --no-bail",
     "test:e2e:local:android": "lerna run test:e2e:local:android --stream --concurrency 1 --scope '*-native'",
     "test:e2e:local:ios": "lerna run test:e2e:local:ios --stream --concurrency 1 --scope '*-native'",
     "build": "lerna run build --ignore @mendix/custom-widgets-utils-internal",

--- a/packages/tools/pluggable-widgets-tools/scripts/runtime.Dockerfile
+++ b/packages/tools/pluggable-widgets-tools/scripts/runtime.Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update -qqy && \
         libfontconfig1 && \
 \
     pip3 install -q --upgrade pip && \
-    pip install -q pyyaml httplib2 && \
+    pip install -q pyyaml==5.4.1 httplib2 && \
 \
     echo "Downloading runtime ${MENDIX_VERSION}..." && \
     wget -q https://cdn.mendix.com/runtime/mendix-${MENDIX_VERSION}.tar.gz -O /tmp/runtime.tar.gz && \

--- a/scripts/test/jest.web.config.js
+++ b/scripts/test/jest.web.config.js
@@ -18,7 +18,7 @@ module.exports = {
             "<rootDir>/__mocks__/fileMock.js",
         "\\.(css|less|scss|sass)$": "identity-obj-proxy"
     },
-    collectCoverage: true,
+    collectCoverage: !process.env.CI,
     coverageDirectory: `${cwd}/dist/coverage`,
     setupFiles: ["jest-canvas-mock"]
 };


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 7️⃣, 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible  ❌
- Compatible with Studio  ❌
- Cross-browser compatible ❌

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (docker file)

## What is the purpose of this PR?
To avoid our runtime docker to break since pyyaml package update that deprecated one command used by m2ee-tools, we're specifying the installed package version.

## Relevant changes
Specified pyyaml version in the docker file. Added new script to run the test:e2e locally without parallelism and added collect code coverage to false for CI execution in the custom widgets jest configuration. 

## What should be covered while testing?
Automation should pass.
