### PR TITLE
chore: add more widget properties to overview

### DIFF
--- a/scripts/data/updateWidgetsOverview.ts
+++ b/scripts/data/updateWidgetsOverview.ts
@@ -3,7 +3,7 @@ import { dirname, join, resolve } from "path";
 import { FileReadError, PatternNotFoundError } from "./errors";
 import { promisify } from "util";
 import { exec } from "child_process";
-import ts from "typescript";
+import { createProgram, escapeLeadingUnderscores } from "typescript";
 
 const execAsync = promisify(exec);
 
@@ -139,11 +139,11 @@ async function extractTextFromFile<P extends Patterns>(
 }
 
 function moduleExports(fileName: string, exportName: string): boolean {
-    const program = ts.createProgram([fileName], {});
+    const program = createProgram([fileName], {});
     const sourceFile = program.getSourceFile(fileName);
     if (sourceFile) {
         const fileSymbol = program.getTypeChecker().getSymbolAtLocation(sourceFile);
-        return fileSymbol?.exports?.get(ts.escapeLeadingUnderscores(exportName)) !== undefined;
+        return fileSymbol?.exports?.get(escapeLeadingUnderscores(exportName)) !== undefined;
     }
     return false;
 }

--- a/scripts/data/updateWidgetsOverview.ts
+++ b/scripts/data/updateWidgetsOverview.ts
@@ -43,9 +43,12 @@ async function main(): Promise<void> {
                         }
                     );
 
-                    const hasPreview = await fs
+                    const hasStructurePreview = await fs
                         .readdir(join(packagePath, "src"))
                         .then(files => files.some(path => path.endsWith(".editorConfig.ts")));
+                    const hasDesignModePreview = await fs
+                        .readdir(join(packagePath, "src"))
+                        .then(files => files.some(path => path.endsWith(".editorPreview.tsx")));
                     const hasTileIcons = await fs
                         .readdir(join(packagePath, "src"))
                         .then(files => files.some(path => path.endsWith(".tile.png")));
@@ -58,7 +61,8 @@ async function main(): Promise<void> {
                         pluginWidget: pluginWidget === "true",
                         offlineCapable: offlineCapable === "true",
                         supportedPlatform: supportedPlatform?.toLowerCase() ?? "web",
-                        hasPreview,
+                        hasStructurePreview,
+                        hasDesignModePreview,
                         hasTileIcons,
                         hasDarkModeIcons
                     };

--- a/scripts/data/updateWidgetsOverview.ts
+++ b/scripts/data/updateWidgetsOverview.ts
@@ -43,11 +43,24 @@ async function main(): Promise<void> {
                         }
                     );
 
+                    const hasPreview = await fs
+                        .readdir(join(packagePath, "src"))
+                        .then(files => files.some(path => path.endsWith(".editorConfig.ts")));
+                    const hasTileIcons = await fs
+                        .readdir(join(packagePath, "src"))
+                        .then(files => files.some(path => path.endsWith(".tile.png")));
+                    const hasDarkModeIcons = await fs
+                        .readdir(join(packagePath, "src"))
+                        .then(files => files.some(path => path.endsWith(".dark.png")));
+
                     return {
                         id,
                         pluginWidget: pluginWidget === "true",
                         offlineCapable: offlineCapable === "true",
-                        supportedPlatform: supportedPlatform ?? "Web"
+                        supportedPlatform: supportedPlatform ?? "Web",
+                        hasPreview,
+                        hasTileIcons,
+                        hasDarkModeIcons
                     };
                 } catch (e) {
                     if (e instanceof Error && (e.name === "FileReadError" || e.name === "ValueNotFoundError")) {

--- a/scripts/data/updateWidgetsOverview.ts
+++ b/scripts/data/updateWidgetsOverview.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from "fs";
-import { dirname, join } from "path";
+import { dirname, join, resolve } from "path";
 import { FileReadError, PatternNotFoundError } from "./errors";
 import { promisify } from "util";
 import { exec } from "child_process";
@@ -87,7 +87,7 @@ async function main(): Promise<void> {
 
     const result = packages.filter(isDefined);
 
-    await writeFile("data/widgets.json", JSON.stringify(result, null, "\t"));
+    await writeFile(resolve(__dirname, "../../data/widgets.json"), JSON.stringify(result, null, "\t"));
 }
 
 function isDefined<T>(val: T | undefined | null): val is T {

--- a/scripts/data/updateWidgetsOverview.ts
+++ b/scripts/data/updateWidgetsOverview.ts
@@ -57,7 +57,7 @@ async function main(): Promise<void> {
                         id,
                         pluginWidget: pluginWidget === "true",
                         offlineCapable: offlineCapable === "true",
-                        supportedPlatform: supportedPlatform ?? "Web",
+                        supportedPlatform: supportedPlatform?.toLowerCase() ?? "web",
                         hasPreview,
                         hasTileIcons,
                         hasDarkModeIcons


### PR DESCRIPTION
## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (describe)

## What is the purpose of this PR?
Collect more information per widget in the generated widget overview file

## Relevant changes
Collect whether widgets have a preview / tile icons / dark icons

## What should be covered while testing?
Data file is generated correctly