### PR TITLE
[NC-587] Improve build output native modules

### DIFF
--- a/configs/jsactions/rollup.config.js
+++ b/configs/jsactions/rollup.config.js
@@ -139,7 +139,8 @@ const nativeExternal = [
     /^react-native-reanimated(\/|$)/,
     /^react-native-svg(\/|$)/,
     /^react-native-vector-icons(\/|$)/,
-    /^react-navigation(\/|$)/
+    /^react-navigation(\/|$)/,
+    /^react-native-device-info(\/|$)/
 ];
 
 // These libraries are being used silently by @react-native-community/cameraroll and @react-native-community/geolocation and both dont have these libs as a peer or dependency

--- a/configs/jsactions/rollup.config.js
+++ b/configs/jsactions/rollup.config.js
@@ -120,7 +120,7 @@ export default async args => {
             filter: [
                 "**/*.*",
                 "{license,LICENSE}",
-                "!**/{android,ios,windows,mac,jest,github,gradle,__*__,docs,jest,example*}/**/*",
+                "!**/{android,ios,windows,mac,jest,github,gradle,__*__,.bin,demo,docs,test,jest,example*}/**/*",
                 "!**/*.{config,setup}.*",
                 "!**/*.{podspec,flow}"
             ]


### PR DESCRIPTION
## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
To exclude more unwanted subfolders of node modules in the build process.
To include the missing module `react-native-permissions` as it is not automatically included due to the dynamic import. 

## What should be covered while testing?
The JS actions in both NativeMobileResources & NanoflowCommons should be tested.
