### PR TITLE
Added flexbox options

### DIFF
--- a/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
@@ -232,6 +232,18 @@
                     "class": "row-right"
                 },
                 {
+                    "name": "Space-around align as a row",
+                    "class": "row-space-around"
+                },
+                {
+                    "name": "Space-between align as a row",
+                    "class": "row-space-between"
+                },
+                {
+                    "name": "Space-evenly align as a row",
+                    "class": "row-space-evenly"
+                },
+                {
                     "name": "Left align as a column",
                     "oldNames": ["Left align as column"],
                     "class": "col-left"


### PR DESCRIPTION
As discussed with Chris Hodges
added     justify-content: space-around    justify-content: space-between   and    justify-content: space-evenly to the flexbox alignments
See:  https://github.com/mendix/widgets-resources/pull/1191 to make these added classes work

## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ✅ 
- Compatible with: MX 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Native specific
- Works in Android ✅ 
- Works in iOS ✅ 
- Works in Tablet ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

**_Please remove unnecessary emojis and sections and this comment before proceeding_**

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
_Add more alignments for flexbox_

## Relevant changes
_These new options are very much used in projects and needed to be added everytime. Make them a default option in the design properties solves needless customization

## What should be covered while testing?
_..._