### PR TITLE
[WC-874] Video Player - Change default data source to dynamic

### DIFF
--- a/packages/pluggableWidgets/video-player-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/video-player-web/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [3.0.1] - 2021-11-01
+
+### Changed
+- Changed the default value for the video data source to dynamic
+
 ## [3.0.0] - 2021-09-28
 
 ### Added

--- a/packages/pluggableWidgets/video-player-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/video-player-web/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## [3.0.1] - 2021-11-01
-
 ### Changed
 - Changed the default value for the video data source to dynamic
 

--- a/packages/pluggableWidgets/video-player-web/package.json
+++ b/packages/pluggableWidgets/video-player-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "video-player-web",
   "widgetName": "VideoPlayer",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Player for YouTube, Dailymotion, Vimeo and Mp4 videos",
   "copyright": "© Mendix Technology BV 2021. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.xml
@@ -8,7 +8,7 @@
     <properties>
         <propertyGroup caption="General">
             <propertyGroup caption="Data source">
-                <property key="type" type="enumeration" defaultValue="expression">
+                <property key="type" type="enumeration" defaultValue="dynamic">
                     <caption>Type</caption>
                     <description />
                     <enumerationValues>

--- a/packages/pluggableWidgets/video-player-web/src/package.xml
+++ b/packages/pluggableWidgets/video-player-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="VideoPlayer" version="3.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="VideoPlayer" version="3.0.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="VideoPlayer.xml"/>
         </widgetFiles>


### PR DESCRIPTION
Changed default value to dynamic

## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes  ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## What is the purpose of this PR?
Change the default data source type to be dynamic instead of expression.

## Relevant changes
--

## What should be covered while testing?
General usage of the widget
