### PR TITLE
split inner and outer spacing

### DIFF
--- a/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
@@ -24,22 +24,6 @@
                     "name": "Outer large",
                     "oldNames": ["Large"],
                     "class": "spacing-outer-top-large"
-                },
-                {
-                    "name": "Inner none",
-                    "class": "spacing-inner-top-none"
-                },
-                {
-                    "name": "Inner small",
-                    "class": "spacing-inner-top"
-                },
-                {
-                    "name": "Inner medium",
-                    "class": "spacing-inner-top-medium"
-                },
-                {
-                    "name": "Inner large",
-                    "class": "spacing-inner-top-large"
                 }
             ]
         },
@@ -67,22 +51,6 @@
                     "name": "Outer large",
                     "oldNames": ["Large"],
                     "class": "spacing-outer-bottom-large"
-                },
-                {
-                    "name": "Inner none",
-                    "class": "spacing-inner-bottom-none"
-                },
-                {
-                    "name": "Inner small",
-                    "class": "spacing-inner-bottom"
-                },
-                {
-                    "name": "Inner medium",
-                    "class": "spacing-inner-bottom-medium"
-                },
-                {
-                    "name": "Inner large",
-                    "class": "spacing-inner-bottom-large"
                 }
             ]
         },
@@ -110,22 +78,6 @@
                     "name": "Outer large",
                     "oldNames": ["Large"],
                     "class": "spacing-outer-left-large"
-                },
-                {
-                    "name": "Inner none",
-                    "class": "spacing-inner-left-none"
-                },
-                {
-                    "name": "Inner small",
-                    "class": "spacing-inner-left"
-                },
-                {
-                    "name": "Inner medium",
-                    "class": "spacing-inner-left-medium"
-                },
-                {
-                    "name": "Inner large",
-                    "class": "spacing-inner-left-large"
                 }
             ]
         },
@@ -153,22 +105,98 @@
                     "name": "Outer large",
                     "oldNames": ["Large"],
                     "class": "spacing-outer-right-large"
+                }
+            ]
+        },
+        {
+            "name": "Inner spacing top",
+            "type": "Dropdown",
+            "description": "The top spacing within this element.",
+            "options": [
+                {
+                    "name": "None",
+                    "class": "spacing-inner-top-none"
                 },
                 {
-                    "name": "Inner none",
+                    "name": "Small",
+                    "class": "spacing-inner-top"
+                },
+                {
+                    "name": "Medium",
+                    "class": "spacing-inner-top-medium"
+                },
+                {
+                    "name": "Large",
+                    "class": "spacing-inner-top-large"
+                }
+            ]
+        },
+        {
+            "name": "Inner spacing right",
+            "type": "Dropdown",
+            "description": "The right spacing within this element.",
+            "options": [
+                {
+                    "name": "None",
                     "class": "spacing-inner-right-none"
                 },
                 {
-                    "name": "Inner small",
+                    "name": "Small",
                     "class": "spacing-inner-right"
                 },
                 {
-                    "name": "Inner medium",
+                    "name": "Medium",
                     "class": "spacing-inner-right-medium"
                 },
                 {
-                    "name": "Inner large",
+                    "name": "Large",
                     "class": "spacing-inner-right-large"
+                }
+            ]
+        },
+        {
+            "name": "Inner spacing bottom",
+            "type": "Dropdown",
+            "description": "The bottom spacing within this element.",
+            "options": [
+                {
+                    "name": "None",
+                    "class": "spacing-inner-bottom-none"
+                },
+                {
+                    "name": "Small",
+                    "class": "spacing-inner-bottom"
+                },
+                {
+                    "name": "Medium",
+                    "class": "spacing-inner-bottom-medium"
+                },
+                {
+                    "name": "Large",
+                    "class": "spacing-inner-bottom-large"
+                }
+            ]
+        },
+        {
+            "name": "Inner spacing left",
+            "type": "Dropdown",
+            "description": "The left spacing within this element.",
+            "options": [
+                {
+                    "name": "None",
+                    "class": "spacing-inner-left-none"
+                },
+                {
+                    "name": "Small",
+                    "class": "spacing-inner-left"
+                },
+                {
+                    "name": "Medium",
+                    "class": "spacing-inner-left-medium"
+                },
+                {
+                    "name": "Large",
+                    "class": "spacing-inner-left-large"
                 }
             ]
         },
@@ -208,6 +236,12 @@
             "type": "Toggle",
             "description": "Hide element on desktop.",
             "class": "hide-desktop"
+        },
+        {
+            "name": "Width 100",
+            "type": "Toggle",
+            "description": "full width",
+            "class": "w-100"
         }
     ],
     "DivContainer": [


### PR DESCRIPTION
As discussed with Chris Hodges:
Removed the inner spacing (padding) from the spacing options and gave them a separate option.
This gives more flexibility in the styling, for example if you have a coloured background card that needs more spacing from the other objects, but also the text in the coloured square needs to have more spacing.
Also added  w-100 (width 100%) option.  This helps some widgets with correct placement.

## Checklist
- Contains unit tests  ❌
- Contains breaking changes ✅
- Contains Atlas changes ✅ 
- Compatible with: MX 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Native specific
- Works in Android ✅ 
- Works in iOS ✅ 
- Works in Tablet ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

**_Please remove unnecessary emojis and sections and this comment before proceeding_**

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
_Add new helpful feature for design properties_

## Relevant changes
_Removed the inner spacing (padding) from the spacing options and gave them a separate option.
This gives more flexibility in the styling, for example if you have a coloured background card that needs more spacing from the other objects, but also the text in the coloured square needs to have more spacing._

## What should be covered while testing?
_Projects who use inner spacing in their spacing design property will break.  Maybe we can update "convert classes to design properties" function to recognize the old values and new values?_

## Extra comments (optional)
_In my current projects, I solved it to leave the inner spacing statements in the spacing property and just added inner spacing as well. But this gives the users 2 options to set inner spacing_
