### PR TITLE
[WC-927]: Re-enable range slider e2e test

### DIFF
--- a/packages/pluggableWidgets/range-slider-web/package.json
+++ b/packages/pluggableWidgets/range-slider-web/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
     "pretest:e2e": "npm run release && node ../../../scripts/test/updateAtlas.js --latest-atlas",
-    "test:e2e": "echo 'Skipping tests'",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web",
     "test:e2e:dev": "pluggable-widgets-tools test:e2e:web:dev",
     "release": "cross-env MPKOUTPUT=RangeSlider.mpk pluggable-widgets-tools release:web",
     "release:marketplace": "node ../../../scripts/release/marketplaceRelease.js"

--- a/packages/pluggableWidgets/range-slider-web/tests/e2e/objects/rangeSlider.widget.ts
+++ b/packages/pluggableWidgets/range-slider-web/tests/e2e/objects/rangeSlider.widget.ts
@@ -8,7 +8,7 @@ class RangeSlider {
     }
 
     get element(): WebdriverIO.Element {
-        return page.waitForElement(`.widget-range-slider.mx-name-${this.name}`);
+        return page.waitForElement(`.mx-name-${this.name} .widget-range-slider`);
     }
 
     get minValueText(): string {


### PR DESCRIPTION
#### Web specific
- Contains e2e tests ✅ 
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (test)

## What is the purpose of this PR?
Re-enable slider e2e test of range slider widget.

## Relevant changes
Changed selector to work with new widget.

## What should be covered while testing?
Automation should pass.
