### PR TITLE
[WC-828] Data Grid - Add design property to wrap texts

### DIFF
--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/datagrid.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/datagrid.scss
@@ -203,6 +203,18 @@ $brand-primary: #264ae5 !default;
         > .empty-placeholder {
             width: 100%;
         }
+
+        &.wrap-text {
+            min-height: 0;
+            min-width: 0;
+
+            > .td-text,
+            > .mx-text {
+                text-overflow: ellipsis;
+                overflow: hidden;
+                white-space: nowrap;
+            }
+        }
     }
 
     & *:focus {

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- We added a property to wrap texts in the columns.
+
 ## [2.0.3] - 2021-11-16
 
 ### Fixed

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datagrid-web",
   "widgetName": "Datagrid",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "",
   "copyright": "© Mendix Technology BV 2021. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -143,7 +143,8 @@ export const getPreview = (values: DatagridPreviewProps): StructurePreviewProps 
                   hidable: "no",
                   size: 1,
                   sortable: false,
-                  alignment: "left"
+                  alignment: "left",
+                  wrapText: false
               }
           ];
     const columns: RowLayoutProps = {

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
@@ -5,6 +5,7 @@ import { Table, TableColumn } from "./components/Table";
 import { parseStyle } from "@mendix/piw-utils-internal";
 import { Selectable } from "mendix/preview/Selectable";
 import { ObjectItem, GUID } from "mendix";
+import classNames from "classnames";
 
 interface PreviewProps extends Omit<DatagridPreviewProps, "class"> {
     className: string;
@@ -32,7 +33,8 @@ export function preview(props: PreviewProps): ReactElement {
                       hidable: "no",
                       size: 1,
                       sortable: false,
-                      alignment: "left"
+                      alignment: "left",
+                      wrapText: false
                   }
               ];
 
@@ -57,7 +59,7 @@ export function preview(props: PreviewProps): ReactElement {
             cellRenderer={useCallback(
                 (renderWrapper, _, columnIndex) => {
                     const column = columns[columnIndex];
-                    const className = column.alignment ? `align-column-${column.alignment}` : "";
+                    const className = classNames(`align-column-${column.alignment}`, { "wrap-text": column.wrapText });
                     let content;
                     switch (column.showContentAs) {
                         case "attribute":

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -123,7 +123,9 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
 
                     return renderWrapper(
                         content,
-                        classNames(`align-column-${column.alignment}`, column.columnClass?.get(value)?.value),
+                        classNames(`align-column-${column.alignment}`, column.columnClass?.get(value)?.value, {
+                            "wrap-text": column.wrapText
+                        }),
                         props.onClick ? () => executeAction(props.onClick?.get(value)) : undefined
                     );
                 },

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -114,6 +114,10 @@
                                 <description />
                                 <returnType type="String"/>
                             </property>
+                            <property key="wrapText" type="boolean" defaultValue="false">
+                                <caption>Wrap text</caption>
+                                <description />
+                            </property>
                         </propertyGroup>
                     </properties>
                 </property>

--- a/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Table.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/__tests__/Table.spec.tsx
@@ -57,7 +57,8 @@ describe("Table", () => {
                 hidable: "no" as const,
                 width: "autoFill" as const,
                 size: 1,
-                alignment: "left" as const
+                alignment: "left" as const,
+                wrapText: false
             }
         ];
         const component = render(<Table {...mockTableProps()} columnsFilterable columns={columns} />);
@@ -83,7 +84,8 @@ describe("Table", () => {
                 hidable: "no" as const,
                 width: "autoFill" as const,
                 size: 1,
-                alignment: "center" as const
+                alignment: "center" as const,
+                wrapText: false
             },
             {
                 header: "Test 2",
@@ -93,7 +95,8 @@ describe("Table", () => {
                 hidable: "no" as const,
                 width: "autoFill" as const,
                 size: 1,
-                alignment: "right" as const
+                alignment: "right" as const,
+                wrapText: false
             }
         ];
 
@@ -124,7 +127,8 @@ describe("Table", () => {
                 hidable: "no" as const,
                 width: "autoFill" as const,
                 size: 1,
-                alignment: "center" as const
+                alignment: "center" as const,
+                wrapText: false
             }
         ];
         const component = render(<Table {...mockTableProps()} preview columns={columns} />);
@@ -170,7 +174,8 @@ function mockTableProps(): TableProps<ObjectItem> {
             hidable: "no" as const,
             width: "autoFill" as const,
             size: 1,
-            alignment: "left" as const
+            alignment: "left" as const,
+            wrapText: false
         }
     ];
     return {

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="2.0.3" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="2.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Datagrid.xml"/>
         </widgetFiles>

--- a/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
@@ -39,6 +39,7 @@ export interface ColumnsType {
     size: number;
     alignment: AlignmentEnum;
     columnClass?: ListExpressionValue<string>;
+    wrapText: boolean;
 }
 
 export type PaginationEnum = "buttons" | "virtualScrolling";
@@ -66,6 +67,7 @@ export interface ColumnsPreviewType {
     size: number | null;
     alignment: AlignmentEnum;
     columnClass: string;
+    wrapText: boolean;
 }
 
 export interface FilterListPreviewType {


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

#### Feature specific
- Comply with designs ✅
- Comply with PM's requirements ✅

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Add the possibility to wrap texts when widgets are not being used as the content of a column.

## Relevant changes
Added extra class in the data-widgets module folder and a property for each column.

## What should be covered while testing?
Tests with widgets and pure texts should be done.

## Extra comments (optional)
It also works with Text widgets with different renderings like span, p, h1 when placed directly inside the columns (not inside containers).
