### PR TITLE
feat: reusing docker images from github container registry

### DIFF
--- a/scripts/release/module-automation/commons.js
+++ b/scripts/release/module-automation/commons.js
@@ -68,7 +68,15 @@ async function getPackageInfo(path) {
 
 // Create reusable mxbuild image
 async function createModuleMpkInDocker(sourceDir, moduleName, mendixVersion, excludeFilesRegExp) {
-    const existingImages = (await execShellCommand(`docker image ls -q mxbuild:${mendixVersion}`)).toString().trim();
+    const ghcr = process.env.CI ? "ghcr.io/mendix/widgets-resources/" : "";
+
+    if (ghcr) {
+        console.log(`Pulling mxbuild:${mendixVersion} docker image from Github Container Registry...`);
+        await execShellCommand(`docker pull ${ghcr}mxbuild:${mendixVersion}`);
+    }
+    const existingImages = (await execShellCommand(`docker image ls -q ${ghcr}mxbuild:${mendixVersion}`))
+        .toString()
+        .trim();
     if (!existingImages) {
         console.log(`Creating new mxbuild docker image...`);
         await execShellCommand(


### PR DESCRIPTION
## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Reuse images already published over GH Container Registry during modules automation.

## Relevant changes
Added commands to reuse images from GHCR

## What should be covered while testing?
--