### PR TITLE
New flexbox justify options

### DIFF
--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_helper-classes.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_helper-classes.scss
@@ -144,6 +144,25 @@
         flex-flow: row #{$important-helpers-value};
         justify-content: flex-end #{$important-helpers-value};
     }
+    
+    .row-space-around {
+        display: flex #{$important-helpers-value};
+        align-items: center #{$important-helpers-value};
+        flex-flow: row #{$important-helpers-value};
+        justify-content: space-around #{$important-helpers-value};
+    }
+    .row-space-between {
+        display: flex #{$important-helpers-value};
+        align-items: center #{$important-helpers-value};
+        flex-flow: row #{$important-helpers-value};
+        justify-content: space-between #{$important-helpers-value};
+    }
+    .row-space-evenly {
+        display: flex #{$important-helpers-value};
+        align-items: center #{$important-helpers-value};
+        flex-flow: row #{$important-helpers-value};
+        justify-content: space-evenly #{$important-helpers-value};
+    }
 
     .col-left {
         display: flex #{$important-helpers-value};


### PR DESCRIPTION
As discussed with Chris Hodges:
added     justify-content: space-around    justify-content: space-between   and    justify-content: space-evenly to the flexbox alignments

## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ✅ 
- Compatible with: MX 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Native specific
- Works in Android ✅ 
- Works in iOS ✅ 
- Works in Tablet ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

**_Please remove unnecessary emojis and sections and this comment before proceeding_**

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
_To improve design properties we first need to improve some styling files_

## Relevant changes
_added     justify-content: space-around    justify-content: space-between   and    justify-content: space-evenly to the flexbox alignments.  This is very often used in projects_

## What should be covered while testing?
_..._