### PR TITLE
[WC-921] Pluggable Widgets Tools - fix lib resolution for web widgets

### DIFF
--- a/packages/pluggableWidgets/image-web/src/components/Lightbox.tsx
+++ b/packages/pluggableWidgets/image-web/src/components/Lightbox.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import React, { createElement, ReactElement, useCallback } from "react";
-import Modal, { ModalProps, RenderModalBackdropProps } from "react-overlays/Modal";
+import Modal, { ModalProps, RenderModalBackdropProps } from "react-overlays/esm/Modal";
 
 import closeIconSvg from "../assets/ic24-close.svg";
 

--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Fixed
+- We fixed an issue with libraries resolution in Web widgets.
+
+## [9.8.0] - 2021-12-06
+
+### Fixed
 - We fixed the typing generation for `editorPreview` files.
 
 ### Added

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -155,7 +155,7 @@ export default async args => {
 
     function getCommonPlugins(config) {
         return [
-            nodeResolve({ preferBuiltins: false, mainFields: ["module", "browser", "main"] }),
+            nodeResolve({ preferBuiltins: false, mainFields: ["browser", "main", "module"] }),
             isTypescript
                 ? typescript({
                       noEmitOnError: !args.watch,

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.8.0",
+  "version": "9.8.1",
   "description": "Mendix Pluggable Widgets Tools",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2021. All rights reserved.",


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fix the entry point resolution in web widgets. We are having some cases that libraries does not work well with Rollup and discovered in the 2 cases we had the problem was because node-resolve plugin was preferring "module" entrypoint over "main" which seems to be incorrect to most of the web libraries. As we are bundling in one unique file and terser does a good treeshaking for the unused methods it doesnt seems to be a big problem for web widgets (size wise).

## Relevant changes
Changed the main way of resolve libraries.

## What should be covered while testing?
General usage and possible increase in bundle/mpk size.
