### PR TITLE
chore: specify npm version requirement in README for monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ See [CONTRIBUTING.md](https://github.com/mendix/widgets-resources/blob/master/CO
 
 -   `npm install` on root
 
+### Requirements
+
+-   For this repository you need npm version 6 or below. Version 7 and above are unsupported.
+
 ### For developing native widgets in `packages/pluggableWidgets`:
 
 -   Create a simple Mendix project in Studio


### PR DESCRIPTION
## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Specify that you need npm 6 or below and that 7 and above are unsupported. Based on an issue reported in slack: https://mendix.slack.com/archives/CJZ85RLTA/p1635856606210300
