### PR TITLE
[WC-246] Added visibility option for popup items

### DIFF
--- a/packages/pluggableWidgets/popup-menu-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/popup-menu-web/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- We added a visibility property on popup items
+
 ## [3.0.0] - 2021-09-28
 
 ### Added

--- a/packages/pluggableWidgets/popup-menu-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/popup-menu-web/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
-- We added a visibility property on popup items
+- We added a visibility property on popup items.
 
 ## [3.0.0] - 2021-09-28
 

--- a/packages/pluggableWidgets/popup-menu-web/package.json
+++ b/packages/pluggableWidgets/popup-menu-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "popup-menu-web",
   "widgetName": "PopupMenu",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "copyright": "© Mendix Technology BV 2021. All rights reserved.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.editorConfig.ts
+++ b/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.editorConfig.ts
@@ -41,6 +41,7 @@ export function getProperties(
                 hidePropertyIn(defaultProperties, values, "basicItems", index, "caption");
                 hidePropertyIn(defaultProperties, values, "basicItems", index, "action");
                 hidePropertyIn(defaultProperties, values, "basicItems", index, "styleClass");
+                hidePropertyIn(defaultProperties, values, "basicItems", index, "visible");
             }
             if (item.styleClass === "defaultStyle") {
                 changePropertyIn(

--- a/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.xml
+++ b/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.xml
@@ -36,6 +36,12 @@
                             <category>General</category>
                             <description/>
                         </property>
+                        <property key="visible" type="expression" defaultValue="true" required="false">
+                            <caption>Visible</caption>
+                            <category>General</category>
+                            <description/>
+                            <returnType type="Boolean"/>
+                        </property>
                         <property key="action" type="action" required="false">
                             <caption>On click action</caption>
                             <category>General</category>
@@ -65,6 +71,12 @@
                             <caption>Content</caption>
                             <category>General</category>
                             <description/>
+                        </property>
+                        <property key="visible" type="expression" defaultValue="true" required="false">
+                            <caption>Visible</caption>
+                            <category>General</category>
+                            <description/>
+                            <returnType type="Boolean"/>
                         </property>
                         <property key="action" type="action" required="false">
                             <caption>On click action</caption>

--- a/packages/pluggableWidgets/popup-menu-web/src/__tests__/PopupMenu.spec.ts
+++ b/packages/pluggableWidgets/popup-menu-web/src/__tests__/PopupMenu.spec.ts
@@ -3,6 +3,7 @@ import { createElement } from "react";
 import { BasicItemsType, CustomItemsType, PopupMenuContainerProps } from "../../typings/PopupMenuProps";
 import { PopupMenu } from "../components/PopupMenu";
 import { actionValue, dynamicValue } from "@mendix/piw-utils-internal";
+import { ValueStatus } from "mendix";
 
 jest.useFakeTimers();
 
@@ -62,6 +63,24 @@ describe("Popup menu", () => {
             expect(basicItemProps.action.execute).toHaveBeenCalledTimes(1);
         });
 
+        it("renders basic items without hidden items", () => {
+            const basicItem: BasicItemsType = {
+                ...basicItemProps,
+                visible: {
+                    value: false,
+                    status: ValueStatus.Available
+                }
+            };
+            const popupMenu = createPopupMenu({
+                ...defaultProps,
+                basicItems: [
+                    basicItem,
+                    { itemType: "divider", caption: dynamicValue("Caption"), styleClass: "defaultStyle" }
+                ]
+            });
+            expect(popupMenu.find(".popupmenu-basic-item")).toHaveLength(0);
+        });
+
         it("renders with style Inverse", () => {
             basicItemProps.styleClass = "inverseStyle";
             const popupMenu = createPopupMenu(defaultProps);
@@ -109,6 +128,21 @@ describe("Popup menu", () => {
             const popupMenu = createPopupMenu(defaultProps);
 
             expect(popupMenu.find(".popupmenu-custom-item")).toHaveLength(1);
+        });
+
+        it("renders custom items without hidden items", () => {
+            const customItem: CustomItemsType = {
+                ...customItemProps,
+                visible: {
+                    value: false,
+                    status: ValueStatus.Available
+                }
+            };
+            const popupMenu = createPopupMenu({
+                ...defaultProps,
+                customItems: [customItem]
+            });
+            expect(popupMenu.find(".popupmenu-custom-item")).toHaveLength(0);
         });
 
         it("triggers action", () => {

--- a/packages/pluggableWidgets/popup-menu-web/src/components/PopupMenu.tsx
+++ b/packages/pluggableWidgets/popup-menu-web/src/components/PopupMenu.tsx
@@ -15,7 +15,7 @@ import { ReactElement, useState, createElement, useCallback, useEffect, useRef }
 import { executeAction } from "@mendix/piw-utils-internal";
 import { ActionValue } from "mendix";
 
-import { PopupMenuContainerProps, PositionEnum } from "../../typings/PopupMenuProps";
+import { PopupMenuContainerProps, PositionEnum, BasicItemsType, CustomItemsType } from "../../typings/PopupMenuProps";
 
 export interface PopupMenuProps extends PopupMenuContainerProps {
     preview?: boolean;
@@ -81,48 +81,59 @@ export function PopupMenu(props: PopupMenuProps): ReactElement {
     );
 }
 
+function checkVisibility(item: BasicItemsType | CustomItemsType): boolean {
+    if (Object.prototype.hasOwnProperty.call(item, "visible")) {
+        return !!item.visible?.value;
+    }
+    return true;
+}
+
 function createMenuOptions(
     props: PopupMenuContainerProps,
     handleOnClickItem: (itemAction?: ActionValue) => void
 ): ReactElement[] {
     if (!props.advancedMode) {
-        return props.basicItems.map((item, index) => {
-            if (item.itemType === "divider") {
-                return <div key={index} className={"popupmenu-basic-divider"} />;
-            } else {
-                const pickedStyle =
-                    item.styleClass !== "defaultStyle"
-                        ? "popupmenu-basic-item-" + item.styleClass.replace("Style", "")
-                        : "";
-                return (
-                    <div
-                        key={index}
-                        className={classNames("popupmenu-basic-item", pickedStyle)}
-                        onClick={e => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            handleOnClickItem(item.action);
-                        }}
-                    >
-                        {item.caption?.value ?? ""}
-                    </div>
-                );
-            }
-        });
+        return props.basicItems
+            .filter(item => checkVisibility(item))
+            .map((item, index) => {
+                if (item.itemType === "divider") {
+                    return <div key={index} className={"popupmenu-basic-divider"} />;
+                } else {
+                    const pickedStyle =
+                        item.styleClass !== "defaultStyle"
+                            ? "popupmenu-basic-item-" + item.styleClass.replace("Style", "")
+                            : "";
+                    return (
+                        <div
+                            key={index}
+                            className={classNames("popupmenu-basic-item", pickedStyle)}
+                            onClick={e => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                handleOnClickItem(item.action);
+                            }}
+                        >
+                            {item.caption?.value ?? ""}
+                        </div>
+                    );
+                }
+            });
     } else {
-        return props.customItems.map((item, index) => (
-            <div
-                key={index}
-                className={"popupmenu-custom-item"}
-                onClick={e => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    handleOnClickItem(item.action);
-                }}
-            >
-                {item.content}
-            </div>
-        ));
+        return props.customItems
+            .filter(item => checkVisibility(item))
+            .map((item, index) => (
+                <div
+                    key={index}
+                    className={"popupmenu-custom-item"}
+                    onClick={e => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        handleOnClickItem(item.action);
+                    }}
+                >
+                    {item.content}
+                </div>
+            ));
     }
 }
 

--- a/packages/pluggableWidgets/popup-menu-web/src/package.xml
+++ b/packages/pluggableWidgets/popup-menu-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="PopupMenu" version="3.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="PopupMenu" version="3.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="PopupMenu.xml"/>
         </widgetFiles>

--- a/packages/pluggableWidgets/popup-menu-web/typings/PopupMenuProps.d.ts
+++ b/packages/pluggableWidgets/popup-menu-web/typings/PopupMenuProps.d.ts
@@ -20,12 +20,14 @@ export type StyleClassEnum =
 export interface BasicItemsType {
     itemType: ItemTypeEnum;
     caption?: DynamicValue<string>;
+    visible?: DynamicValue<boolean>;
     action?: ActionValue;
     styleClass: StyleClassEnum;
 }
 
 export interface CustomItemsType {
     content: ReactNode;
+    visible?: DynamicValue<boolean>;
     action?: ActionValue;
 }
 
@@ -36,12 +38,14 @@ export type PositionEnum = "left" | "right" | "top" | "bottom";
 export interface BasicItemsPreviewType {
     itemType: ItemTypeEnum;
     caption: string;
+    visible: string;
     action: {} | null;
     styleClass: StyleClassEnum;
 }
 
 export interface CustomItemsPreviewType {
     content: { widgetCount: number; renderer: ComponentType<{ caption?: string }> };
+    visible: string;
     action: {} | null;
 }
 
@@ -50,23 +54,23 @@ export interface PopupMenuContainerProps {
     class: string;
     style?: CSSProperties;
     tabIndex?: number;
+    advancedMode: boolean;
     menuTrigger?: ReactNode;
     basicItems: BasicItemsType[];
     customItems: CustomItemsType[];
     trigger: TriggerEnum;
     position: PositionEnum;
-    advancedMode: boolean;
     menuToggle: boolean;
 }
 
 export interface PopupMenuPreviewProps {
     class: string;
     style: string;
+    advancedMode: boolean;
     menuTrigger: { widgetCount: number; renderer: ComponentType<{ caption?: string }> };
     basicItems: BasicItemsPreviewType[];
     customItems: CustomItemsPreviewType[];
     trigger: TriggerEnum;
     position: PositionEnum;
-    advancedMode: boolean;
     menuToggle: boolean;
 }


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 7️⃣, 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

#### Feature specific
- Comply with designs ❌
- Comply with PM's requirements ✅

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
The purpose is to add functionality for end-users to toggle visibility of items inside popup depending on the situation.

## Relevant changes
I added a visibility expression property on the pop-up widget for basic and custom items.
Added consistency check when divider type of item is selected.
Added unit tests for both cases (hidden/visible)

## What should be covered while testing?
I kept the previous configuration, but it'll be good to test if this widget works on previously created popups.

## Extra comments (optional)
- Bumped version to **3.1.0**

