### PR TITLE
'align self' renamed to 'move to'

### DIFF
--- a/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
@@ -173,8 +173,8 @@
             ]
         },
         {
-            "name": "Align self",
-            "oldNames": ["Align Self"],
+            "name": "Move to",
+            "oldNames": ["Align self"],
             "type": "Dropdown",
             "description": "Float the element to the left or to the right.",
             "options": [


### PR DESCRIPTION
As discussed with Chris Hodges:
Renamed the 'Align self' to 'Move to' because of 'Align self' is a Flexbox property and can invoke wrong taught about this property, it will not make a flex-item out of the element.

## Checklist
- Contains unit tests  ❌
- Contains breaking changes ✅
- Contains Atlas changes ✅ 
- Compatible with: MX 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Native specific
- Works in Android ✅ 
- Works in iOS ✅ 
- Works in Tablet ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

**_Please remove unnecessary emojis and sections and this comment before proceeding_**

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
_Add new helpful feature for design properties_

## Relevant changes
_Renamed the 'Align self' to 'Move to' because of 'Align self' is a Flexbox property and can invoke wrong taught about this property, it will not make a flex-item out of the element._

## What should be covered while testing?
_Projects who use this property will break on this name change_
