### PR TITLE
[UIA-24] Fix for warning on registerDeviceForRemoteMessages call in RequestNotificationPermission

### DIFF
--- a/packages/jsActions/mobile-resources-native/src/notifications/RequestNotificationPermission.ts
+++ b/packages/jsActions/mobile-resources-native/src/notifications/RequestNotificationPermission.ts
@@ -23,7 +23,7 @@ export async function RequestNotificationPermission(): Promise<boolean> {
     return messaging()
         .requestPermission()
         .then(() =>
-            Platform.OS === "ios"
+            Platform.OS === "ios" && !messaging().isDeviceRegisteredForRemoteMessages
                 ? messaging()
                       .registerDeviceForRemoteMessages()
                       .then(() => true)


### PR DESCRIPTION
Fix for warning on superfluous `messaging().registerDeviceForRemoteMessages()` call in the RequestNotificationPermission action (Native Mobile Resources).

#### Native specific
- Works in Android ✅
- Works in iOS ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Solves the following warning that users currently get when using the RequestNotificationPermission action in iOS: `Usage of "messaging().registerDeviceForRemoteMessages()" is not required. You only need to register if auto-registration is disabled in your 'firebase.json' configuration file via the 'messaging_ios_auto_register_for_remote_messages' property`.

## Relevant changes
Added the same check as used in the Notifications widget: https://github.com/mendix/widgets-resources/blob/69c1ab10d788282e298921101888f220a29b2b01/packages/pluggableWidgets/notifications-native/src/Notifications.tsx#L128