### PR TITLE
Removing create element import requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,25 +91,6 @@
 				"@babel/types": "^7.10.4"
 			}
 		},
-		"@babel/helper-builder-react-jsx": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz",
-			"integrity": "sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==",
-			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.10.4",
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-builder-react-jsx-experimental": {
-			"version": "7.12.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.4.tgz",
-			"integrity": "sha512-AjEa0jrQqNk7eDQOo0pTfUOwQBMF+xVqrausQwT9/rTKy0g04ggFNaJpaE09IQMn9yExluigWMJcj0WC7bq+Og==",
-			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.10.4",
-				"@babel/helper-module-imports": "^7.12.1",
-				"@babel/types": "^7.12.1"
-			}
-		},
 		"@babel/helper-compilation-targets": {
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.1.tgz",
@@ -598,6 +579,7 @@
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.1.tgz",
 			"integrity": "sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			}
@@ -899,24 +881,68 @@
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.1.tgz",
-			"integrity": "sha512-RmKejwnT0T0QzQUzcbP5p1VWlpnP8QHtdhEtLG55ZDQnJNalbF3eeDyu3dnGKvGzFIQiBzFhBYTwvv435p9Xpw==",
+			"version": "7.14.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz",
+			"integrity": "sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==",
 			"requires": {
-				"@babel/helper-builder-react-jsx": "^7.10.4",
-				"@babel/helper-builder-react-jsx-experimental": "^7.12.1",
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/plugin-syntax-jsx": "^7.12.1"
+				"@babel/helper-annotate-as-pure": "^7.14.5",
+				"@babel/helper-module-imports": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/plugin-syntax-jsx": "^7.14.5",
+				"@babel/types": "^7.14.9"
+			},
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.15.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
+					"integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
+					"requires": {
+						"@babel/types": "^7.15.4"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.15.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+					"integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+					"requires": {
+						"@babel/types": "^7.15.4"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.15.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+					"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
+				},
+				"@babel/plugin-syntax-jsx": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
+					"integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				},
+				"@babel/types": {
+					"version": "7.15.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+					"integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-react-jsx-development": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.1.tgz",
-			"integrity": "sha512-IilcGWdN1yNgEGOrB96jbTplRh+V2Pz1EoEwsKsHfX1a/L40cUYuD71Zepa7C+ujv7kJIxnDftWeZbKNEqZjCQ==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.14.5.tgz",
+			"integrity": "sha512-rdwG/9jC6QybWxVe2UVOa7q6cnTpw8JRRHOxntG/h6g/guAOe6AhtQHJuJh5FwmnXIT1bdm5vC2/5huV8ZOorQ==",
 			"requires": {
-				"@babel/helper-builder-react-jsx-experimental": "^7.12.1",
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/plugin-syntax-jsx": "^7.12.1"
+				"@babel/plugin-transform-react-jsx": "^7.14.5"
 			}
 		},
 		"@babel/plugin-transform-react-jsx-self": {
@@ -936,12 +962,41 @@
 			}
 		},
 		"@babel/plugin-transform-react-pure-annotations": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.12.1.tgz",
-			"integrity": "sha512-RqeaHiwZtphSIUZ5I85PEH19LOSzxfuEazoY7/pWASCAIBuATQzpSVD+eT6MebeeZT2F4eSL0u4vw6n4Nm0Mjg==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.14.5.tgz",
+			"integrity": "sha512-3X4HpBJimNxW4rhUy/SONPyNQHp5YRr0HhJdT2OH1BRp0of7u3Dkirc7x9FRJMKMqTBI079VZ1hzv7Ouuz///g==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.10.4",
-				"@babel/helper-plugin-utils": "^7.10.4"
+				"@babel/helper-annotate-as-pure": "^7.14.5",
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.15.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
+					"integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
+					"requires": {
+						"@babel/types": "^7.15.4"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.15.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+					"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
+				},
+				"@babel/types": {
+					"version": "7.15.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+					"integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
@@ -1140,17 +1195,36 @@
 			}
 		},
 		"@babel/preset-react": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.12.1.tgz",
-			"integrity": "sha512-euCExymHCi0qB9u5fKw7rvlw7AZSjw/NaB9h7EkdTt5+yHRrXdiRTh7fkG3uBPpJg82CqLfp1LHLqWGSCrab+g==",
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.14.5.tgz",
+			"integrity": "sha512-XFxBkjyObLvBaAvkx1Ie95Iaq4S/GUEIrejyrntQ/VCMKUYvKLoyKxOBzJ2kjA3b6rC9/KL6KXfDC2GqvLiNqQ==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/plugin-transform-react-display-name": "^7.12.1",
-				"@babel/plugin-transform-react-jsx": "^7.12.1",
-				"@babel/plugin-transform-react-jsx-development": "^7.12.1",
-				"@babel/plugin-transform-react-jsx-self": "^7.12.1",
-				"@babel/plugin-transform-react-jsx-source": "^7.12.1",
-				"@babel/plugin-transform-react-pure-annotations": "^7.12.1"
+				"@babel/helper-plugin-utils": "^7.14.5",
+				"@babel/helper-validator-option": "^7.14.5",
+				"@babel/plugin-transform-react-display-name": "^7.14.5",
+				"@babel/plugin-transform-react-jsx": "^7.14.5",
+				"@babel/plugin-transform-react-jsx-development": "^7.14.5",
+				"@babel/plugin-transform-react-pure-annotations": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+				},
+				"@babel/helper-validator-option": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+					"integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
+				},
+				"@babel/plugin-transform-react-display-name": {
+					"version": "7.15.1",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.15.1.tgz",
+					"integrity": "sha512-yQZ/i/pUCJAHI/LbtZr413S3VT26qNrEm0M5RRxQJA947/YNYwbZbBaXGDrq6CG5QsZycI1VIP6d7pQaBfP+8Q==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.14.5"
+					}
+				}
 			}
 		},
 		"@babel/register": {
@@ -4691,9 +4765,9 @@
 			}
 		},
 		"@popperjs/core": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
-			"integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
+			"version": "2.10.2",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
+			"integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ=="
 		},
 		"@ptomasroos/react-native-multi-slider": {
 			"version": "1.0.0",
@@ -5866,6 +5940,14 @@
 			"integrity": "sha512-Kli9UqZwO12cvJ4dT2kGaBtpgq96y8TPsvsB87XTCO+jEMMVy0OZ4WMW+8plS/lBKCtMNtwRNYNlD3+8Stgn2Q==",
 			"requires": {
 				"@types/d3": "^3"
+			}
+		},
+		"@types/popper.js": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@types/popper.js/-/popper.js-1.11.0.tgz",
+			"integrity": "sha512-1SDEDA6VacGAqDOmwbMcJD39bg0sHbM8y6LHOV3CMxyDBRrwTodRyIIj5f4eR/nlgpeyPoG1fKXqbkRmg+5yRg==",
+			"requires": {
+				"popper.js": "*"
 			}
 		},
 		"@types/prettier": {
@@ -27850,6 +27932,11 @@
 			"requires": {
 				"numeric": "^1.2.6"
 			}
+		},
+		"popper.js": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+			"integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
 		},
 		"portfinder": {
 			"version": "1.0.28",

--- a/packages/tools/pluggable-widgets-tools/configs/eslint.js.base.json
+++ b/packages/tools/pluggable-widgets-tools/configs/eslint.js.base.json
@@ -41,6 +41,7 @@
         "react/no-deprecated": "warn",
         "react/jsx-uses-vars": "error",
         "react/jsx-uses-react": "off",
+        "react/react-in-jsx-scope": "off",
 
         "jest/no-disabled-tests": "warn",
         "jest/no-focused-tests": "error",

--- a/packages/tools/pluggable-widgets-tools/configs/eslint.ts.base.json
+++ b/packages/tools/pluggable-widgets-tools/configs/eslint.ts.base.json
@@ -94,6 +94,7 @@
         "react/no-deprecated": "warn",
         "react/jsx-uses-vars": "error",
         "react/jsx-uses-react": "off",
+        "react/react-in-jsx-scope": "off",
 
         "array-callback-return": "error",
         "curly": "error",

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -163,11 +163,14 @@ export default async args => {
                 overrides: [
                     {
                         test: /node_modules/,
-                        plugins: ["@babel/plugin-transform-flow-strip-types", "@babel/plugin-transform-react-jsx"]
+                        plugins: [
+                            "@babel/plugin-transform-flow-strip-types",
+                            ["@babel/plugin-transform-react-jsx", { runtime: "automatic" }]
+                        ]
                     },
                     {
                         exclude: /node_modules/,
-                        plugins: [["@babel/plugin-transform-react-jsx", { pragma: "createElement" }]]
+                        plugins: [["@babel/plugin-transform-react-jsx", { runtime: "automatic" }]]
                     }
                 ]
             }),

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.native.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.native.js
@@ -135,11 +135,14 @@ export default async args => {
                 overrides: [
                     {
                         test: /node_modules/,
-                        plugins: ["@babel/plugin-transform-flow-strip-types", "@babel/plugin-transform-react-jsx"]
+                        plugins: [
+                            "@babel/plugin-transform-flow-strip-types",
+                            ["@babel/plugin-transform-react-jsx", { runtime: "automatic" }]
+                        ]
                     },
                     {
                         exclude: /node_modules/,
-                        plugins: [["@babel/plugin-transform-react-jsx", { pragma: "createElement" }]]
+                        plugins: [["@babel/plugin-transform-react-jsx", { runtime: "automatic" }]]
                     }
                 ]
             }),

--- a/packages/tools/pluggable-widgets-tools/configs/tsconfig.base.json
+++ b/packages/tools/pluggable-widgets-tools/configs/tsconfig.base.json
@@ -15,13 +15,12 @@
         "strict": true,
         "strictFunctionTypes": false,
         "skipLibCheck": true,
-        "noUnusedLocals": true,
+        "noUnusedLocals": false,
         "noUnusedParameters": true,
-        "jsx": "react",
-        "jsxFactory": "createElement",
+        "jsx": "react-jsx",
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
         "useUnknownInCatchVariables": false,
-        "exactOptionalPropertyTypes": false
+        "exactOptionalPropertyTypes": false,
     }
 }

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -37,8 +37,9 @@
   "dependencies": {
     "@babel/core": "^7.12.3",
     "@babel/plugin-proposal-class-properties": "^7.12.1",
+    "@babel/plugin-transform-react-jsx": "^7.14.9",
     "@babel/preset-env": "^7.12.1",
-    "@babel/preset-react": "^7.12.1",
+    "@babel/preset-react": "^7.14.5",
     "@rollup/plugin-alias": "^3.1.5",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^20.0.0",


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
With React 17 is possible to auto import createElement using features from Babel and Typescript. This PR introduces the flags allowing users to be able to create widgets without import createElement from React.

## Relevant changes
--

## What should be covered while testing?
General usage of widgets by sample.
