### PR TITLE
[Crafting] Export data widgets module without snippet

### DIFF
--- a/packages/modules/data-widgets/CHANGELOG.md
+++ b/packages/modules/data-widgets/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## [2.0.1] Data Widgets - 2021-10-7
+### Changed
+- We removed the Snippet, Example enumeration and version constant from the module.
+
+### Added
+- We added a .version file inside themesource/datawidgets containing the module version.
 
 ## [2.0.1] DatagridDateFilter
 ### Fixed

--- a/packages/modules/data-widgets/CHANGELOG.md
+++ b/packages/modules/data-widgets/CHANGELOG.md
@@ -11,31 +11,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - We added a .version file inside themesource/datawidgets containing the module version.
 
-## [2.0.1] DatagridDateFilter
-### Fixed
+## [2.0.2] - 2021-10-13
+
+### Filter widgets
+
+#### Added
+- We added the possibility to store the filter value in an attribute and trigger an onChange event on every filter change.
+- We added a "Enable advanced options" toggle for Studio users.
+
+### Data Grid 2, Gallery & Tree Node
+
+#### Changed
+- We made the "Enable advanced options" available only for Studio users, keeping all the advanced features available by default in Studio Pro.
+
+
+## [2.0.1] - 2021-10-07
+
+### Filter widgets
+
+#### Fixed
 - We fixed an issue where widgets get duplicate identifiers assigned under certain circumstances which causes inconsistencies in accessibility.
 
-## [2.0.1] DatagridDropdownFilter
-### Fixed
-- We fixed an issue where widgets get duplicate identifiers assigned under certain circumstances which causes inconsistencies in accessibility.
+### Data Grid 2
 
-## [2.0.1] DatagridNumberFilter
-### Fixed
-- We fixed an issue where widgets get duplicate identifiers assigned under certain circumstances which causes inconsistencies in accessibility.
-
-## [2.0.1] DatagridTextFilter
-### Fixed
-- We fixed an issue where widgets get duplicate identifiers assigned under certain circumstances which causes inconsistencies in accessibility.
-
-## [2.0.1] Datagrid
-### Changed
+#### Changed
 - We added a check to prevent actions to be triggered while being executed
 
-### Fixed
+#### Fixed
 - We fixed an issue where widgets get duplicate identifiers assigned under certain circumstances which causes inconsistencies in accessibility.
 
-## [1.0.1] Gallery
-### Changed
+### Gallery
+
+#### Changed
 - We added a check to prevent actions to be triggered while being executed
 
 ## [2.0.0] - 2021-09-28

--- a/packages/modules/data-widgets/package.json
+++ b/packages/modules/data-widgets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "data-widgets",
   "moduleName": "Data Widgets",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2021. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/datagrid-date-filter-web/typings/DatagridDateFilterProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/typings/DatagridDateFilterProps.d.ts
@@ -19,7 +19,6 @@ export interface DatagridDateFilterContainerProps {
     placeholder?: DynamicValue<string>;
     adjustable: boolean;
     valueAttribute?: EditableValue<Date>;
-    filterAttribute?: EditableValue<string>;
     onChange?: ActionValue;
     screenReaderButtonCaption?: DynamicValue<string>;
     screenReaderCalendarCaption?: DynamicValue<string>;
@@ -35,7 +34,6 @@ export interface DatagridDateFilterPreviewProps {
     placeholder: string;
     adjustable: boolean;
     valueAttribute: string;
-    filterAttribute: string;
     onChange: {} | null;
     screenReaderButtonCaption: string;
     screenReaderCalendarCaption: string;

--- a/scripts/release/module-automation/commons.js
+++ b/scripts/release/module-automation/commons.js
@@ -214,7 +214,7 @@ async function cloneRepo(githubUrl, localFolder) {
     await rm(localFolder, { recursive: true, force: true });
     mkdir("-p", localFolder);
     await execShellCommand(`git clone ${githubUrlAuthenticated} ${localFolder}`);
-    await setLocalGitCredentials(localFolder);
+    // await setLocalGitCredentials(localFolder);
 }
 
 async function createMPK(tmpFolder, moduleInfo) {
@@ -240,6 +240,14 @@ async function createGithubReleaseFrom({ title, body, tag, mpkOutput, isDraft = 
     );
 }
 
+function zip(src, fileName) {
+    return execShellCommand(`cd "${src}" && zip -r ../${fileName} .`);
+}
+
+function unzip(src, dest) {
+    return execShellCommand(`unzip "${src}" -d "${dest}"`);
+}
+
 module.exports = {
     setLocalGitCredentials,
     execShellCommand,
@@ -258,4 +266,6 @@ module.exports = {
     createGithubRelease,
     createGithubReleaseFrom,
     writeToWidgetChangelogs
+    zip,
+    unzip
 };

--- a/scripts/release/module-automation/commons.js
+++ b/scripts/release/module-automation/commons.js
@@ -214,7 +214,7 @@ async function cloneRepo(githubUrl, localFolder) {
     await rm(localFolder, { recursive: true, force: true });
     mkdir("-p", localFolder);
     await execShellCommand(`git clone ${githubUrlAuthenticated} ${localFolder}`);
-    // await setLocalGitCredentials(localFolder);
+    await setLocalGitCredentials(localFolder);
 }
 
 async function createMPK(tmpFolder, moduleInfo) {
@@ -265,7 +265,7 @@ module.exports = {
     createMPK,
     createGithubRelease,
     createGithubReleaseFrom,
-    writeToWidgetChangelogs
+    writeToWidgetChangelogs,
     zip,
     unzip
 };


### PR DESCRIPTION
## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Remove the dependency on Snippets and make modules language agnostic. When exporting a module some widgets might require values in the text template fields, this becomes a problem when a new language is added in the project settings.

## Relevant changes
In this PR I am adding the entries for each widget to the exported package.xml inside the mpk file. In addition to it I also removed the Snippet and constants from [Data Widgets module](https://github.com/mendix/DataWidgets-module/commit/bca5a9980287cd769991d759f9761854804795de).

## What should be covered while testing?
Check if the exported [DataWidgets.mpk.zip](https://github.com/mendix/widgets-resources/files/7372703/DataWidgets.mpk.zip) works as expected. _(Github does not allow to attach mpk, so i zipped it)_

## Extra comments (optional)
Might be useful for Native Mobile Resources. @wesleysieses 
