### PR TITLE
fix(pluggable-widgets-tools): fix jest web mocks

### DIFF
--- a/packages/tools/pluggable-widgets-tools/test-config/__mocks__/FilterBuilders.js
+++ b/packages/tools/pluggable-widgets-tools/test-config/__mocks__/FilterBuilders.js
@@ -1,13 +1,15 @@
-export const attribute = jest.fn();
-export const literal = jest.fn();
-export const or = jest.fn();
-export const and = jest.fn();
-export const equals = jest.fn();
-export const notEqual = jest.fn();
-export const contains = jest.fn();
-export const startsWith = jest.fn();
-export const endsWith = jest.fn();
-export const greaterThan = jest.fn();
-export const greaterThanOrEqual = jest.fn();
-export const lessThan = jest.fn();
-export const lessThanOrEqual = jest.fn();
+module.exports = {
+    attribute: jest.fn(),
+    literal: jest.fn(),
+    or: jest.fn(),
+    and: jest.fn(),
+    equals: jest.fn(),
+    notEqual: jest.fn(),
+    contains: jest.fn(),
+    startsWith: jest.fn(),
+    endsWith: jest.fn(),
+    greaterThan: jest.fn(),
+    greaterThanOrEqual: jest.fn(),
+    lessThan: jest.fn(),
+    lessThanOrEqual: jest.fn()
+};

--- a/packages/tools/pluggable-widgets-tools/test-config/__mocks__/WebIcon.js
+++ b/packages/tools/pluggable-widgets-tools/test-config/__mocks__/WebIcon.js
@@ -1,3 +1,5 @@
 import { createElement } from "react";
 
-export const Icon = () => createElement("img", { src: "mocked/web/icon" });
+module.exports = {
+    Icon: () => createElement("img", { src: "mocked/web/icon" })
+};

--- a/packages/tools/pluggable-widgets-tools/test-config/transform.js
+++ b/packages/tools/pluggable-widgets-tools/test-config/transform.js
@@ -1,7 +1,7 @@
 module.exports = require("babel-jest").createTransformer({
     presets: ["@babel/preset-env", "@babel/preset-react"],
     plugins: [
-        ["@babel/plugin-proposal-class-properties", { "loose": true }],
-        ["@babel/plugin-transform-react-jsx", { "pragma": "createElement" }]
+        ["@babel/plugin-proposal-class-properties", { loose: true }],
+        ["@babel/plugin-transform-react-jsx", { pragma: "createElement" }]
     ]
 });


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Pluggable widgets tools outside our mono repo is located inside node_modules which causes the transformations from es6 files to not work. In this PR I am converting current es6 kind files to commonjs.

## Relevant changes
Changed the way we export jest mocks for web widgets.

## What should be covered while testing?
Automation should be enough.
