### PR TITLE
[WC-827] Configurable tooltips for columns in Datagrid 2

### DIFF
--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+
+- We added "Tooltip" property for column, which allow you to control text that will be seen when hovering cell.
 - We added dark mode to Structure mode preview.
 
 ## [2.1.0] - 2021-12-3

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -131,6 +131,7 @@ export const getPreview = (values: DatagridPreviewProps, isDarkMode: boolean): S
         : [
               {
                   header: "Column",
+                  tooltip: "",
                   attribute: "",
                   width: "autoFit",
                   columnClass: "",

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -28,6 +28,9 @@ export function getProperties(
         if (column.showContentAs !== "customContent") {
             hidePropertyIn(defaultProperties, values, "columns", index, "content");
         }
+        if (column.showContentAs === "customContent") {
+            hidePropertyIn(defaultProperties, values, "columns", index, "tooltip");
+        }
         if (!values.columnsSortable) {
             hidePropertyIn(defaultProperties, values, "columns", index, "sortable");
         }

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorPreview.tsx
@@ -17,6 +17,7 @@ export function preview(props: DatagridPreviewProps): ReactElement {
             : [
                   {
                       header: "Column",
+                      tooltip: "",
                       attribute: "[No attribute selected]",
                       width: "autoFill",
                       columnClass: "",

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -107,12 +107,22 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
             cellRenderer={useCallback(
                 (renderWrapper, value, columnIndex) => {
                     const column = props.columns[columnIndex];
+                    const title = column.tooltip && isAvailable(column.tooltip) ? column.tooltip.value : undefined;
+                    // const title = (column.tooltip && isAvailable(column.tooltip) && column.tooltip.value) || "";
                     let content;
 
                     if (column.showContentAs === "attribute") {
-                        content = <span className="td-text">{column.attribute?.get(value)?.displayValue ?? ""}</span>;
+                        content = (
+                            <span title={title} className="td-text">
+                                {column.attribute?.get(value)?.displayValue ?? ""}
+                            </span>
+                        );
                     } else if (column.showContentAs === "dynamicText") {
-                        content = <span className="td-text">{column.dynamicText?.get(value)?.value ?? ""}</span>;
+                        content = (
+                            <span title={title} className="td-text">
+                                {column.dynamicText?.get(value)?.value ?? ""}
+                            </span>
+                        );
                     } else {
                         content = column.content?.get(value);
                     }

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.tsx
@@ -4,7 +4,6 @@ import { FilterCondition } from "mendix/filters";
 import { and } from "mendix/filters/builders";
 
 import { Table, TableColumn } from "./components/Table";
-import classNames from "classnames";
 import {
     FilterFunction,
     FilterType,
@@ -12,8 +11,9 @@ import {
     useFilterContext,
     useMultipleFiltering
 } from "@mendix/piw-utils-internal/components/web";
-import { executeAction, isAvailable } from "@mendix/piw-utils-internal";
+import { isAvailable } from "@mendix/piw-utils-internal";
 import { extractFilters } from "./utils/filters";
+import { useCellRenderer } from "./utils/useCellRenderer";
 
 export default function Datagrid(props: DatagridContainerProps): ReactElement {
     const id = useRef(`DataGrid${generateUUID()}`);
@@ -27,6 +27,7 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
     const [filtered, setFiltered] = useState(false);
     const multipleFilteringState = useMultipleFiltering();
     const { FilterContext } = useFilterContext();
+    const cellRenderer = useCellRenderer({ columns: props.columns, onClick: props.onClick });
 
     useEffect(() => {
         props.datasource.requestTotalCount(true);
@@ -104,39 +105,7 @@ export default function Datagrid(props: DatagridContainerProps): ReactElement {
 
     return (
         <Table
-            cellRenderer={useCallback(
-                (renderWrapper, value, columnIndex) => {
-                    const column = props.columns[columnIndex];
-                    const title = column.tooltip && isAvailable(column.tooltip) ? column.tooltip.value : undefined;
-                    // const title = (column.tooltip && isAvailable(column.tooltip) && column.tooltip.value) || "";
-                    let content;
-
-                    if (column.showContentAs === "attribute") {
-                        content = (
-                            <span title={title} className="td-text">
-                                {column.attribute?.get(value)?.displayValue ?? ""}
-                            </span>
-                        );
-                    } else if (column.showContentAs === "dynamicText") {
-                        content = (
-                            <span title={title} className="td-text">
-                                {column.dynamicText?.get(value)?.value ?? ""}
-                            </span>
-                        );
-                    } else {
-                        content = column.content?.get(value);
-                    }
-
-                    return renderWrapper(
-                        content,
-                        classNames(`align-column-${column.alignment}`, column.columnClass?.get(value)?.value, {
-                            "wrap-text": column.wrapText
-                        }),
-                        props.onClick ? () => executeAction(props.onClick?.get(value)) : undefined
-                    );
-                },
-                [props.columns, props.onClick]
-            )}
+            cellRenderer={cellRenderer}
             className={props.class}
             columns={columns}
             columnsDraggable={props.columnsDraggable}

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -58,7 +58,7 @@
                                 <caption>Caption</caption>
                                 <description/>
                             </property>
-                            <property key="tooltip" type="textTemplate" required="false">
+                            <property key="tooltip" type="textTemplate" required="false" dataSource="../datasource">
                                 <caption>Tooltip</caption>
                                 <description />
                             </property>

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.xml
@@ -58,6 +58,10 @@
                                 <caption>Caption</caption>
                                 <description/>
                             </property>
+                            <property key="tooltip" type="textTemplate" required="false">
+                                <caption>Tooltip</caption>
+                                <description />
+                            </property>
                             <property key="filter" type="widgets" required="false">
                                 <caption>Filter</caption>
                                 <description/>

--- a/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
@@ -23,12 +23,14 @@ export type TableColumn = Omit<
     "attribute" | "columnClass" | "content" | "dynamicText" | "filter" | "showContentAs" | "tooltip"
 >;
 
+export type CellRenderer<T extends ObjectItem = ObjectItem> = (
+    renderWrapper: (children: ReactNode, className?: string, onClick?: () => void) => ReactElement,
+    value: T,
+    columnIndex: number
+) => ReactElement;
+
 export interface TableProps<T extends ObjectItem> {
-    cellRenderer: (
-        renderWrapper: (children: ReactNode, className?: string, onClick?: () => void) => ReactElement,
-        value: T,
-        columnIndex: number
-    ) => ReactElement;
+    cellRenderer: CellRenderer<T>;
     className: string;
     columns: TableColumn[];
     columnsFilterable: boolean;

--- a/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
@@ -20,7 +20,7 @@ import { InfiniteBody, Pagination } from "@mendix/piw-utils-internal/components/
 
 export type TableColumn = Omit<
     ColumnsPreviewType,
-    "attribute" | "columnClass" | "content" | "dynamicText" | "filter" | "showContentAs"
+    "attribute" | "columnClass" | "content" | "dynamicText" | "filter" | "showContentAs" | "tooltip"
 >;
 
 export interface TableProps<T extends ObjectItem> {

--- a/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/useCellRenderer.spec.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/useCellRenderer.spec.ts
@@ -13,7 +13,6 @@ import { ColumnsType } from "../../../typings/DatagridProps";
 const col: ColumnsType = {
     showContentAs: "attribute",
     header: dynamicValue("Test"),
-    // content: buildWidgetValue("Jupiter"),
     sortable: false,
     resizable: false,
     draggable: false,

--- a/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/useCellRenderer.spec.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/useCellRenderer.spec.ts
@@ -106,8 +106,8 @@ describe("Datagrid useCellRenderer hook", () => {
         });
 
         const renderWrapper = jest.fn(x => x);
-        result.current(renderWrapper, { id: "333" as GUID }, 0);
+        const output = result.current(renderWrapper, { id: "333" as GUID }, 0);
         expect(renderWrapper).toBeCalled();
-        expect(renderWrapper.mock.calls[0][0]).toEqual("custom content");
+        expect(output).toEqual("custom content");
     });
 });

--- a/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/useCellRenderer.spec.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/useCellRenderer.spec.ts
@@ -1,0 +1,114 @@
+import { GUID } from "mendix";
+import { renderHook } from "@testing-library/react-hooks";
+import { useCellRenderer } from "../useCellRenderer";
+import {
+    dynamicValue,
+    buildListExpression,
+    buildWidgetValue,
+    EditableValueBuilder,
+    ListAttributeValueBuilder
+} from "@mendix/piw-utils-internal";
+import { ColumnsType } from "../../../typings/DatagridProps";
+
+const col: ColumnsType = {
+    showContentAs: "attribute",
+    header: dynamicValue("Test"),
+    // content: buildWidgetValue("Jupiter"),
+    sortable: false,
+    resizable: false,
+    draggable: false,
+    hidable: "no" as const,
+    width: "autoFill" as const,
+    size: 1,
+    alignment: "left" as const,
+    wrapText: false
+};
+
+describe("Datagrid useCellRenderer hook", () => {
+    it("adds title when column has attribute as datasource", () => {
+        const tooltipValue = "Jupiter is the fifth planet from the Sun";
+        const { result } = renderHook(() => {
+            const attribute = new ListAttributeValueBuilder().withId("attribute1").withType("String").build();
+            const tooltip = buildListExpression(tooltipValue);
+
+            attribute.get = jest.fn(() => new EditableValueBuilder<string>().withValue("Jupiter").build());
+
+            return useCellRenderer({
+                columns: [{ ...col, attribute, tooltip }]
+            });
+        });
+
+        const renderWrapper = jest.fn(x => x);
+        const output = result.current(renderWrapper, { id: "111" as GUID }, 0);
+        expect(renderWrapper).toBeCalled();
+        expect(output.type).toBe("span");
+        expect(output.props.title).toEqual(tooltipValue);
+        expect(output.props.children).toEqual("Formatted Jupiter");
+    });
+
+    it("not render title attribute if tooltip is empty string", () => {
+        const tooltipValue = "";
+        const { result: resultA } = renderHook(() => {
+            const attribute = new ListAttributeValueBuilder().withId("attribute1").withType("String").build();
+            const tooltip = buildListExpression(tooltipValue);
+
+            attribute.get = jest.fn(() => new EditableValueBuilder<string>().withValue("Jupiter").build());
+
+            return useCellRenderer({
+                columns: [{ ...col, attribute, tooltip }]
+            });
+        });
+
+        const { result: resultB } = renderHook(() => {
+            const tooltip = buildListExpression(tooltipValue);
+            const dynamicText = buildListExpression("Make me happy");
+
+            return useCellRenderer({
+                columns: [{ ...col, showContentAs: "dynamicText", dynamicText, tooltip }]
+            });
+        });
+
+        const wrapperA = jest.fn(x => x);
+        const wrapperB = jest.fn(x => x);
+        const outputA = resultA.current(wrapperA, { id: "111" as GUID }, 0);
+        const outputB = resultB.current(wrapperB, { id: "112" as GUID }, 0);
+        expect(outputA.props.title).toBeUndefined();
+        expect(outputB.props.title).toBeUndefined();
+    });
+
+    it("adds title when column has dynamicText as datasource", () => {
+        const tooltipValue = "Do not forget to make $ git lfs pull";
+        const { result } = renderHook(() => {
+            const tooltip = buildListExpression(tooltipValue);
+            const dynamicText = buildListExpression("Make me happy");
+
+            return useCellRenderer({
+                columns: [{ ...col, showContentAs: "dynamicText", dynamicText, tooltip }]
+            });
+        });
+
+        const renderWrapper = jest.fn(x => x);
+        const output = result.current(renderWrapper, { id: "222" as GUID }, 0);
+        expect(renderWrapper).toBeCalled();
+        expect(output.type).toBe("span");
+        expect(output.props.title).toEqual(tooltipValue);
+        expect(output.props.children).toEqual("Make me happy");
+    });
+
+    it("ignores tooltip when content is 'customContent'", () => {
+        const tooltipValue = "Lorem ipsum";
+        const { result } = renderHook(() => {
+            const tooltip = buildListExpression(tooltipValue);
+            const content = buildWidgetValue("custom content");
+
+            return useCellRenderer({
+                columns: [{ ...col, showContentAs: "customContent", content, tooltip }]
+            });
+        });
+
+        const renderWrapper = jest.fn(x => x);
+        result.current(renderWrapper, { id: "333" as GUID }, 0);
+        expect(renderWrapper).toBeCalled();
+        expect(renderWrapper.mock.calls[0][0]).toEqual("custom content");
+    });
+});

--- a/packages/pluggableWidgets/datagrid-web/src/utils/useCellRenderer.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/useCellRenderer.tsx
@@ -1,0 +1,45 @@
+import { createElement, useCallback } from "react";
+import { ListActionValue } from "mendix";
+import { CellRenderer } from "../components/Table";
+import { ColumnsType } from "../../typings/DatagridProps";
+import classNames from "classnames";
+import { executeAction } from "@mendix/piw-utils-internal";
+
+interface CellRendererHookProps {
+    columns: ColumnsType[];
+    onClick?: ListActionValue;
+}
+
+export function useCellRenderer(props: CellRendererHookProps): CellRenderer {
+    const renderer: CellRenderer = (renderWrapper, value, columnIndex) => {
+        const column = props.columns[columnIndex];
+        const title = column.tooltip && column.tooltip.get(value)?.value;
+        let content;
+
+        if (column.showContentAs === "attribute") {
+            content = (
+                <span title={title} className="td-text">
+                    {column.attribute?.get(value)?.displayValue ?? ""}
+                </span>
+            );
+        } else if (column.showContentAs === "dynamicText") {
+            content = (
+                <span title={title} className="td-text">
+                    {column.dynamicText?.get(value)?.value ?? ""}
+                </span>
+            );
+        } else {
+            content = column.content?.get(value);
+        }
+
+        return renderWrapper(
+            content,
+            classNames(`align-column-${column.alignment}`, column.columnClass?.get(value)?.value, {
+                "wrap-text": column.wrapText
+            }),
+            props.onClick ? () => executeAction(props.onClick?.get(value)) : undefined
+        );
+    };
+
+    return useCallback(renderer, [props.columns, props.onClick]);
+}

--- a/packages/pluggableWidgets/datagrid-web/src/utils/useCellRenderer.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/useCellRenderer.tsx
@@ -10,9 +10,9 @@ interface CellRendererHookProps {
     onClick?: ListActionValue;
 }
 
-export function useCellRenderer(props: CellRendererHookProps): CellRenderer {
+export function useCellRenderer({ onClick, columns }: CellRendererHookProps): CellRenderer {
     const renderer: CellRenderer = (renderWrapper, value, columnIndex) => {
-        const column = props.columns[columnIndex];
+        const column = columns[columnIndex];
         const title = column.tooltip && column.tooltip.get(value)?.value;
         let content;
 
@@ -37,9 +37,9 @@ export function useCellRenderer(props: CellRendererHookProps): CellRenderer {
             classNames(`align-column-${column.alignment}`, column.columnClass?.get(value)?.value, {
                 "wrap-text": column.wrapText
             }),
-            props.onClick ? () => executeAction(props.onClick?.get(value)) : undefined
+            onClick ? () => executeAction(onClick?.get(value)) : undefined
         );
     };
 
-    return useCallback(renderer, [props.columns, props.onClick]);
+    return useCallback(renderer, [columns, onClick]);
 }

--- a/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
@@ -29,7 +29,7 @@ export interface ColumnsType {
     content?: ListWidgetValue;
     dynamicText?: ListExpressionValue<string>;
     header?: DynamicValue<string>;
-    tooltip?: DynamicValue<string>;
+    tooltip?: ListExpressionValue<string>;
     filter?: ReactNode;
     sortable: boolean;
     resizable: boolean;

--- a/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
+++ b/packages/pluggableWidgets/datagrid-web/typings/DatagridProps.d.ts
@@ -29,6 +29,7 @@ export interface ColumnsType {
     content?: ListWidgetValue;
     dynamicText?: ListExpressionValue<string>;
     header?: DynamicValue<string>;
+    tooltip?: DynamicValue<string>;
     filter?: ReactNode;
     sortable: boolean;
     resizable: boolean;
@@ -57,6 +58,7 @@ export interface ColumnsPreviewType {
     content: { widgetCount: number; renderer: ComponentType<{ caption?: string }> };
     dynamicText: string;
     header: string;
+    tooltip: string;
     filter: { widgetCount: number; renderer: ComponentType<{ caption?: string }> };
     sortable: boolean;
     resizable: boolean;


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

#### Native specific
- Works in Android ✅ ❌
- Works in iOS ✅ ❌
- Works in Tablet ✅ ❌

#### Feature specific
- Comply with designs ✅
- Comply with PM's requirements (in progress)

## This PR contains
- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Add new property to Datagrid v2

## Relevant changes
New `Tooltip` property, which allow you to control text that will be seen when hovering cell

## What should be covered while testing?
You should be able to set tooltip for column in datagrid.

## Extra comments (optional)
@leonardomendix, attached project package for test to the story.