### PR TITLE
[WC-893] fix(datagrid-date-filter-web): fix issue with locale

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12634,9 +12634,9 @@
 			"integrity": "sha1-H80D29UEudvuK5B4yFpfHH08wtM="
 		},
 		"date-fns": {
-			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
-			"integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.27.0.tgz",
+			"integrity": "sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q=="
 		},
 		"dateformat": {
 			"version": "3.0.3",
@@ -29812,16 +29812,23 @@
 			}
 		},
 		"react-datepicker": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.2.1.tgz",
-			"integrity": "sha512-0gcvHMnX8rS1fV90PjjsB7MQdsWNU77JeVHf6bbwK9HnFxgwjVflTx40ebKmHV+leqe+f+FgUP9Nvqbe5RGyfA==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.5.0.tgz",
+			"integrity": "sha512-mFP/SbtFSXx21Wx3Nfv+RREwd/x0q14x7QL79ZCi/PVkHSFLwLWhXyOtj3OIzi1AcVYb/fMMcvi8e5b12n8/sg==",
 			"requires": {
 				"@popperjs/core": "^2.9.2",
 				"classnames": "^2.2.6",
-				"date-fns": "^2.0.1",
+				"date-fns": "^2.24.0",
 				"prop-types": "^15.7.2",
-				"react-onclickoutside": "^6.10.0",
+				"react-onclickoutside": "^6.12.0",
 				"react-popper": "^2.2.5"
+			},
+			"dependencies": {
+				"date-fns": {
+					"version": "2.27.0",
+					"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.27.0.tgz",
+					"integrity": "sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q=="
+				}
 			}
 		},
 		"react-devtools-core": {
@@ -31224,9 +31231,9 @@
 			}
 		},
 		"react-onclickoutside": {
-			"version": "6.11.2",
-			"resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.11.2.tgz",
-			"integrity": "sha512-640486eSwU/t5iD6yeTlefma8dI3bxPXD93hM9JGKyYITAd0P1JFkkcDeyHZRqNpY/fv1YW0Fad9BXr44OY8wQ=="
+			"version": "6.12.1",
+			"resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.12.1.tgz",
+			"integrity": "sha512-a5Q7CkWznBRUWPmocCvE8b6lEYw1s6+opp/60dCunhO+G6E4tDTO2Sd2jKE+leEnnrLAE2Wj5DlDHNqj5wPv1Q=="
 		},
 		"react-overlays": {
 			"version": "5.0.1",

--- a/packages/pluggableWidgets/datagrid-date-filter-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- We fixed an issue with week start day not respecting current app settings (Ticket #136173).
+
+### Changed
+- We aligned week days names with date picker widget from Studio Pro.
+
 ## [2.0.2] - 2021-10-13
 
 ### Added

--- a/packages/pluggableWidgets/datagrid-date-filter-web/package.json
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/package.json
@@ -33,8 +33,8 @@
   "dependencies": {
     "@mendix/piw-utils-internal": "^1.0.0",
     "classnames": "^2.2.6",
-    "date-fns": "^2.16.1",
-    "react-datepicker": "^4.2.1"
+    "date-fns": "^2.24.0",
+    "react-datepicker": "^4.5.0"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/pluggableWidgets/datagrid-date-filter-web/package.json
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datagrid-date-filter-web",
   "widgetName": "DatagridDateFilter",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "copyright": "© Mendix Technology BV 2021. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/DatagridDateFilter.tsx
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/DatagridDateFilter.tsx
@@ -30,7 +30,7 @@ interface Locale {
 
 export default function DatagridDateFilter(props: DatagridDateFilterContainerProps): ReactElement | null {
     const id = useRef(`DateFilter${generateUUID()}`);
-    const { languageTag = "en-US", patterns } = (window as any).mx.session.getConfig().locale;
+    const { languageTag = "en-US", patterns } = window.mx.session.getConfig().locale;
 
     const [language] = languageTag.split("-");
     const languageTagWithoutDash = languageTag.replace("-", "");

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/DatagridDateFilter.tsx
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/DatagridDateFilter.tsx
@@ -30,7 +30,7 @@ interface Locale {
 
 export default function DatagridDateFilter(props: DatagridDateFilterContainerProps): ReactElement | null {
     const id = useRef(`DateFilter${generateUUID()}`);
-    const { languageTag = "en-US", patterns } = window.mx.session.getConfig().locale;
+    const { languageTag = "en-US", patterns, firstDayOfWeek } = window.mx.session.getConfig().locale;
 
     const [language] = languageTag.split("-");
     const languageTagWithoutDash = languageTag.replace("-", "");
@@ -109,6 +109,7 @@ export default function DatagridDateFilter(props: DatagridDateFilterContainerPro
                         screenReaderInputCaption={props.screenReaderInputCaption?.value}
                         styles={props.style}
                         tabIndex={props.tabIndex}
+                        calendarStartDay={firstDayOfWeek}
                         updateFilters={(value: Date | null, type: DefaultFilterEnum): void => {
                             if (
                                 (value && props.valueAttribute?.value && !isEqual(props.valueAttribute.value, value)) ||

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/components/DatePicker.tsx
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/components/DatePicker.tsx
@@ -35,6 +35,7 @@ export const DatePicker = forwardRef(
         const portalRef = useRef<HTMLDivElement>(null);
         const id = useMemo(() => `datepicker_` + Math.random(), []);
         const Portal = createPortal(<div ref={portalRef} id={id} style={{ position: "fixed" }} />, document.body);
+        const calendarStartDay = window.mx.session.getConfig().locale.firstDayOfWeek;
 
         const buttonClick = useCallback(() => {
             setOpen(open => !open);
@@ -59,6 +60,7 @@ export const DatePicker = forwardRef(
                     dropdownMode="select"
                     enableTabLoop
                     locale={props.locale}
+                    calendarStartDay={calendarStartDay}
                     onChange={date => {
                         if (isDate(date) && isValid(date)) {
                             props.setValue(date as Date);
@@ -91,7 +93,7 @@ export const DatePicker = forwardRef(
                     showPopperArrow={false}
                     showYearDropdown
                     strictParsing
-                    useWeekdaysShort
+                    useWeekdaysShort={false}
                     portalId={id}
                 />
                 <button

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/components/DatePicker.tsx
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/components/DatePicker.tsx
@@ -26,6 +26,7 @@ interface DatePickerProps {
     screenReaderInputCaption?: string;
     setValue: Dispatch<SetStateAction<Date | null>>;
     value: Date | null;
+    calendarStartDay?: number;
 }
 
 export const DatePicker = forwardRef(
@@ -35,7 +36,6 @@ export const DatePicker = forwardRef(
         const portalRef = useRef<HTMLDivElement>(null);
         const id = useMemo(() => `datepicker_` + Math.random(), []);
         const Portal = createPortal(<div ref={portalRef} id={id} style={{ position: "fixed" }} />, document.body);
-        const calendarStartDay = window.mx.session.getConfig().locale.firstDayOfWeek;
 
         const buttonClick = useCallback(() => {
             setOpen(open => !open);
@@ -60,7 +60,7 @@ export const DatePicker = forwardRef(
                     dropdownMode="select"
                     enableTabLoop
                     locale={props.locale}
-                    calendarStartDay={calendarStartDay}
+                    calendarStartDay={props.calendarStartDay}
                     onChange={date => {
                         if (isDate(date) && isValid(date)) {
                             props.setValue(date as Date);

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/components/FilterComponent.tsx
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/components/FilterComponent.tsx
@@ -9,6 +9,7 @@ import classNames from "classnames";
 
 interface FilterComponentProps {
     adjustable: boolean;
+    calendarStartDay?: number;
     className?: string;
     defaultFilter: DefaultFilterEnum;
     defaultValue?: Date;
@@ -82,6 +83,7 @@ export function FilterComponent(props: FilterComponentProps): ReactElement {
             )}
             <DatePicker
                 adjustable={props.adjustable}
+                calendarStartDay={props.calendarStartDay}
                 dateFormat={props.dateFormat}
                 locale={props.locale}
                 id={props.id}

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="DatagridDateFilter" version="2.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="DatagridDateFilter" version="2.1.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="DatagridDateFilter.xml"/>
         </widgetFiles>

--- a/packages/pluggableWidgets/datagrid-date-filter-web/typings/global.d.ts
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/typings/global.d.ts
@@ -1,0 +1,30 @@
+export interface MXLocalePatterns {
+    date: string;
+    datetime: string;
+    time: string;
+}
+
+export interface MXSessionLocale {
+    code: string;
+    firstDayOfWeek: number;
+    languageTag: string;
+    patterns: MXLocalePatterns;
+}
+
+export interface MXSessionConfig {
+    locale: MXSessionLocale;
+}
+
+export interface MXSession {
+    getConfig(): MXSessionConfig;
+}
+
+export interface MXGlobalObject {
+    session: MXSession;
+}
+
+declare global {
+    interface Window {
+        mx: MXGlobalObject;
+    }
+}

--- a/packages/pluggableWidgets/pie-doughnut-chart-web/package.json
+++ b/packages/pluggableWidgets/pie-doughnut-chart-web/package.json
@@ -44,6 +44,6 @@
     "@mendix/piw-utils-internal": "^1.0.0",
     "@mendix/shared-charts": "^1.0.0",
     "classnames": "^2.2.6",
-    "date-fns": "^2.16.1"
+    "date-fns": "^2.24.0"
   }
 }

--- a/packages/pluggableWidgets/slider-web/typings/SliderProps.d.ts
+++ b/packages/pluggableWidgets/slider-web/typings/SliderProps.d.ts
@@ -49,8 +49,6 @@ export interface SliderContainerProps {
 
 export interface SliderPreviewProps {
     readOnly: boolean;
-    style?: string;
-    styleObject?: CSSProperties;
     advanced: boolean;
     valueAttribute: string;
     minValueType: MinValueTypeEnum;


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
- This PR is fixing issue with `DatagridDateFilter` not respecting app settings for "first day of week"
- Force datepicker to use ["EEEEEE"](https://date-fns.org/v2.27.0/docs/format) format for weekdays

## Relevant changes
- Getting first day of the week from `mx.session` config and passing it to `DatePicker` component

## What should be covered while testing?
You should be able to change "first day of the week" in App -> Settings -> Runtime and see this change in datepicker of date-filter.