### PR TITLE
[NC-528] Set explicit border colors for Floating Action Button

### DIFF
--- a/packages/modules/atlas-core/CHANGELOG.md
+++ b/packages/modules/atlas-core/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- We corrected the border styling for the Floating Action Button native widget when in Dark Mode.
+
 ## [3.0.8] Atlas Core - 2021-12-3
 ### Added
 - We added a design property to align the content of the image widget.

--- a/packages/modules/atlas-core/package.json
+++ b/packages/modules/atlas-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlas-core",
   "moduleName": "Atlas Core",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2021. All rights reserved.",
   "repository": {

--- a/packages/theming/atlas/package.json
+++ b/packages/theming/atlas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/atlas-ui",
-  "version": "3.0.7",
+  "version": "3.0.9",
   "description": "Mendix Atlas UI is the foundation of making beautiful apps with Mendix. For more information about the framework go to https://atlas.mendix.com.",
   "testProject": {
     "githubUrl": "https://github.com/mendix/Atlas-Design-System",

--- a/packages/theming/atlas/src/theme/native/custom-variables.ts
+++ b/packages/theming/atlas/src/theme/native/custom-variables.ts
@@ -501,7 +501,7 @@ export const floatingActionButton: VariablesFloatingActionButton = {
     },
     secondaryButtonCaptionContainer: {
         backgroundColor: background.primary,
-        borderColor: darkMode ? background.primary : "#eee"
+        borderColor: background.primary
     }
 };
 //

--- a/packages/theming/atlas/src/theme/native/custom-variables.ts
+++ b/packages/theming/atlas/src/theme/native/custom-variables.ts
@@ -500,7 +500,8 @@ export const floatingActionButton: VariablesFloatingActionButton = {
         fontSize: font.sizeSmall
     },
     secondaryButtonCaptionContainer: {
-        backgroundColor: background.primary
+        backgroundColor: background.primary,
+        borderColor: darkMode ? background.primary : "#eee"
     }
 };
 //

--- a/packages/theming/atlas/src/themesource/atlas_core/native/core/widgets/floatingactionbutton.ts
+++ b/packages/theming/atlas/src/themesource/atlas_core/native/core/widgets/floatingactionbutton.ts
@@ -69,6 +69,7 @@ export const com_mendix_widget_native_floatingactionbutton_FloatingActionButton:
     secondaryButtonCaptionContainer: {
         // All ViewStyle properties are allowed
         backgroundColor: floatingActionButton.secondaryButtonCaptionContainer.backgroundColor,
+        borderColor: floatingActionButton.secondaryButtonCaptionContainer.borderColor,
         marginHorizontal: 5,
         elevation: 2,
         shadowOpacity: 0.3,

--- a/packages/theming/atlas/src/themesource/atlas_core/native/types/variables.d.ts
+++ b/packages/theming/atlas/src/themesource/atlas_core/native/types/variables.d.ts
@@ -2,7 +2,6 @@
     Types
 ========================================================================== */
 
-import { ColorValue } from "react-native";
 import { CheckBoxInputType } from "./widgets";
 
 declare type FontWeight = "normal" | "bold" | "100" | "200" | "300" | "400" | "500" | "600" | "700" | "800" | "900";
@@ -415,6 +414,7 @@ export interface VariablesFloatingActionButton {
     };
     secondaryButtonCaptionContainer: {
         backgroundColor: string;
+        borderColor: string;
     };
 }
 

--- a/packages/theming/atlas/src/themesource/atlas_core/native/variables.ts
+++ b/packages/theming/atlas/src/themesource/atlas_core/native/variables.ts
@@ -516,7 +516,7 @@ let floatingActionButton: VariablesFloatingActionButton = {
     },
     secondaryButtonCaptionContainer: {
         backgroundColor: background.primary,
-        borderColor: custom.darkMode ? background.primary : "#eee"
+        borderColor: background.primary
     }
 };
 floatingActionButton = merge(floatingActionButton, custom.floatingActionButton || ({} as any));

--- a/packages/theming/atlas/src/themesource/atlas_core/native/variables.ts
+++ b/packages/theming/atlas/src/themesource/atlas_core/native/variables.ts
@@ -515,7 +515,8 @@ let floatingActionButton: VariablesFloatingActionButton = {
         fontSize: font.sizeSmall
     },
     secondaryButtonCaptionContainer: {
-        backgroundColor: background.primary
+        backgroundColor: background.primary,
+        borderColor: custom.darkMode ? background.primary : "#eee"
     }
 };
 floatingActionButton = merge(floatingActionButton, custom.floatingActionButton || ({} as any));

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,20 +1,25 @@
 ## How to release widgets & modules to the appstore (`./marketplaceRelease.js`)
 
 #### Web Widgets
-1. Create a release in Github
+1. Create a release in GitHub
 1. Add a tag to the commit you want to create a release from. The tag should be formatted like ${PackageName}-v${Major}.${Minor}.${Patch}
     - Example: `maps-web-v2.0.2`
 1. That's it! 
-    - The content should now be released in Github.
+    - The content should now be released in GitHub.
     - The content should now be released in the MX Marketplace. Double check to verify.
-
 
 #### Web Modules
 1. Add a tag to the commit you want to create a release from. The tag should be formatted like ${PackageName}-v${Major}.${Minor}.${Patch}
     - Example: `nanoflow-actions-web-v2.0.0`
 1. That's it! 
-    - The content should now be released in Github.
+    - The content should now be released in GitHub.
     - The content should now be released in the MX Marketplace. Double check to verify.
+
+#### Atlas Core
+2. Trigger the "Create Web Release" action manually in GitHub with the argument "atlas-core".
+3. That's it!
+    - The content should now be released in GitHub as a draft. Approve and publish it.
+    - Then another GitHub action `MarketplaceRelease` will take care of releasing the module to the MX Marketplace. Double check to verify.
 
 #### Native Modules
 1. Make sure a new widget is used on a page in the module and commit your changes, so it's included in the module when it's exported.
@@ -22,19 +27,19 @@
     - Example: `mobile-resources-native-v3.0.0`
     - Example: `nanoflow-actions-native-v3.0.0`
 1. That's it! 
-    - The content should now be released in Github.
+    - The content should now be released in GitHub.
     - The content should now be released in the MX Marketplace. Double check to verify.
 
 #### Hybrid Modules
 1. Add a tag to the commit you want to create a release from. The tag should be formatted like ${PackageName}-v${Major}.${Minor}.${Patch}
     - Example: `mobile-resources-hybrid-v1.0.0`
 1. That's it! 
-    - The content should now be released in Github.
+    - The content should now be released in GitHub.
     - The content should now be released in the MX Marketplace. Double check to verify.
 
 #### Atlas Native Content Module
 1. Add a tag to the commit you want to create a release from. The tag should be formatted like ${PackageName}-v${Major}.${Minor}.${Patch}
     - Example: `atlas-content-native-v4.0.0`
 1. That's it! 
-    - The content should now be released in Github.
+    - The content should now be released in GitHub.
     - The content should now be released in the MX Marketplace. Double check to verify.

--- a/scripts/release/createWebModules.js
+++ b/scripts/release/createWebModules.js
@@ -104,7 +104,7 @@ async function createAtlasWebContentModule() {
 }
 
 async function createAtlasCoreModule() {
-    console.log("Creating the Atlas Web Content module.");
+    console.log("Creating the Atlas Web Core module.");
     const widgets = ["feedback-native"].map(folder => join(repoRootPath, "packages/pluggableWidgets", folder));
     const moduleInfo = {
         ...(await getPackageInfo(moduleFolder)),

--- a/scripts/release/createWebModules.js
+++ b/scripts/release/createWebModules.js
@@ -104,7 +104,7 @@ async function createAtlasWebContentModule() {
 }
 
 async function createAtlasCoreModule() {
-    console.log("Creating the Atlas Web Core module.");
+    console.log("Creating the Atlas Core module.");
     const widgets = ["feedback-native"].map(folder => join(repoRootPath, "packages/pluggableWidgets", folder));
     const moduleInfo = {
         ...(await getPackageInfo(moduleFolder)),


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ✅
- Compatible with: MX 9️⃣

#### Native specific
- Works in Android ✅ 
- Works in iOS ✅ 
- Works in Tablet ✅ 

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
The FAB widget's style in dark mode is not expected. The border is a light color.

The FAB widget [defaults](https://github.com/mastermoo/react-native-action-button/blob/master/ActionButtonItem.js#L208) to a white/grey-ish border color unless it is specified. 

An explicit border color has been added to Atlas.

## What should be covered while testing?
Does the styling take affect with an updated Atlas, in both light and dark mode?

## Extra comments (optional)
The wiget itself (without Atlas) has its own default styling however these are very minimal and don't support dark mode. End-users must use Atlas to get "advanced" styling that supports dark mode.
