### PR TITLE
feat(): stringify the body that is passed to the github release notes

### DIFF
--- a/scripts/release/createWidgetRelease.js
+++ b/scripts/release/createWidgetRelease.js
@@ -37,7 +37,7 @@ async function main() {
     console.log("Creating Github release...");
     await createGithubReleaseFrom({
         title: `${widgetName} (Web) - Marketplace Release v${version}`,
-        body: unreleasedChangelogs,
+        body: JSON.stringify(unreleasedChangelogs),
         tag: `${widgetScope}-v${version}`,
         mkpOutput: releaseMpkPath,
         isDraft: true


### PR DESCRIPTION
[A workflow](https://github.com/mendix/widgets-resources/runs/3937415323?check_suite_focus=true) failed because the body of the release notes had quotes inside that messed up the cli command. I also can't install `gh` locally, so i can't verify this immediately, but it works with git commands.

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)
