### PR TITLE
feat(generator-widget): function components support

### DIFF
--- a/packages/tools/generator-widget/CHANGELOG.md
+++ b/packages/tools/generator-widget/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - We've updated the version of yeoman-generator to 5.4.2.
 - We've updated the configurations for tsconfig in web widgets.
 - We've updated the npm tasks and template classes for web widgets.
+- You can now choose between generating class or function components.
 
 ## [9.0.2] - 2021-05-20
 

--- a/packages/tools/generator-widget/CHANGELOG.md
+++ b/packages/tools/generator-widget/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-### added
+### Added
 
 - We added `@prettier/plugin-xml` plugin to fix xml code format and check for xml errors.
+- You can now choose between generating class or function components.
 
 ## [9.1.0] - 2022-01-04
 
@@ -23,7 +24,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - We've updated the version of yeoman-generator to 5.4.2.
 - We've updated the configurations for tsconfig in web widgets.
 - We've updated the npm tasks and template classes for web widgets.
-- You can now choose between generating class or function components.
 
 ## [9.0.2] - 2021-05-20
 

--- a/packages/tools/generator-widget/generators/app/lib/prompttexts.js
+++ b/packages/tools/generator-widget/generators/app/lib/prompttexts.js
@@ -116,6 +116,24 @@ function promptWidgetProperties(mxProjectDir, widgetName) {
             ],
             default: "full",
             store: true
+        },
+        {
+            when: response => response.boilerplate === "empty",
+            type: "list",
+            name: "programmingStyle",
+            message: "Which type of components do you want to use?",
+            choices: [
+                {
+                    name: "Class Components",
+                    value: "class"
+                },
+                {
+                    name: "Function Components",
+                    value: "function"
+                }
+            ],
+            default: "class",
+            store: true
         }
     ];
 }

--- a/packages/tools/generator-widget/generators/app/lib/prompttexts.js
+++ b/packages/tools/generator-widget/generators/app/lib/prompttexts.js
@@ -85,6 +85,23 @@ function promptWidgetProperties(mxProjectDir, widgetName) {
         },
         {
             type: "list",
+            name: "programmingStyle",
+            message: "Which type of components do you want to use?",
+            choices: [
+                {
+                    name: "Class Components",
+                    value: "class"
+                },
+                {
+                    name: "Function Components",
+                    value: "function"
+                }
+            ],
+            default: "class",
+            store: true
+        },
+        {
+            type: "list",
             name: "platform",
             message: "Which type of widget are you developing?",
             choices: [
@@ -115,24 +132,6 @@ function promptWidgetProperties(mxProjectDir, widgetName) {
                 }
             ],
             default: "full",
-            store: true
-        },
-        {
-            when: response => response.boilerplate === "empty",
-            type: "list",
-            name: "programmingStyle",
-            message: "Which type of components do you want to use?",
-            choices: [
-                {
-                    name: "Class Components",
-                    value: "class"
-                },
-                {
-                    name: "Function Components",
-                    value: "function"
-                }
-            ],
-            default: "class",
             store: true
         }
     ];

--- a/packages/tools/generator-widget/generators/app/lib/utils.js
+++ b/packages/tools/generator-widget/generators/app/lib/utils.js
@@ -17,7 +17,7 @@ function getWidgetDetails(answers) {
         fileExtension: answers.programmingLanguage === "javascript" ? "js" : "ts",
         templateSourcePath: `pluggable/${answers.platform}/${answers.boilerplate}Template${
             answers.programmingLanguage === "javascript" ? "Js" : "Ts"
-        }/`
+        }${answers.programmingStyle === "function" ? "Fn" : ""}/`
     };
 }
 

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateJsFn/src/WidgetName.editorConfig.js.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateJsFn/src/WidgetName.editorConfig.js.ejs
@@ -1,0 +1,24 @@
+export function getProperties(values, defaultProperties) {
+    // Do the values manipulation here to control the visibility of properties in Studio and Studio Pro conditionally.
+    /* Example
+    if (values.myProperty === "custom") {
+        delete defaultProperties.properties.myOtherProperty;
+    }
+    */
+    return defaultProperties;
+}
+
+export function check(values) {
+    const errors = [];
+    // Add errors to the above array to throw errors in Studio and Studio Pro.
+    /* Example
+    if (values.myProperty !== "custom") {
+        errors.push({
+            property: `myProperty`,
+            message: `The value of 'myProperty' is different of 'custom'.`,
+            url: "https://github.com/myrepo/mywidget"
+        });
+    }
+    */
+    return errors;
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateJsFn/src/WidgetName.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateJsFn/src/WidgetName.jsx.ejs
@@ -1,0 +1,7 @@
+import { createElement } from "react";
+
+import { HelloWorld } from "./components/HelloWorld";
+
+export function <%- name %>({ yourName, style }) {
+    return <HelloWorld name={yourName} style={style} />;
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateJsFn/src/WidgetName.xml.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateJsFn/src/WidgetName.xml.ejs
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<widget id="<%- packagePathXml %>.<%- packageName %>.<%- name %>" pluginWidget="true" needsEntityContext="true" offlineCapable="true"
+        supportedPlatform="Native"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
+    <name><%- nameCamelCase %></name>
+    <description><%- description %></description>
+    <icon/>
+    <properties>
+        <propertyGroup caption="General">
+            <property key="yourName" type="string" required="false">
+                <caption>Name</caption>
+                <description>Enter your name</description>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateJsFn/src/components/HelloWorld.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateJsFn/src/components/HelloWorld.jsx.ejs
@@ -1,0 +1,20 @@
+import { createElement } from "react";
+import { Text, View } from "react-native";
+
+import { mergeNativeStyles } from "@mendix/pluggable-widgets-tools";
+
+const defaultStyle = {
+    container: { },
+    label: {
+        color: "#F6BB42"
+    }
+};
+
+export function HelloWorld({ name, style })  {
+    const styles = mergeNativeStyles(defaultStyle, style);
+    return (
+        <View style={styles.container}>
+            <Text style={styles.label}>Hello {name || "World"}</Text>
+        </View>
+    );
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateJsFn/src/components/__tests__/HelloWorld.spec.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateJsFn/src/components/__tests__/HelloWorld.spec.jsx.ejs
@@ -1,0 +1,32 @@
+import { createElement } from "react";
+import { shallow } from "enzyme";
+import { Platform } from "react-native";
+
+import { HelloWorld } from "../HelloWorld";
+
+describe.each(["ios", "android"])("HelloWorld for %s", (os) => {
+    beforeEach(() => {
+        Platform.OS = os;
+        Platform.select = jest.fn((dict) => dict[Platform.OS]);
+    });
+
+    it("renders the structure correctly", () => {
+        const helloWorldProps = {
+            name: "Mendix",
+            style: []
+        };
+        const helloWorld = shallow(<HelloWorld {...helloWorldProps} />);
+
+        expect(helloWorld).toMatchSnapshot();
+    });
+
+    it("renders the structure correctly with custom style", () => {
+        const helloWorldProps = {
+            name: "Mendix",
+            style: [{ container: { borderColor: "white" }, label: { color: "black" } }]
+        };
+        const helloWorld = shallow(<HelloWorld {...helloWorldProps} />);
+
+        expect(helloWorld).toMatchSnapshot();
+    });
+});

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateJsFn/src/package.xml.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateJsFn/src/package.xml.ejs
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<package xmlns="http://www.mendix.com/package/1.0/">
+    <clientModule name="<%- name %>" version="<%- version %>" xmlns="http://www.mendix.com/clientModule/1.0/">
+        <widgetFiles>
+            <widgetFile path="<%- name %>.xml"/>
+        </widgetFiles>
+        <files>
+            <file path="<%- packagePathXml %>/<%- packageName %>"/>
+        </files>
+    </clientModule>
+</package>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/WidgetName.editorConfig.ts.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/WidgetName.editorConfig.ts.ejs
@@ -1,0 +1,57 @@
+import { <%- name %>PreviewProps } from "../typings/<%- name %>Props";
+
+type Properties = PropertyGroup[];
+
+type PropertyGroup = {
+    caption: string;
+    propertyGroups?: PropertyGroup[];
+    properties?: Property[];
+};
+
+type Property = {
+    key: string;
+    caption: string;
+    description?: string;
+    objectHeaders?: string[]; // used for customizing object grids
+    objects?: ObjectProperties[];
+    properties?: Properties[];
+};
+
+type Problem = {
+    property?: string; // key of the property, at which the problem exists
+    severity?: "error" | "warning" | "deprecation"; // default = "error"
+    message: string; // description of the problem
+    studioMessage?: string; // studio-specific message, defaults to message
+    url?: string; // link with more information about the problem
+    studioUrl?: string; // studio-specific link
+};
+
+type ObjectProperties = {
+    properties: PropertyGroup[];
+    captions?: string[]; // used for customizing object grids
+};
+
+export function getProperties(_values: <%- name %>PreviewProps, defaultProperties: Properties): Properties {
+    // Do the values manipulation here to control the visibility of properties in Studio and Studio Pro conditionally.
+    /* Example
+    if (values.myProperty === "custom") {
+        delete defaultProperties.properties.myOtherProperty;
+    }
+    */
+    return defaultProperties;
+}
+
+export function check(_values: <%- name %>PreviewProps): Problem[] {
+    const errors: Problem[] = [];
+    // Add errors to the above array to throw errors in Studio and Studio Pro.
+    /* Example
+    if (values.myProperty !== "custom") {
+        errors.push({
+            property: `myProperty`,
+            message: `The value of 'myProperty' is different of 'custom'.`,
+            url: "https://github.com/myrepo/mywidget"
+        });
+    }
+    */
+    return errors;
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/WidgetName.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/WidgetName.tsx.ejs
@@ -1,0 +1,16 @@
+import { FC, createElement } from "react";
+import { TextStyle, ViewStyle } from "react-native";
+
+import { Style } from "@mendix/pluggable-widgets-tools";
+
+import { HelloWorld } from "./components/HelloWorld";
+import { <%- name %>Props } from "../typings/<%- name %>Props";
+
+export interface CustomStyle extends Style {
+    container: ViewStyle;
+    label: TextStyle;
+}
+
+export const <%- name %>: FC<<%- name %>Props<CustomStyle>> = ({ style, yourName }) => {
+    return <HelloWorld name={yourName} style={style} />;
+};

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/WidgetName.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/WidgetName.tsx.ejs
@@ -11,6 +11,6 @@ export interface CustomStyle extends Style {
     label: TextStyle;
 }
 
-export function <%- name %>({ style, yourName }: <%- name %>Props<CustomStyle>): ReactElement | null {
+export function <%- name %>({ style, yourName }: <%- name %>Props<CustomStyle>): ReactElement {
     return <HelloWorld name={yourName} style={style} />;
 }

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/WidgetName.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/WidgetName.tsx.ejs
@@ -1,4 +1,4 @@
-import { FC, createElement } from "react";
+import { ReactElement, createElement } from "react";
 import { TextStyle, ViewStyle } from "react-native";
 
 import { Style } from "@mendix/pluggable-widgets-tools";
@@ -11,6 +11,6 @@ export interface CustomStyle extends Style {
     label: TextStyle;
 }
 
-export const <%- name %>: FC<<%- name %>Props<CustomStyle>> = ({ style, yourName }) => {
+export function <%- name %>({ style, yourName }: <%- name %>Props<CustomStyle>): ReactElement | null {
     return <HelloWorld name={yourName} style={style} />;
-};
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/WidgetName.xml.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/WidgetName.xml.ejs
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<widget id="<%- packagePathXml %>.<%- packageName %>.<%- name %>" pluginWidget="true" needsEntityContext="true" offlineCapable="true"
+        supportedPlatform="Native"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
+    <name><%- nameCamelCase %></name>
+    <description><%- description %></description>
+    <icon/>
+    <properties>
+        <propertyGroup caption="General">
+            <property key="yourName" type="string" required="false">
+                <caption>Name</caption>
+                <description>Enter your name</description>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/components/HelloWorld.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/components/HelloWorld.tsx.ejs
@@ -1,0 +1,27 @@
+import { FC, createElement } from "react";
+import { Text, View } from "react-native";
+
+import { mergeNativeStyles } from "@mendix/pluggable-widgets-tools";
+
+import { CustomStyle } from "../<%- name %>";
+
+export interface HelloWorldProps {
+    name?: string;
+    style: CustomStyle[];
+}
+
+const defaultStyle: CustomStyle = {
+    container: { },
+    label: {
+        color: "#F6BB42"
+    }
+};
+
+export const HelloWorld: FC<HelloWorldProps> = ({ name, style }) => {
+    const styles = mergeNativeStyles(defaultStyle, style);
+    return (
+        <View style={styles.container}>
+            <Text style={styles.label}>Hello {name || "World"}</Text>
+        </View>
+    );
+};

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/components/HelloWorld.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/components/HelloWorld.tsx.ejs
@@ -1,4 +1,4 @@
-import { FC, createElement } from "react";
+import { ReactElement, createElement } from "react";
 import { Text, View } from "react-native";
 
 import { mergeNativeStyles } from "@mendix/pluggable-widgets-tools";
@@ -17,11 +17,11 @@ const defaultStyle: CustomStyle = {
     }
 };
 
-export const HelloWorld: FC<HelloWorldProps> = ({ name, style }) => {
+export function HelloWorld({ name, style }: HelloWorldProps): ReactElement | null {
     const styles = mergeNativeStyles(defaultStyle, style);
     return (
         <View style={styles.container}>
             <Text style={styles.label}>Hello {name || "World"}</Text>
         </View>
     );
-};
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/components/HelloWorld.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/components/HelloWorld.tsx.ejs
@@ -17,7 +17,7 @@ const defaultStyle: CustomStyle = {
     }
 };
 
-export function HelloWorld({ name, style }: HelloWorldProps): ReactElement | null {
+export function HelloWorld({ name, style }: HelloWorldProps): ReactElement {
     const styles = mergeNativeStyles(defaultStyle, style);
     return (
         <View style={styles.container}>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/components/__tests__/HelloWorld.spec.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/components/__tests__/HelloWorld.spec.tsx.ejs
@@ -1,0 +1,32 @@
+import { createElement } from "react";
+import { shallow } from "enzyme";
+import { Platform } from "react-native";
+
+import { HelloWorld, HelloWorldProps } from "../HelloWorld";
+
+describe.each(["ios", "android"])("HelloWorld for %s", (os: "ios" | "android") => {
+    beforeEach(() => {
+        Platform.OS = os;
+        Platform.select = jest.fn((dict: any) => dict[Platform.OS]);
+    });
+
+    it("renders the structure correctly", () => {
+        const helloWorldProps: HelloWorldProps = {
+            name: "Mendix",
+            style: []
+        };
+        const helloWorld = shallow(<HelloWorld {...helloWorldProps} />);
+
+        expect(helloWorld).toMatchSnapshot();
+    });
+
+    it("renders the structure correctly with custom style", () => {
+        const helloWorldProps: HelloWorldProps = {
+            name: "Mendix",
+            style: [{ container: { borderColor: "white" }, label: { color: "black" } }]
+        };
+        const helloWorld = shallow(<HelloWorld {...helloWorldProps} />);
+
+        expect(helloWorld).toMatchSnapshot();
+    });
+});

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/package.xml.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/package.xml.ejs
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<package xmlns="http://www.mendix.com/package/1.0/">
+    <clientModule name="<%- name %>" version="<%- version %>" xmlns="http://www.mendix.com/clientModule/1.0/">
+        <widgetFiles>
+            <widgetFile path="<%- name %>.xml"/>
+        </widgetFiles>
+        <files>
+            <file path="<%- packagePathXml %>/<%- packageName %>"/>
+        </files>
+    </clientModule>
+</package>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/WidgetName.editorConfig.js.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/WidgetName.editorConfig.js.ejs
@@ -1,0 +1,24 @@
+export function getProperties(values, defaultProperties) {
+    // Do the values manipulation here to control the visibility of properties in Studio and Studio Pro conditionally.
+    /* Example
+    if (values.myProperty === "custom") {
+        delete defaultProperties.properties.myOtherProperty;
+    }
+    */
+    return defaultProperties;
+}
+
+export function check(values) {
+    const errors = [];
+    // Add errors to the above array to throw errors in Studio and Studio Pro.
+    /* Example
+    if (values.myProperty !== "custom") {
+        errors.push({
+            property: `myProperty`,
+            message: `The value of 'myProperty' is different of 'custom'.`,
+            url: "https://github.com/myrepo/mywidget"
+        });
+    }
+    */
+    return errors;
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/WidgetName.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/WidgetName.jsx.ejs
@@ -1,0 +1,21 @@
+import { createElement } from "react";
+
+import { Badge } from "./components/Badge";
+
+export function <%- name %>(props) {
+    const onClickHandler = () => {
+        const { onClick } = props;
+
+        if (onClick && onClick.canExecute && !onClick.isExecuting) {
+            onClick.execute();
+        }
+    };
+
+    return (
+        <Badge
+            style={props.style}
+            onClick={onClickHandler}
+            value={props.value?.displayValue || "Default"}
+        />
+    );
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/WidgetName.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/WidgetName.jsx.ejs
@@ -1,21 +1,19 @@
-import { createElement } from "react";
+import { createElement, useCallback } from "react";
 
 import { Badge } from "./components/Badge";
 
-export function <%- name %>(props) {
-    const onClickHandler = () => {
-        const { onClick } = props;
-
+export function <%- name %>({ value, style, onClick }) {
+    const onClickHandler = useCallback(() => {
         if (onClick && onClick.canExecute && !onClick.isExecuting) {
             onClick.execute();
         }
-    };
+    }, [onClick]);
 
     return (
         <Badge
-            style={props.style}
+            style={style}
             onClick={onClickHandler}
-            value={props.value?.displayValue || "Default"}
+            value={value?.displayValue || "Default"}
         />
     );
 }

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/WidgetName.xml.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/WidgetName.xml.ejs
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<widget id="<%- packagePathXml %>.<%- packageName %>.<%- name %>" pluginWidget="true" needsEntityContext="true" offlineCapable="true"
+        supportedPlatform="Native"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
+    <name><%- nameCamelCase %></name>
+    <description><%- description %></description>
+    <icon>
+        iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAABp1BMVEUAAABV//9mzP9LtP9Ms/9Jtv9NsvdJsfpLtPpJsfdJsfhJsvhJsvdKsvdJsPhKsPhJsfdJsPhJsfdIsfhJsfdIsPdJsfhJsfhJsPhJsPhIsfhIsPdJsPdKsPdKsfdNsvdOsvdPs/dQs/dRtPdStPdTtPdUtfdWtvdXtvdauPdcuPdeufdeufhguvhiu/hju/hkvPhmvfhnvfhpvvhrv/huwPhvwfhxwfhywvhzwvh4xfl5xfl6xfl8xvl9xvl9x/mByPmCyfmFyvmGyvmJzPmKzPmLzfmNzvqPzvqQz/qT0PqU0PqU0fqX0vqY0vqa0/qe1fqg1vqj1/uk1/un2fup2vut2/uv3Puw3Puw3fuz3vu13/u23/u34Pu44Pu64fu64fy84vy94vy+4/y/4/zD5fzE5fzG5vzH5vzI5/zK6PzL6PzR6/zT7P3U7P3V7f3W7f3Y7v3Z7v3c8P3e8f3f8f3g8f3i8v3l8/3l9P3n9P3r9v7t9/7u9/7v+P7w+P7x+f7y+f70+v71+v74/P75/P76/f77/f78/f78/v79/v7+/v7////6dMsRAAAAG3RSTlMAAwURGxwhMTNic3SEh4iVp7XBzejt7vH5/f6PsMNWAAABsklEQVR4AWIYfGAUjIJRMAqYuYREJKWJAqLCPGwY+jnFpEkBEryMqPr5pEkFgkwo9kuTDviR/S9GhgFSHAgDuKXJAQIIA4TIMkAcEY4i0mQBVrgBkuQZwA43QJo8wIFhQEhEOIBQOutHJozDOP5Crp4e1RhkJ0tKGJFd6oNEdtmJyEIzpaZl5nrRZgaHM/2Pf5/vwXXfyagXgG93bwSAlEolowLMm9w83gibhXH2gKKVdD67gTnWjwCk+VVjMQS4suSnnjMLRVFc9sAHvAX2A9fySaXNBMbEZVUWscaHIMRuqwBgD8hDEbnsRmfjUKJkAQZGCTlO/xWBwIADQLIZBlY441MvfoF1xlFS/4fy+bzXKh4dgNJE7L3eh3tmtuWa+AMcMIY3dgUvZQpGEYmMw2kD7HC+R29UqyoXLaBd0QZxzgXgikLLDSqJTKU5HOcS0MsbA9jPqtwCRvXm2eorBbNIJBw3KJ9O4Yl+AAXdnyaLt7PWN3jRWLvzmAVp94zO5+n41/onfo/UpExxZqI0O7NQr0DhIq9Io7hQpbRYp7hiobRqo6ByFcNWuY6CUTAKRgEAo8X0lBD3V30AAAAASUVORK5CYII=
+    </icon>
+    <properties>
+        <propertyGroup caption="General">
+            <property key="value" type="attribute" required="false">
+                <caption>Value</caption>
+                <description>The attribute that contains the value for the badge</description>
+                <attributeTypes>
+                    <attributeType name="String"/>
+                    <attributeType name="Enum"/>
+                    <attributeType name="Integer"/>
+                    <attributeType name="Decimal"/>
+                    <attributeType name="Long"/>
+                </attributeTypes>
+            </property>
+        </propertyGroup>
+        <propertyGroup caption="Events">
+            <property key="onClick" type="action" required="false">
+                <caption>On click</caption>
+                <description>Action to trigger when the badge is clicked</description>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/components/Badge.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/components/Badge.jsx.ejs
@@ -1,0 +1,31 @@
+import { createElement } from "react";
+import { Platform, Text, TouchableNativeFeedback, TouchableOpacity, View } from "react-native";
+
+import { mergeNativeStyles } from "@mendix/pluggable-widgets-tools";
+
+import { defaultBadgeStyle } from "../ui/styles";
+
+export function Badge(props) {
+    const styles = mergeNativeStyles(defaultBadgeStyle, props.style);
+
+    const Touchable = Platform.OS === "android" ? TouchableNativeFeedback : TouchableOpacity;
+
+    const renderContent = () => {
+        const text = <Text style={styles.label}>{props.value}</Text>;
+
+        if (Platform.OS === "android") {
+            return <View style={styles.badge}>{text}</View>;
+        }
+
+        return text;
+    };
+
+    return (
+        <View style={styles.container}>
+            <Touchable style={styles.badge} onPress={props.onClick} useForeground={true}>
+                {renderContent()}
+            </Touchable>
+        </View>
+    );
+
+} 

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/components/Badge.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/components/Badge.jsx.ejs
@@ -1,4 +1,4 @@
-import { createElement } from "react";
+import { createElement, useMemo } from "react";
 import { Platform, Text, TouchableNativeFeedback, TouchableOpacity, View } from "react-native";
 
 import { mergeNativeStyles } from "@mendix/pluggable-widgets-tools";
@@ -10,7 +10,7 @@ export function Badge({ value, style, onClick }) {
 
     const Touchable = Platform.OS === "android" ? TouchableNativeFeedback : TouchableOpacity;
 
-    const renderContent = () => {
+    const renderContent = useMemo(() => {
         const text = <Text style={styles.label}>{value}</Text>;
 
         if (Platform.OS === "android") {
@@ -18,12 +18,12 @@ export function Badge({ value, style, onClick }) {
         }
 
         return text;
-    };
+    }, [styles, value]);
 
     return (
         <View style={styles.container}>
             <Touchable style={styles.badge} onPress={onClick} useForeground={true}>
-                {renderContent()}
+                {renderContent}
             </Touchable>
         </View>
     );

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/components/Badge.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/components/Badge.jsx.ejs
@@ -5,13 +5,13 @@ import { mergeNativeStyles } from "@mendix/pluggable-widgets-tools";
 
 import { defaultBadgeStyle } from "../ui/styles";
 
-export function Badge(props) {
-    const styles = mergeNativeStyles(defaultBadgeStyle, props.style);
+export function Badge({ value, style, onClick }) {
+    const styles = mergeNativeStyles(defaultBadgeStyle, style);
 
     const Touchable = Platform.OS === "android" ? TouchableNativeFeedback : TouchableOpacity;
 
     const renderContent = () => {
-        const text = <Text style={styles.label}>{props.value}</Text>;
+        const text = <Text style={styles.label}>{value}</Text>;
 
         if (Platform.OS === "android") {
             return <View style={styles.badge}>{text}</View>;
@@ -22,7 +22,7 @@ export function Badge(props) {
 
     return (
         <View style={styles.container}>
-            <Touchable style={styles.badge} onPress={props.onClick} useForeground={true}>
+            <Touchable style={styles.badge} onPress={onClick} useForeground={true}>
                 {renderContent()}
             </Touchable>
         </View>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/components/__tests__/Badge.spec.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/components/__tests__/Badge.spec.jsx.ejs
@@ -1,0 +1,51 @@
+import { createElement } from "react";
+import { shallow } from "enzyme";
+import { Platform, TouchableNativeFeedback, TouchableOpacity } from "react-native";
+
+import { Badge } from "../Badge";
+
+describe.each(["ios", "android"])("Badge for %s", os => {
+    beforeEach(() => {
+        Platform.OS = os;
+        Platform.select = jest.fn(dict => dict[Platform.OS]);
+    });
+
+    it("renders the structure correctly", () => {
+        const badgeProps = {
+            style: [],
+            onClick: jest.fn(),
+            value: "0"
+        };
+        const badge = shallow(<Badge {...badgeProps} />);
+
+        expect(badge).toMatchSnapshot();
+    });
+
+    it("renders the structure correctly with custom style", () => {
+        const badgeProps = {
+            style: [{ container: { display: "flex" }, badge: { borderColor: "white" }, label: { color: "black" } }],
+            onClick: jest.fn(),
+            value: "0"
+        };
+        const badge = shallow(<Badge {...badgeProps} />);
+
+        expect(badge).toMatchSnapshot();
+    });
+
+    it("triggers the onClick action when pressed", () => {
+        const badgeProps = {
+            style: [],
+            onClick: jest.fn(),
+            value: "0"
+        };
+        const badge = shallow(<Badge {...badgeProps} />);
+
+        const Touchable = Platform.OS === "android" ? TouchableNativeFeedback : TouchableOpacity;
+
+        expect(badge.children().find(Touchable)).not.toBeNull();
+
+        badge.children().simulate("press");
+
+        expect(badgeProps.onClick).toHaveBeenCalled();
+    });
+});

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/package.xml.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/package.xml.ejs
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<package xmlns="http://www.mendix.com/package/1.0/">
+    <clientModule name="<%- name %>" version="<%- version %>" xmlns="http://www.mendix.com/clientModule/1.0/">
+        <widgetFiles>
+            <widgetFile path="<%- name %>.xml"/>
+        </widgetFiles>
+        <files>
+            <file path="<%- packagePathXml %>/<%- packageName %>"/>
+        </files>
+    </clientModule>
+</package>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/ui/styles.js
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/ui/styles.js
@@ -1,0 +1,22 @@
+export const defaultBadgeStyle = {
+    container: {
+        flexDirection: "row",
+        borderRadius: 30,
+        overflow: "hidden"
+    },
+    badge: {
+        borderRadius: 30,
+        paddingLeft: 10,
+        paddingRight: 10,
+        paddingTop: 5,
+        paddingBottom: 5,
+        backgroundColor: "#D9534F",
+        overflow: "hidden"
+    },
+    label: {
+        textAlign: "center",
+        fontSize: 15,
+        fontWeight: "bold",
+        color: "#FFFFFF"
+    }
+};

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/WidgetName.editorConfig.ts.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/WidgetName.editorConfig.ts.ejs
@@ -1,0 +1,57 @@
+import { <%- name %>PreviewProps } from "../typings/<%- name %>Props";
+
+type Properties = PropertyGroup[];
+
+type PropertyGroup = {
+    caption: string;
+    propertyGroups?: PropertyGroup[];
+    properties?: Property[];
+};
+
+type Property = {
+    key: string;
+    caption: string;
+    description?: string;
+    objectHeaders?: string[]; // used for customizing object grids
+    objects?: ObjectProperties[];
+    properties?: Properties[];
+};
+
+type Problem = {
+    property?: string; // key of the property, at which the problem exists
+    severity?: "error" | "warning" | "deprecation"; // default = "error"
+    message: string; // description of the problem
+    studioMessage?: string; // studio-specific message, defaults to message
+    url?: string; // link with more information about the problem
+    studioUrl?: string; // studio-specific link
+};
+
+type ObjectProperties = {
+    properties: PropertyGroup[];
+    captions?: string[]; // used for customizing object grids
+};
+
+export function getProperties(_values: <%- name %>PreviewProps, defaultProperties: Properties): Properties {
+    // Do the values manipulation here to control the visibility of properties in Studio and Studio Pro conditionally.
+    /* Example
+    if (values.myProperty === "custom") {
+        delete defaultProperties.properties.myOtherProperty;
+    }
+    */
+    return defaultProperties;
+}
+
+export function check(_values: <%- name %>PreviewProps): Problem[] {
+    const errors: Problem[] = [];
+    // Add errors to the above array to throw errors in Studio and Studio Pro.
+    /* Example
+    if (values.myProperty !== "custom") {
+        errors.push({
+            property: `myProperty`,
+            message: `The value of 'myProperty' is different of 'custom'.`,
+            url: "https://github.com/myrepo/mywidget"
+        });
+    }
+    */
+    return errors;
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/WidgetName.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/WidgetName.tsx.ejs
@@ -1,0 +1,23 @@
+import { ReactElement, createElement } from "react";
+
+import { Badge } from "./components/Badge";
+import { BadgeStyle } from "./ui/styles";
+import { <%- name %>Props } from "../typings/<%- name %>Props";
+
+export function <%- name %>(props: <%- name %>Props<BadgeStyle>): ReactElement | null {
+    const onClickHandler = (): void => {
+        const { onClick } = props;
+
+        if (onClick && onClick.canExecute && !onClick.isExecuting) {
+            onClick.execute();
+        }
+    };
+
+    return (
+        <Badge
+            style={props.style}
+            onClick={onClickHandler}
+            value={props.value?.displayValue || "Default"}
+        />
+    );
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/WidgetName.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/WidgetName.tsx.ejs
@@ -1,23 +1,21 @@
-import { ReactElement, createElement } from "react";
+import { ReactElement, createElement, useCallback } from "react";
 
 import { Badge } from "./components/Badge";
 import { BadgeStyle } from "./ui/styles";
 import { <%- name %>Props } from "../typings/<%- name %>Props";
 
-export function <%- name %>(props: <%- name %>Props<BadgeStyle>): ReactElement | null {
-    const onClickHandler = (): void => {
-        const { onClick } = props;
-
+export function <%- name %>({ value, style, onClick }: <%- name %>Props<BadgeStyle>): ReactElement {
+    const onClickHandler = useCallback(() => {
         if (onClick && onClick.canExecute && !onClick.isExecuting) {
             onClick.execute();
         }
-    };
+    }, [onClick]);
 
     return (
         <Badge
-            style={props.style}
+            style={style}
             onClick={onClickHandler}
-            value={props.value?.displayValue || "Default"}
+            value={value?.displayValue || "Default"}
         />
     );
 }

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/WidgetName.xml.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/WidgetName.xml.ejs
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<widget id="<%- packagePathXml %>.<%- packageName %>.<%- name %>" pluginWidget="true" needsEntityContext="true" offlineCapable="true"
+        supportedPlatform="Native"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
+    <name><%- nameCamelCase %></name>
+    <description><%- description %></description>
+    <icon>
+        iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAABp1BMVEUAAABV//9mzP9LtP9Ms/9Jtv9NsvdJsfpLtPpJsfdJsfhJsvhJsvdKsvdJsPhKsPhJsfdJsPhJsfdIsfhJsfdIsPdJsfhJsfhJsPhJsPhIsfhIsPdJsPdKsPdKsfdNsvdOsvdPs/dQs/dRtPdStPdTtPdUtfdWtvdXtvdauPdcuPdeufdeufhguvhiu/hju/hkvPhmvfhnvfhpvvhrv/huwPhvwfhxwfhywvhzwvh4xfl5xfl6xfl8xvl9xvl9x/mByPmCyfmFyvmGyvmJzPmKzPmLzfmNzvqPzvqQz/qT0PqU0PqU0fqX0vqY0vqa0/qe1fqg1vqj1/uk1/un2fup2vut2/uv3Puw3Puw3fuz3vu13/u23/u34Pu44Pu64fu64fy84vy94vy+4/y/4/zD5fzE5fzG5vzH5vzI5/zK6PzL6PzR6/zT7P3U7P3V7f3W7f3Y7v3Z7v3c8P3e8f3f8f3g8f3i8v3l8/3l9P3n9P3r9v7t9/7u9/7v+P7w+P7x+f7y+f70+v71+v74/P75/P76/f77/f78/f78/v79/v7+/v7////6dMsRAAAAG3RSTlMAAwURGxwhMTNic3SEh4iVp7XBzejt7vH5/f6PsMNWAAABsklEQVR4AWIYfGAUjIJRMAqYuYREJKWJAqLCPGwY+jnFpEkBEryMqPr5pEkFgkwo9kuTDviR/S9GhgFSHAgDuKXJAQIIA4TIMkAcEY4i0mQBVrgBkuQZwA43QJo8wIFhQEhEOIBQOutHJozDOP5Crp4e1RhkJ0tKGJFd6oNEdtmJyEIzpaZl5nrRZgaHM/2Pf5/vwXXfyagXgG93bwSAlEolowLMm9w83gibhXH2gKKVdD67gTnWjwCk+VVjMQS4suSnnjMLRVFc9sAHvAX2A9fySaXNBMbEZVUWscaHIMRuqwBgD8hDEbnsRmfjUKJkAQZGCTlO/xWBwIADQLIZBlY441MvfoF1xlFS/4fy+bzXKh4dgNJE7L3eh3tmtuWa+AMcMIY3dgUvZQpGEYmMw2kD7HC+R29UqyoXLaBd0QZxzgXgikLLDSqJTKU5HOcS0MsbA9jPqtwCRvXm2eorBbNIJBw3KJ9O4Yl+AAXdnyaLt7PWN3jRWLvzmAVp94zO5+n41/onfo/UpExxZqI0O7NQr0DhIq9Io7hQpbRYp7hiobRqo6ByFcNWuY6CUTAKRgEAo8X0lBD3V30AAAAASUVORK5CYII=
+    </icon>
+    <properties>
+        <propertyGroup caption="General">
+            <property key="value" type="attribute" required="false">
+                <caption>Value</caption>
+                <description>The attribute that contains the value for the badge</description>
+                <attributeTypes>
+                    <attributeType name="String"/>
+                    <attributeType name="Enum"/>
+                    <attributeType name="Integer"/>
+                    <attributeType name="Decimal"/>
+                    <attributeType name="Long"/>
+                </attributeTypes>
+            </property>
+        </propertyGroup>
+        <propertyGroup caption="Events">
+            <property key="onClick" type="action" required="false">
+                <caption>On click</caption>
+                <description>Action to trigger when the badge is clicked</description>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/components/Badge.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/components/Badge.tsx.ejs
@@ -1,4 +1,4 @@
-import { ReactElement, createElement, ElementType } from "react";
+import { ReactElement, createElement, ElementType, useMemo } from "react";
 import { Platform, Text, TouchableNativeFeedback, TouchableOpacity, View } from "react-native";
 
 import { mergeNativeStyles } from "@mendix/pluggable-widgets-tools";
@@ -16,7 +16,7 @@ export function Badge({ value, style, onClick }: BadgeProps): ReactElement {
 
     const Touchable: ElementType = Platform.OS === "android" ? TouchableNativeFeedback : TouchableOpacity;
 
-    const renderContent = (): ReactElement => {
+    const renderContent = useMemo(() => {
         const text = <Text style={styles.label}>{value}</Text>;
 
         if (Platform.OS === "android") {
@@ -24,12 +24,12 @@ export function Badge({ value, style, onClick }: BadgeProps): ReactElement {
         }
 
         return text;
-    };
+    }, [styles, value]);
 
     return (
         <View style={styles.container}>
             <Touchable style={styles.badge} onPress={onClick} useForeground={true}>
-                {renderContent()}
+                {renderContent}
             </Touchable>
         </View>
     );

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/components/Badge.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/components/Badge.tsx.ejs
@@ -11,13 +11,13 @@ export interface BadgeProps {
     onClick: () => void;
 }
 
-export function Badge(props: BadgeProps): ReactElement | null {
-    const styles = mergeNativeStyles(defaultBadgeStyle, props.style);
+export function Badge({ value, style, onClick }: BadgeProps): ReactElement {
+    const styles = mergeNativeStyles(defaultBadgeStyle, style);
 
     const Touchable: ElementType = Platform.OS === "android" ? TouchableNativeFeedback : TouchableOpacity;
 
     const renderContent = (): ReactElement => {
-        const text = <Text style={styles.label}>{props.value}</Text>;
+        const text = <Text style={styles.label}>{value}</Text>;
 
         if (Platform.OS === "android") {
             return <View style={styles.badge}>{text}</View>;
@@ -28,7 +28,7 @@ export function Badge(props: BadgeProps): ReactElement | null {
 
     return (
         <View style={styles.container}>
-            <Touchable style={styles.badge} onPress={props.onClick} useForeground={true}>
+            <Touchable style={styles.badge} onPress={onClick} useForeground={true}>
                 {renderContent()}
             </Touchable>
         </View>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/components/Badge.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/components/Badge.tsx.ejs
@@ -1,0 +1,37 @@
+import { ReactElement, createElement, ElementType } from "react";
+import { Platform, Text, TouchableNativeFeedback, TouchableOpacity, View } from "react-native";
+
+import { mergeNativeStyles } from "@mendix/pluggable-widgets-tools";
+
+import { BadgeStyle, defaultBadgeStyle } from "../ui/styles";
+
+export interface BadgeProps {
+    value: string;
+    style: BadgeStyle[];
+    onClick: () => void;
+}
+
+export function Badge(props: BadgeProps): ReactElement | null {
+    const styles = mergeNativeStyles(defaultBadgeStyle, props.style);
+
+    const Touchable: ElementType = Platform.OS === "android" ? TouchableNativeFeedback : TouchableOpacity;
+
+    const renderContent = (): ReactElement => {
+        const text = <Text style={styles.label}>{props.value}</Text>;
+
+        if (Platform.OS === "android") {
+            return <View style={styles.badge}>{text}</View>;
+        }
+
+        return text;
+    };
+
+    return (
+        <View style={styles.container}>
+            <Touchable style={styles.badge} onPress={props.onClick} useForeground={true}>
+                {renderContent()}
+            </Touchable>
+        </View>
+    );
+
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/components/__tests__/Badge.spec.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/components/__tests__/Badge.spec.tsx.ejs
@@ -1,0 +1,51 @@
+import { createElement } from "react";
+import { shallow } from "enzyme";
+import { Platform, TouchableNativeFeedback, TouchableOpacity } from "react-native";
+
+import { Badge, BadgeProps } from "../Badge";
+
+describe.each(["ios", "android"])("Badge for %s", (os: "ios" | "android") => {
+    beforeEach(() => {
+        Platform.OS = os;
+        Platform.select = jest.fn((dict: any) => dict[Platform.OS]);
+    });
+
+    it("renders the structure correctly", () => {
+        const badgeProps: BadgeProps = {
+            style: [],
+            onClick: jest.fn(),
+            value: "0"
+        };
+        const badge = shallow(<Badge {...badgeProps} />);
+
+        expect(badge).toMatchSnapshot();
+    });
+
+    it("renders the structure correctly with custom style", () => {
+        const badgeProps: BadgeProps = {
+            style: [{ container: { display: "flex" }, badge: { borderColor: "white" }, label: { color: "black" } }],
+            onClick: jest.fn(),
+            value: "0"
+        };
+        const badge = shallow(<Badge {...badgeProps} />);
+
+        expect(badge).toMatchSnapshot();
+    });
+
+    it("triggers the onClick action when pressed", () => {
+        const badgeProps: BadgeProps = {
+            style: [],
+            onClick: jest.fn(),
+            value: "0"
+        };
+        const badge = shallow(<Badge {...badgeProps} />);
+
+        const Touchable = Platform.OS === "android" ? TouchableNativeFeedback : TouchableOpacity;
+
+        expect(badge.children().find(Touchable)).not.toBeNull();
+
+        badge.children().simulate("press");
+
+        expect(badgeProps.onClick).toHaveBeenCalled();
+    });
+});

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/package.xml.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/package.xml.ejs
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<package xmlns="http://www.mendix.com/package/1.0/">
+    <clientModule name="<%- name %>" version="<%- version %>" xmlns="http://www.mendix.com/clientModule/1.0/">
+        <widgetFiles>
+            <widgetFile path="<%- name %>.xml"/>
+        </widgetFiles>
+        <files>
+            <file path="<%- packagePathXml %>/<%- packageName %>"/>
+        </files>
+    </clientModule>
+</package>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/ui/styles.ts
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/ui/styles.ts
@@ -1,0 +1,32 @@
+import { TextStyle, ViewStyle } from "react-native";
+
+import { Style } from "@mendix/pluggable-widgets-tools";
+
+export interface BadgeStyle extends Style {
+    container: ViewStyle;
+    badge: ViewStyle;
+    label: TextStyle;
+}
+
+export const defaultBadgeStyle: BadgeStyle = {
+    container: {
+        flexDirection: "row",
+        borderRadius: 30,
+        overflow: "hidden"
+    },
+    badge: {
+        borderRadius: 30,
+        paddingLeft: 10,
+        paddingRight: 10,
+        paddingTop: 5,
+        paddingBottom: 5,
+        backgroundColor: "#D9534F",
+        overflow: "hidden"
+    },
+    label: {
+        textAlign: "center",
+        fontSize: 15,
+        fontWeight: "bold",
+        color: "#FFFFFF"
+    }
+};

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/WidgetName.editorConfig.js.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/WidgetName.editorConfig.js.ejs
@@ -1,0 +1,24 @@
+export function getProperties(values, defaultProperties) {
+    // Do the values manipulation here to control the visibility of properties in Studio and Studio Pro conditionally.
+    /* Example
+    if (values.myProperty === "custom") {
+        delete defaultProperties.properties.myOtherProperty;
+    }
+    */
+    return defaultProperties;
+}
+
+export function check(values) {
+    const errors = [];
+    // Add errors to the above array to throw errors in Studio and Studio Pro.
+    /* Example
+    if (values.myProperty !== "custom") {
+        errors.push({
+            property: `myProperty`,
+            message: `The value of 'myProperty' is different of 'custom'.`,
+            url: "https://github.com/myrepo/mywidget"
+        });
+    }
+    */
+    return errors;
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/WidgetName.editorPreview.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/WidgetName.editorPreview.jsx.ejs
@@ -1,0 +1,10 @@
+import { createElement } from "react";
+import { HelloWorldSample } from "./components/HelloWorldSample";
+
+export function preview({ sampleText }) {
+    return <HelloWorldSample sampleText={sampleText} />;
+}
+
+export function getPreviewCss() {
+    return require("./ui/<%- name %>.css");
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/WidgetName.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/WidgetName.jsx.ejs
@@ -3,6 +3,6 @@ import { createElement } from "react";
 import { HelloWorldSample } from "./components/HelloWorldSample";
 import "./ui/<%- name %>.css";
 
-export default function <%- name %>({ sampleText }) {
+export function <%- name %>({ sampleText }) {
     return <HelloWorldSample sampleText={sampleText} />;
 }

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/WidgetName.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/WidgetName.jsx.ejs
@@ -1,0 +1,8 @@
+import { createElement } from "react";
+
+import { HelloWorldSample } from "./components/HelloWorldSample";
+import "./ui/<%- name %>.css";
+
+export default function <%- name %>({ sampleText }) {
+    return <HelloWorldSample sampleText={sampleText} />;
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/WidgetName.xml.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/WidgetName.xml.ejs
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<widget id="<%- packagePathXml %>.<%- packageName %>.<%- name %>" pluginWidget="true" needsEntityContext="true" offlineCapable="true"
+        supportedPlatform="Web"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
+    <name><%- nameCamelCase %></name>
+    <description><%- description %></description>
+    <icon/>
+    <properties>
+        <propertyGroup caption="General">
+            <property key="sampleText" type="string" required="false">
+                <caption>Default value</caption>
+                <description>Sample text input</description>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/components/HelloWorldSample.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/components/HelloWorldSample.jsx.ejs
@@ -1,0 +1,5 @@
+import { createElement } from "react";
+
+export function HelloWorldSample({ sampleText }) {
+    return <div className="widget-hello-world">Hello {sampleText}</div>;
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/components/__tests__/HelloWorldSample.spec.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/components/__tests__/HelloWorldSample.spec.jsx.ejs
@@ -1,0 +1,21 @@
+import { createElement } from "react";
+import { shallow } from "enzyme";
+
+import { HelloWorldSample } from "../HelloWorldSample";
+
+describe("HelloWorldSample", () => {
+    const createHelloWorld = (props) => shallow(<HelloWorldSample {...props} />);
+
+    it("should render the structure correctly", () => {
+        const helloWorldProps = {
+            sampleText: "World"
+        };
+        const helloWorld = createHelloWorld(helloWorldProps);
+
+        expect(
+            helloWorld.equals(
+                <div className="widget-hello-world">Hello {helloWorldProps.sampleText}</div>
+            )
+        ).toEqual(true);
+    });
+});

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/package.xml.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/package.xml.ejs
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<package xmlns="http://www.mendix.com/package/1.0/">
+    <clientModule name="<%- name %>" version="<%- version %>" xmlns="http://www.mendix.com/clientModule/1.0/">
+        <widgetFiles>
+            <widgetFile path="<%- name %>.xml"/>
+        </widgetFiles>
+        <files>
+            <file path="<%- packagePathXml %>/<%- packageName %>"/>
+        </files>
+    </clientModule>
+</package>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/ui/WidgetName.css
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/ui/WidgetName.css
@@ -1,0 +1,6 @@
+/*
+Place your custom CSS here
+*/
+.widget-hello-world {
+
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/tests/e2e/WidgetName.spec.js.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/tests/e2e/WidgetName.spec.js.ejs
@@ -1,0 +1,14 @@
+const homepage = require("./pages/home.page");
+
+describe("<%- name %>", () => {
+    it("should render a div with text", () => {
+        homepage.open();
+
+        /**
+        * Create here your tests, Example:
+        * homepage.div().waitForVisible();
+        * const widgetValue = homepage.div().getText();
+        * expect(widgetValue).toContain("Hello ");
+        **/
+    });
+});

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/tests/e2e/pages/home.page.js.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/tests/e2e/pages/home.page.js.ejs
@@ -1,0 +1,13 @@
+class HomePage {
+
+    /**
+    * Create here your accessor to html elements. Example:
+    * div() { return $(".widget-name div"); }
+    **/
+
+    open() {
+        browser.url("/");
+    }
+}
+const homepage = new HomePage();
+module.exports = homepage;

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTs/src/WidgetName.editorPreview.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTs/src/WidgetName.editorPreview.tsx.ejs
@@ -2,7 +2,6 @@ import { Component, ReactNode, createElement } from "react";
 import { HelloWorldSample } from "./components/HelloWorldSample";
 import { <%- name %>PreviewProps } from "../typings/<%- name %>Props";
 
-declare function require(name: string): string;
 
 export class preview extends Component<<%- name %>PreviewProps> {
     render(): ReactNode {

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.editorConfig.ts.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.editorConfig.ts.ejs
@@ -1,0 +1,57 @@
+import { <%- name %>PreviewProps } from "../typings/<%- name %>Props";
+
+type Properties = PropertyGroup[];
+
+type PropertyGroup = {
+    caption: string;
+    propertyGroups?: PropertyGroup[];
+    properties?: Property[];
+};
+
+type Property = {
+    key: string;
+    caption: string;
+    description?: string;
+    objectHeaders?: string[]; // used for customizing object grids
+    objects?: ObjectProperties[];
+    properties?: Properties[];
+};
+
+type Problem = {
+    property?: string; // key of the property, at which the problem exists
+    severity?: "error" | "warning" | "deprecation"; // default = "error"
+    message: string; // description of the problem
+    studioMessage?: string; // studio-specific message, defaults to message
+    url?: string; // link with more information about the problem
+    studioUrl?: string; // studio-specific link
+};
+
+type ObjectProperties = {
+    properties: PropertyGroup[];
+    captions?: string[]; // used for customizing object grids
+};
+
+export function getProperties(_values: <%- name %>PreviewProps, defaultProperties: Properties): Properties {
+    // Do the values manipulation here to control the visibility of properties in Studio and Studio Pro conditionally.
+    /* Example
+    if (values.myProperty === "custom") {
+        delete defaultProperties.properties.myOtherProperty;
+    }
+    */
+    return defaultProperties;
+}
+
+export function check(_values: <%- name %>PreviewProps): Problem[] {
+    const errors: Problem[] = [];
+    // Add errors to the above array to throw errors in Studio and Studio Pro.
+    /* Example
+    if (values.myProperty !== "custom") {
+        errors.push({
+            property: `myProperty`,
+            message: `The value of 'myProperty' is different of 'custom'.`,
+            url: "https://github.com/myrepo/mywidget"
+        });
+    }
+    */
+    return errors;
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.editorPreview.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.editorPreview.tsx.ejs
@@ -2,9 +2,7 @@ import { ReactElement, createElement } from "react";
 import { HelloWorldSample } from "./components/HelloWorldSample";
 import { <%- name %>PreviewProps } from "../typings/<%- name %>Props";
 
-declare function require(name: string): string;
-
-export function preview({ sampleText }: <%- name %>PreviewProps): ReactElement | null {
+export function preview({ sampleText }: <%- name %>PreviewProps): ReactElement {
     return <HelloWorldSample sampleText={sampleText} />;
 }
 

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.editorPreview.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.editorPreview.tsx.ejs
@@ -1,12 +1,12 @@
-import { FC, createElement } from "react";
+import { ReactElement, createElement } from "react";
 import { HelloWorldSample } from "./components/HelloWorldSample";
 import { <%- name %>PreviewProps } from "../typings/<%- name %>Props";
 
 declare function require(name: string): string;
 
-export const preview: FC<<%- name %>PreviewProps> = ({ sampleText }) => {
+export function preview({ sampleText }: <%- name %>PreviewProps): ReactElement | null {
     return <HelloWorldSample sampleText={sampleText} />;
-};
+}
 
 export function getPreviewCss(): string {
     return require("./ui/<%- name %>.css");

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.editorPreview.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.editorPreview.tsx.ejs
@@ -1,0 +1,13 @@
+import { FC, createElement } from "react";
+import { HelloWorldSample } from "./components/HelloWorldSample";
+import { <%- name %>PreviewProps } from "../typings/<%- name %>Props";
+
+declare function require(name: string): string;
+
+export const preview: FC<<%- name %>PreviewProps> = ({ sampleText }) => {
+    return <HelloWorldSample sampleText={sampleText} />;
+};
+
+export function getPreviewCss(): string {
+    return require("./ui/<%- name %>.css");
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.tsx.ejs
@@ -1,0 +1,12 @@
+import { FC, createElement } from "react";
+import { HelloWorldSample } from "./components/HelloWorldSample";
+
+import { <%- name %>ContainerProps } from "../typings/<%- name %>Props";
+
+import "./ui/<%- name %>.css";
+
+const <%- name %>: FC<<%- name %>ContainerProps> = ({ sampleText }) => {
+    return <HelloWorldSample sampleText={sampleText ? sampleText : "World"} />;
+};
+
+export default <%- name %>;

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.tsx.ejs
@@ -5,6 +5,6 @@ import { <%- name %>ContainerProps } from "../typings/<%- name %>Props";
 
 import "./ui/<%- name %>.css";
 
-export default function <%- name %>({ sampleText }: <%- name %>ContainerProps): ReactElement | null {
+export function <%- name %>({ sampleText }: <%- name %>ContainerProps): ReactElement {
     return <HelloWorldSample sampleText={sampleText ? sampleText : "World"} />;
 }

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.tsx.ejs
@@ -1,12 +1,10 @@
-import { FC, createElement } from "react";
+import { ReactElement, createElement } from "react";
 import { HelloWorldSample } from "./components/HelloWorldSample";
 
 import { <%- name %>ContainerProps } from "../typings/<%- name %>Props";
 
 import "./ui/<%- name %>.css";
 
-const <%- name %>: FC<<%- name %>ContainerProps> = ({ sampleText }) => {
+export default function <%- name %>({ sampleText }: <%- name %>ContainerProps): ReactElement | null {
     return <HelloWorldSample sampleText={sampleText ? sampleText : "World"} />;
-};
-
-export default <%- name %>;
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.xml.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.xml.ejs
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<widget id="<%- packagePathXml %>.<%- packageName %>.<%- name %>" pluginWidget="true" needsEntityContext="true" offlineCapable="true"
+        supportedPlatform="Web"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
+    <name><%- nameCamelCase %></name>
+    <description><%- description %></description>
+    <icon/>
+    <properties>
+        <propertyGroup caption="General">
+            <property key="sampleText" type="string" required="false">
+                <caption>Default value</caption>
+                <description>Sample text input</description>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/components/HelloWorldSample.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/components/HelloWorldSample.tsx.ejs
@@ -4,6 +4,6 @@ export interface HelloWorldSampleProps {
     sampleText?: string;
 }
 
-export function HelloWorldSample({ sampleText }: HelloWorldSampleProps): ReactElement | null {
+export function HelloWorldSample({ sampleText }: HelloWorldSampleProps): ReactElement {
     return <div className="widget-hello-world">Hello {sampleText}</div>;
 }

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/components/HelloWorldSample.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/components/HelloWorldSample.tsx.ejs
@@ -1,9 +1,9 @@
-import { FC, createElement } from "react";
+import { ReactElement, createElement } from "react";
 
 export interface HelloWorldSampleProps {
     sampleText?: string;
 }
 
-export const HelloWorldSample: FC<HelloWorldSampleProps> = ({ sampleText }) => {
+export function HelloWorldSample({ sampleText }: HelloWorldSampleProps): ReactElement | null {
     return <div className="widget-hello-world">Hello {sampleText}</div>;
-};
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/components/HelloWorldSample.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/components/HelloWorldSample.tsx.ejs
@@ -1,0 +1,9 @@
+import { FC, createElement } from "react";
+
+export interface HelloWorldSampleProps {
+    sampleText?: string;
+}
+
+export const HelloWorldSample: FC<HelloWorldSampleProps> = ({ sampleText }) => {
+    return <div className="widget-hello-world">Hello {sampleText}</div>;
+};

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/components/__tests__/HelloWorldSample.spec.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/components/__tests__/HelloWorldSample.spec.tsx.ejs
@@ -1,0 +1,22 @@
+import { createElement } from "react";
+import { shallow, ShallowWrapper } from "enzyme";
+
+import { HelloWorldSample, HelloWorldSampleProps } from "../HelloWorldSample";
+
+describe("HelloWorldSample", () => {
+    const createHelloWorld = (props: HelloWorldSampleProps): ShallowWrapper => shallow(<HelloWorldSample {...props} />);
+
+    it("should render the structure correctly", () => {
+        const helloWorldProps: HelloWorldSampleProps = {
+            sampleText: "World"
+        };
+
+        const helloWorld = createHelloWorld(helloWorldProps);
+
+        expect(
+            helloWorld.equals(
+                <div className="widget-hello-world">Hello {helloWorldProps.sampleText}</div>
+            )
+        ).toEqual(true);
+    });
+});

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/package.xml.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/package.xml.ejs
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<package xmlns="http://www.mendix.com/package/1.0/">
+    <clientModule name="<%- name %>" version="<%- version %>" xmlns="http://www.mendix.com/clientModule/1.0/">
+        <widgetFiles>
+            <widgetFile path="<%- name %>.xml"/>
+        </widgetFiles>
+        <files>
+            <file path="<%- packagePathXml %>/<%- packageName %>"/>
+        </files>
+    </clientModule>
+</package>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/ui/WidgetName.css
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/ui/WidgetName.css
@@ -1,0 +1,6 @@
+/*
+Place your custom CSS here
+*/
+.widget-hello-world {
+
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/tests/e2e/WidgetName.spec.ts.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/tests/e2e/WidgetName.spec.ts.ejs
@@ -1,0 +1,14 @@
+import homepage from "./pages/home.page";
+
+describe("<%- name %>", () => {
+    it("should render a div with text", () => {
+        homepage.open();
+
+        /**
+         * Create your tests here. Example:
+         * homepage.div.waitForVisible();
+         * const widgetValue = homepage.div.getText();
+         * expect(widgetValue).toContain("Hello ");
+         */
+    });
+});

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/tests/e2e/pages/home.page.ts.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/tests/e2e/pages/home.page.ts.ejs
@@ -1,0 +1,13 @@
+class HomePage {
+
+    /**
+     * Create your accessors to html elements here. Example:
+     * public get div() { return $(".widget-name div"); }
+     */
+
+    public open(): void {
+        browser.url("/");
+    }
+}
+const homepage = new HomePage();
+export default homepage;

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/tests/e2e/tsconfig.json
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/tests/e2e/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+      "target": "es6",
+      "module": "commonjs",
+      "moduleResolution": "node",
+      "emitDecoratorMetadata": true,
+      "experimentalDecorators": true,
+      "removeComments": true,
+      "noImplicitAny": false,
+      "outDir": "../../dist/e2e",
+      "types": [
+        "jasmine",
+        "@wdio/sync"
+      ]
+    },
+    "exclude": [
+      "node_modules"
+    ],
+    "compileOnSave": false
+  }

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/tests/e2e/tsconfig.json
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/tests/e2e/tsconfig.json
@@ -1,20 +1,15 @@
 {
-    "compilerOptions": {
-      "target": "es6",
-      "module": "commonjs",
-      "moduleResolution": "node",
-      "emitDecoratorMetadata": true,
-      "experimentalDecorators": true,
-      "removeComments": true,
-      "noImplicitAny": false,
-      "outDir": "../../dist/e2e",
-      "types": [
-        "jasmine",
-        "@wdio/sync"
-      ]
-    },
-    "exclude": [
-      "node_modules"
-    ],
-    "compileOnSave": false
-  }
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "types": ["node", "webdriverio/sync", "@wdio/jasmine-framework", "wdio-image-comparison-service", "@wdio/devtools-service"],
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "removeComments": true,
+    "noImplicitAny": false,
+    "outDir": "../../dist/e2e"
+  },
+  "exclude": ["node_modules"],
+  "compileOnSave": false
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJs/src/components/Alert.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJs/src/components/Alert.jsx.ejs
@@ -1,9 +1,10 @@
-import { createElement } from "react";
+import { Component, ReactNode, createElement } from "react";
 import classNames from "classnames";
 
-export const Alert = ({ className, bootstrapStyle, message }) =>
-    message
-        ? (<div className={classNames(`alert alert-${bootstrapStyle}`, className)}>{message}</div>)
-        : null;
-
-Alert.displayName = "Alert";
+export class Alert extends Component {
+    render() {
+        return this.props.message
+            ? (<div className={classNames(`alert alert-${this.props.bootstrapStyle}`, this.props.className)}>{this.props.message}</div>)
+            : null;
+    }
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/WidgetName.editorConfig.js.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/WidgetName.editorConfig.js.ejs
@@ -1,0 +1,24 @@
+export function getProperties(values, defaultProperties) {
+    // Do the values manipulation here to control the visibility of properties in Studio and Studio Pro conditionally.
+    /* Example
+    if (values.myProperty === "custom") {
+        delete defaultProperties.properties.myOtherProperty;
+    }
+    */
+    return defaultProperties;
+}
+
+export function check(values) {
+    const errors = [];
+    // Add errors to the above array to throw errors in Studio and Studio Pro.
+    /* Example
+    if (values.myProperty !== "custom") {
+        errors.push({
+            property: `myProperty`,
+            message: `The value of 'myProperty' is different of 'custom'.`,
+            url: "https://github.com/myrepo/mywidget"
+        });
+    }
+    */
+    return errors;
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/WidgetName.editorPreview.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/WidgetName.editorPreview.jsx.ejs
@@ -1,0 +1,38 @@
+import { createElement } from "react";
+
+import { parseInlineStyle } from "@mendix/pluggable-widgets-tools";
+
+import { BadgeSample } from "./components/BadgeSample";
+
+function parentInline(node) {
+    // Temporary fix, the web modeler add a containing div, to render inline we need to change it.
+    if (node && node.parentElement && node.parentElement.parentElement) {
+        node.parentElement.parentElement.style.display = "inline-block";
+    }
+}
+
+function transformProps(props) {
+    return {
+        type: props.<%- packageName %>Type,
+        bootstrapStyle: props.bootstrapStyle,
+        className: props.className,
+        clickable: false,
+        style: parseInlineStyle(props.style),
+        defaultValue: props.<%- packageName %>Value ? props.<%- packageName %>Value : "",
+        value: props.valueAttribute
+    };
+}
+
+
+export function preview(props) {
+    return (
+        <div ref={parentInline}>
+            <BadgeSample {...transformProps(this.props)}></BadgeSample>
+        </div>
+    );
+}
+
+export function getPreviewCss() {
+    return require("./ui/<%- name %>.css");
+}
+

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/WidgetName.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/WidgetName.jsx.ejs
@@ -1,24 +1,25 @@
-import { createElement } from "react";
+import { createElement, useCallback } from "react";
 
 import { BadgeSample } from "./components/BadgeSample";
 import "./ui/<%- name %>.css";
 
-export default function <%- name %>(props) {
-    const onClick = () => {
-        if (props.onClickAction && props.onClickAction.canExecute) {
-            props.onClickAction.execute();
+export function <%- name %>(props) {
+    const { <%- packageName %>Type, <%- packageName %>Value, valueAttribute, onClickAction, style, bootstrapStyle } = props;
+    const onClickHandler = useCallback(() => {
+        if (onClickAction && onClickAction.canExecute) {
+            onClickAction.execute();
         }
-    };
+    }, [onClickAction]);
 
     return (
         <BadgeSample
-            type={props.<%- packageName %>Type}
-            bootstrapStyle={props.bootstrapStyle}
+            type={<%- packageName %>Type}
+            bootstrapStyle={bootstrapStyle}
             className={props.class}
-            clickable={!!props.onClickAction}
-            defaultValue={props.<%- packageName %>Value ? props.<%- packageName %>Value : ""}
-            onClickAction={onClick}
-            style={props.style}
-            value={props.valueAttribute ? props.valueAttribute.displayValue : ""} />
+            clickable={!!onClickAction}
+            defaultValue={<%- packageName %>Value ? <%- packageName %>Value : ""}
+            onClickAction={onClickHandler}
+            style={style}
+            value={valueAttribute ? valueAttribute.displayValue : ""} />
     );
 }

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/WidgetName.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/WidgetName.jsx.ejs
@@ -1,0 +1,24 @@
+import { createElement } from "react";
+
+import { BadgeSample } from "./components/BadgeSample";
+import "./ui/<%- name %>.css";
+
+export default function <%- name %>(props) {
+    const onClick = () => {
+        if (props.onClickAction && props.onClickAction.canExecute) {
+            props.onClickAction.execute();
+        }
+    };
+
+    return (
+        <BadgeSample
+            type={props.<%- packageName %>Type}
+            bootstrapStyle={props.bootstrapStyle}
+            className={props.class}
+            clickable={!!props.onClickAction}
+            defaultValue={props.<%- packageName %>Value ? props.<%- packageName %>Value : ""}
+            onClickAction={onClick}
+            style={props.style}
+            value={props.valueAttribute ? props.valueAttribute.displayValue : ""} />
+    );
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/WidgetName.xml.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/WidgetName.xml.ejs
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<widget id="<%- packagePathXml %>.<%- packageName %>.<%- name %>" pluginWidget="true" needsEntityContext="true" offlineCapable="true"
+        supportedPlatform="Web"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
+    <name><%- nameCamelCase %></name>
+    <description><%- description %></description>
+    <icon>
+        iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAABp1BMVEUAAABV//9mzP9LtP9Ms/9Jtv9NsvdJsfpLtPpJsfdJsfhJsvhJsvdKsvdJsPhKsPhJsfdJsPhJsfdIsfhJsfdIsPdJsfhJsfhJsPhJsPhIsfhIsPdJsPdKsPdKsfdNsvdOsvdPs/dQs/dRtPdStPdTtPdUtfdWtvdXtvdauPdcuPdeufdeufhguvhiu/hju/hkvPhmvfhnvfhpvvhrv/huwPhvwfhxwfhywvhzwvh4xfl5xfl6xfl8xvl9xvl9x/mByPmCyfmFyvmGyvmJzPmKzPmLzfmNzvqPzvqQz/qT0PqU0PqU0fqX0vqY0vqa0/qe1fqg1vqj1/uk1/un2fup2vut2/uv3Puw3Puw3fuz3vu13/u23/u34Pu44Pu64fu64fy84vy94vy+4/y/4/zD5fzE5fzG5vzH5vzI5/zK6PzL6PzR6/zT7P3U7P3V7f3W7f3Y7v3Z7v3c8P3e8f3f8f3g8f3i8v3l8/3l9P3n9P3r9v7t9/7u9/7v+P7w+P7x+f7y+f70+v71+v74/P75/P76/f77/f78/f78/v79/v7+/v7////6dMsRAAAAG3RSTlMAAwURGxwhMTNic3SEh4iVp7XBzejt7vH5/f6PsMNWAAABsklEQVR4AWIYfGAUjIJRMAqYuYREJKWJAqLCPGwY+jnFpEkBEryMqPr5pEkFgkwo9kuTDviR/S9GhgFSHAgDuKXJAQIIA4TIMkAcEY4i0mQBVrgBkuQZwA43QJo8wIFhQEhEOIBQOutHJozDOP5Crp4e1RhkJ0tKGJFd6oNEdtmJyEIzpaZl5nrRZgaHM/2Pf5/vwXXfyagXgG93bwSAlEolowLMm9w83gibhXH2gKKVdD67gTnWjwCk+VVjMQS4suSnnjMLRVFc9sAHvAX2A9fySaXNBMbEZVUWscaHIMRuqwBgD8hDEbnsRmfjUKJkAQZGCTlO/xWBwIADQLIZBlY441MvfoF1xlFS/4fy+bzXKh4dgNJE7L3eh3tmtuWa+AMcMIY3dgUvZQpGEYmMw2kD7HC+R29UqyoXLaBd0QZxzgXgikLLDSqJTKU5HOcS0MsbA9jPqtwCRvXm2eorBbNIJBw3KJ9O4Yl+AAXdnyaLt7PWN3jRWLvzmAVp94zO5+n41/onfo/UpExxZqI0O7NQr0DhIq9Io7hQpbRYp7hiobRqo6ByFcNWuY6CUTAKRgEAo8X0lBD3V30AAAAASUVORK5CYII=
+    </icon>
+    <properties>
+        <propertyGroup caption="General">
+            <property key="valueAttribute" type="attribute" required="false">
+                <caption>Value attribute</caption>
+                <description>The attribute that contains the <%- packageName %> value</description>
+                <attributeTypes>
+                    <attributeType name="String"/>
+                    <attributeType name="Enum"/>
+                    <attributeType name="Integer"/>
+                    <attributeType name="Decimal"/>
+                    <attributeType name="Long"/>
+                </attributeTypes>
+            </property>
+            <property key="<%- packageName %>Value" type="string" required="false">
+                <caption>Default value</caption>
+                <description>The <%- packageName %> value shown when no value is provided via the attribute</description>
+            </property>
+        </propertyGroup>
+        <propertyGroup caption="Display">
+            <property key="bootstrapStyle" type="enumeration" defaultValue="default">
+                <caption><%- name %> style</caption>
+                <description>The appearance of the <%- packageName %></description>
+                <enumerationValues>
+                    <enumerationValue key="default">Default</enumerationValue>
+                    <enumerationValue key="primary">Primary</enumerationValue>
+                    <enumerationValue key="success">Success</enumerationValue>
+                    <enumerationValue key="info">Info</enumerationValue>
+                    <enumerationValue key="inverse">Inverse</enumerationValue>
+                    <enumerationValue key="warning">Warning</enumerationValue>
+                    <enumerationValue key="danger">Danger</enumerationValue>
+                </enumerationValues>
+            </property>
+            <property key="<%- packageName %>Type" type="enumeration" required="true" defaultValue="badge">
+                <caption>Type</caption>
+                <description>Render it as either a badge or a color label</description>
+                <enumerationValues>
+                    <enumerationValue key="badge">Badge</enumerationValue>
+                    <enumerationValue key="label">Label</enumerationValue>
+                </enumerationValues>
+            </property>
+        </propertyGroup>
+        <propertyGroup caption="Events">
+            <property key="onClickAction" type="action" required="false">
+                <caption>On click action</caption>
+                <description>Action to trigger when button / label is clicked</description>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/components/Alert.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/components/Alert.jsx.ejs
@@ -1,0 +1,9 @@
+import { createElement } from "react";
+import classNames from "classnames";
+
+export const Alert = ({ className, bootstrapStyle, message }) =>
+    message
+        ? (<div className={classNames(`alert alert-${bootstrapStyle}`, className)}>{message}</div>)
+        : null;
+
+Alert.displayName = "Alert";

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/components/Alert.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/components/Alert.jsx.ejs
@@ -1,9 +1,8 @@
 import { createElement } from "react";
 import classNames from "classnames";
 
-export const Alert = ({ className, bootstrapStyle, message }) =>
-    message
+export function Alert({ className, bootstrapStyle, message }) {
+    return message
         ? (<div className={classNames(`alert alert-${bootstrapStyle}`, className)}>{message}</div>)
         : null;
-
-Alert.displayName = "Alert";
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/components/BadgeSample.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/components/BadgeSample.jsx.ejs
@@ -2,15 +2,18 @@ import { createElement } from "react";
 import classNames from "classnames";
 
 export function BadgeSample(props) {
+    const { type, defaultValue, className, style, value, bootstrapStyle, clickable, onClickAction, getRef } = props;
     return (
         <span
-            className={classNames("widget-<%- packageName %>", props.type, props.className, {
-                [`label-${props.bootstrapStyle}`]: !!props.bootstrapStyle,
-                "widget-<%- packageName %>-clickable": props.clickable
+            className={classNames("widget-jsf", type, className, {
+                [`label-${bootstrapStyle}`]: !!bootstrapStyle,
+                "widget-jsf-clickable": clickable
             })}
-            onClick={props.onClickAction}
-            ref={props.getRef}
-            style={props.style}
-        >{props.value || props.defaultValue}</span>
+            onClick={onClickAction}
+            ref={getRef}
+            style={style}
+        >
+            {value || defaultValue}
+        </span>
     );
 }

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/components/BadgeSample.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/components/BadgeSample.jsx.ejs
@@ -1,0 +1,16 @@
+import { createElement } from "react";
+import classNames from "classnames";
+
+export function BadgeSample(props) {
+    return (
+        <span
+            className={classNames("widget-<%- packageName %>", props.type, props.className, {
+                [`label-${props.bootstrapStyle}`]: !!props.bootstrapStyle,
+                "widget-<%- packageName %>-clickable": props.clickable
+            })}
+            onClick={props.onClickAction}
+            ref={props.getRef}
+            style={props.style}
+        >{props.value || props.defaultValue}</span>
+    );
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/components/BadgeSample.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/components/BadgeSample.jsx.ejs
@@ -5,9 +5,9 @@ export function BadgeSample(props) {
     const { type, defaultValue, className, style, value, bootstrapStyle, clickable, onClickAction, getRef } = props;
     return (
         <span
-            className={classNames("widget-jsf", type, className, {
+            className={classNames("widget-<%- packageName %>", type, className, {
                 [`label-${bootstrapStyle}`]: !!bootstrapStyle,
-                "widget-jsf-clickable": clickable
+                "widget-<%- packageName %>-clickable": clickable
             })}
             onClick={onClickAction}
             ref={getRef}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/components/__tests__/Alert.spec.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/components/__tests__/Alert.spec.jsx.ejs
@@ -1,0 +1,24 @@
+import { createElement } from "react";
+import { shallow } from "enzyme";
+
+import { Alert } from "../Alert";
+
+describe("Alert", () => {
+    it("renders the structure when an alert message is specified", () => {
+        const message = "This is an error";
+        const alert = shallow(<Alert
+            bootstrapStyle="danger"
+            className="widget-badge-alert"
+            message={message}/>);
+
+        expect(alert.equals(
+            <div className="alert alert-danger widget-badge-alert">{message}</div>
+        )).toEqual(true);
+    });
+
+    it("renders no structure when the alert message is not specified", () => {
+        const alert = shallow(<Alert bootstrapStyle="danger"/>);
+
+        expect(alert.isEmptyRender()).toEqual(true);
+    });
+});

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/components/__tests__/BadgeSample.spec.jsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/components/__tests__/BadgeSample.spec.jsx.ejs
@@ -1,0 +1,101 @@
+import { createElement } from "react";
+import { shallow } from "enzyme";
+
+import { BadgeSample } from "../BadgeSample";
+
+describe("Badge", () => {
+    const createBadge = (props) => shallow(<BadgeSample {...props} />);
+
+    it("should render the structure", () => {
+        const badgeProps = {
+            type: "badge",
+            bootstrapStyle: "default",
+            value: "0"
+        };
+        const badge = createBadge(badgeProps);
+
+        expect(
+            badge.equals(
+                <span className="widget-<%- packageName %> badge label-default">0</span>
+            )
+        ).toEqual(true);
+    });
+
+    it("should show value when no value or default value provided", () => {
+        const value = "value";
+        const badge = createBadge({ type: "label", value, defaultValue: "default value" });
+
+        expect(badge.text()).toBe(value);
+    });
+
+    it("should show default value when no value is provided", () => {
+        const defaultValue = "default";
+        const badge = createBadge({ type: "label", value: undefined, defaultValue });
+
+        expect(badge.text()).toBe(defaultValue);
+    });
+
+    it("should show no value when no value or default value provided", () => {
+        const badge = createBadge({ type: "label", value: undefined });
+
+        expect(badge.text()).toBe("");
+    });
+
+    it("configured as a label should have the class label", () => {
+        const badge = createBadge({ type: "label" });
+
+        expect(badge.hasClass("label")).toBe(true);
+    });
+
+    it("configured as a badge should have the class badge", () => {
+        const badge = createBadge({ type: "badge" });
+
+        expect(badge.hasClass("badge")).toBe(true);
+    });
+
+    it("with a click action should respond to click events", () => {
+        const badgeProps = { onClickAction: jest.fn(), type: "badge" };
+        const onClick = badgeProps.onClickAction = jest.fn();
+        const badge = createBadge(badgeProps);
+
+        badge.simulate("click");
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("with the Bootstrap style default should have the class label-default", () => {
+        const badge = createBadge({ bootstrapStyle: "default", type: "badge" });
+
+        expect(badge.hasClass("label-default")).toBe(true);
+    });
+
+    it("with the Bootstrap style primary should have the class label-primary", () => {
+        const badge = createBadge({ bootstrapStyle: "primary", type: "badge" });
+
+        expect(badge.hasClass("label-primary")).toBe(true);
+    });
+
+    it("with the Bootstrap style success should have the class label-success", () => {
+        const badge = createBadge({ bootstrapStyle: "success", type: "badge" });
+
+        expect(badge.hasClass("label-success")).toBe(true);
+    });
+
+    it("with the Bootstrap style info should have the class label-info", () => {
+        const badge = createBadge({ bootstrapStyle: "info", type: "badge" });
+
+        expect(badge.hasClass("label-info")).toBe(true);
+    });
+
+    it("with the Bootstrap style warning should have the class label-warning", () => {
+        const badge = createBadge({ bootstrapStyle: "warning", type: "badge" });
+
+        expect(badge.hasClass("label-warning")).toBe(true);
+    });
+
+    it("with the Bootstrap style danger should have the class label-danger", () => {
+        const badge = createBadge({ bootstrapStyle: "danger", type: "badge" });
+
+        expect(badge.hasClass("label-danger")).toBe(true);
+    });
+});

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/package.xml.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/package.xml.ejs
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<package xmlns="http://www.mendix.com/package/1.0/">
+    <clientModule name="<%- name %>" version="<%- version %>" xmlns="http://www.mendix.com/clientModule/1.0/">
+        <widgetFiles>
+            <widgetFile path="<%- name %>.xml"/>
+        </widgetFiles>
+        <files>
+            <file path="<%- packagePathXml %>/<%- packageName %>"/>
+        </files>
+    </clientModule>
+</package>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/ui/WidgetName.css.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/ui/WidgetName.css.ejs
@@ -1,0 +1,24 @@
+.widget-<%- packageName %>-clickable {
+    cursor: pointer;
+}
+
+.widget-<%- packageName %> {
+    display: inline-block;
+}
+
+.widget-<%- packageName %>.badge:empty {
+    display: initial;
+    /* Fix padding to stay round */
+    padding: 3px 10px;
+}
+
+.widget-<%- packageName %>.label:empty {
+    display: initial;
+    /* Fix padding to stay square */
+    padding: .2em .8em .3em;
+}
+
+.widget-<%- packageName %>.badge {
+    min-width: 18px;
+    min-height: 18px;
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/tests/e2e/WidgetName.spec.js.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/tests/e2e/WidgetName.spec.js.ejs
@@ -1,0 +1,17 @@
+const homepage = require("./pages/home.page");
+
+const badgeValue = "Badge";
+
+describe("<%- name %>", () => {
+    it("should render a badge with a caption", () => {
+        homepage.open();
+
+        /**
+        * Create here your tests, Example:
+        * homepage.badge().waitForVisible();
+        *
+        * const widgetValue = homepage.badge().getText();
+        * expect(widgetValue).toContain(badgeValue);
+        **/
+    });
+});

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/tests/e2e/pages/home.page.js.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/tests/e2e/pages/home.page.js.ejs
@@ -1,0 +1,15 @@
+class HomePage {
+
+    /**
+     * Create your accessors to html elements here. Example:
+     * badge() { return $(".widget-badge.badge.mx-name-badge1"); }
+     *
+     * label() { return $(".widget-badge.label.mx-name-badge7"); }
+     */
+
+    open() {
+        browser.url("/");
+    }
+}
+const homepage = new HomePage();
+module.exports = homepage;

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTs/src/WidgetName.editorPreview.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTs/src/WidgetName.editorPreview.tsx.ejs
@@ -5,8 +5,6 @@ import { parseInlineStyle } from "@mendix/pluggable-widgets-tools";
 import { BadgeSample, BadgeSampleProps } from "./components/BadgeSample";
 import { <%- name %>PreviewProps } from "../typings/<%- name %>Props";
 
-declare function require(name: string): string;
-
 export class preview extends Component<<%- name %>PreviewProps> {
     render(): ReactNode {
         return (

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTs/src/components/Alert.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTs/src/components/Alert.tsx.ejs
@@ -1,4 +1,4 @@
-import { FunctionComponent, createElement } from "react";
+import { Component, ReactNode, createElement } from "react";
 import classNames from "classnames";
 
 export interface AlertProps {
@@ -7,9 +7,10 @@ export interface AlertProps {
     bootstrapStyle: "default" | "primary" | "success" | "info" | "inverse" | "warning" | "danger";
 }
 
-export const Alert: FunctionComponent<AlertProps> = (props) =>
-    props.message
-        ? (<div className={classNames(`alert alert-${props.bootstrapStyle}`, props.className)}>{props.message}</div>)
-        : null;
-
-Alert.displayName = "Alert";
+export class Alert extends Component<AlertProps> {
+    render(): ReactNode {
+        return this.props.message
+            ? (<div className={classNames(`alert alert-${this.props.bootstrapStyle}`, this.props.className)}>{this.props.message}</div>)
+            : null;
+    }
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTs/src/components/BadgeSample.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTs/src/components/BadgeSample.tsx.ejs
@@ -1,11 +1,11 @@
-import { Component, ReactNode, createElement } from "react";
+import { Component, ReactNode, CSSProperties, createElement } from "react";
 import classNames from "classnames";
 
 export interface BadgeSampleProps {
     type: "badge" | "label";
     defaultValue?: string;
     className?: string;
-    style?: object;
+    style?: CSSProperties;
     value?: string;
     bootstrapStyle?: BootstrapStyle;
     clickable?: boolean;

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/WidgetName.editorConfig.ts.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/WidgetName.editorConfig.ts.ejs
@@ -1,0 +1,57 @@
+import { <%- name %>PreviewProps } from "../typings/<%- name %>Props";
+
+type Properties = PropertyGroup[];
+
+type PropertyGroup = {
+    caption: string;
+    propertyGroups?: PropertyGroup[];
+    properties?: Property[];
+};
+
+type Property = {
+    key: string;
+    caption: string;
+    description?: string;
+    objectHeaders?: string[]; // used for customizing object grids
+    objects?: ObjectProperties[];
+    properties?: Properties[];
+};
+
+type Problem = {
+    property?: string; // key of the property, at which the problem exists
+    severity?: "error" | "warning" | "deprecation"; // default = "error"
+    message: string; // description of the problem
+    studioMessage?: string; // studio-specific message, defaults to message
+    url?: string; // link with more information about the problem
+    studioUrl?: string; // studio-specific link
+};
+
+type ObjectProperties = {
+    properties: PropertyGroup[];
+    captions?: string[]; // used for customizing object grids
+};
+
+export function getProperties(_values: <%- name %>PreviewProps, defaultProperties: Properties): Properties {
+    // Do the values manipulation here to control the visibility of properties in Studio and Studio Pro conditionally.
+    /* Example
+    if (values.myProperty === "custom") {
+        delete defaultProperties.properties.myOtherProperty;
+    }
+    */
+    return defaultProperties;
+}
+
+export function check(_values: <%- name %>PreviewProps): Problem[] {
+    const errors: Problem[] = [];
+    // Add errors to the above array to throw errors in Studio and Studio Pro.
+    /* Example
+    if (values.myProperty !== "custom") {
+        errors.push({
+            property: `myProperty`,
+            message: `The value of 'myProperty' is different of 'custom'.`,
+            url: "https://github.com/myrepo/mywidget"
+        });
+    }
+    */
+    return errors;
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/WidgetName.editorPreview.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/WidgetName.editorPreview.tsx.ejs
@@ -5,8 +5,6 @@ import { parseInlineStyle } from "@mendix/pluggable-widgets-tools";
 import { BadgeSample, BadgeSampleProps } from "./components/BadgeSample";
 import { <%- name %>PreviewProps } from "../typings/<%- name %>Props";
 
-declare function require(name: string): string;
-
 function parentInline(node?: HTMLElement | null): void {
     // Temporary fix, the web modeler add a containing div, to render inline we need to change it.
     if (node && node.parentElement && node.parentElement.parentElement) {
@@ -26,7 +24,7 @@ function transformProps(props: <%- name %>PreviewProps): BadgeSampleProps {
     };
 }
 
-export function preview(props: <%- name %>PreviewProps): ReactElement | null {
+export function preview(props: <%- name %>PreviewProps): ReactElement {
     return (
         <div ref={parentInline}>
             <BadgeSample {...transformProps(props)}></BadgeSample>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/WidgetName.editorPreview.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/WidgetName.editorPreview.tsx.ejs
@@ -1,0 +1,39 @@
+import { ReactElement, createElement } from "react";
+
+import { parseInlineStyle } from "@mendix/pluggable-widgets-tools";
+
+import { BadgeSample, BadgeSampleProps } from "./components/BadgeSample";
+import { <%- name %>PreviewProps } from "../typings/<%- name %>Props";
+
+declare function require(name: string): string;
+
+function parentInline(node?: HTMLElement | null): void {
+    // Temporary fix, the web modeler add a containing div, to render inline we need to change it.
+    if (node && node.parentElement && node.parentElement.parentElement) {
+        node.parentElement.parentElement.style.display = "inline-block";
+    }
+}
+
+function transformProps(props: <%- name %>PreviewProps): BadgeSampleProps {
+    return {
+        type: props.<%- packageName %>Type,
+        bootstrapStyle: props.bootstrapStyle,
+        className: props.className,
+        clickable: false,
+        style: parseInlineStyle(props.style),
+        defaultValue: props.<%- packageName %>Value ? props.<%- packageName %>Value : "",
+        value: props.valueAttribute
+    };
+}
+
+export function preview(props: <%- name %>PreviewProps): ReactElement | null {
+    return (
+        <div ref={parentInline}>
+            <BadgeSample {...transformProps(props)}></BadgeSample>
+        </div>
+    );
+}
+
+export function getPreviewCss(): string {
+    return require("./ui/<%- name %>.css");
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/WidgetName.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/WidgetName.tsx.ejs
@@ -1,26 +1,26 @@
-import { ReactElement, createElement } from "react";
+import { ReactElement, createElement, useCallback } from "react";
 
 import { <%- name %>ContainerProps } from "../typings/<%- name %>Props";
 import { BadgeSample } from "./components/BadgeSample";
 import "./ui/<%- name %>.css";
 
-export default function <%- name %>(props: <%- name %>ContainerProps): ReactElement | null {
-    const onClick = (): void => {
-        if (props.onClickAction && props.onClickAction.canExecute) {
-            props.onClickAction.execute();
+export function <%- name %>(props: <%- name %>ContainerProps): ReactElement {
+    const { <%- packageName %>Type, <%- packageName %>Value, valueAttribute, onClickAction, style, bootstrapStyle } = props;
+    const onClickHandler = useCallback(() => {
+        if (onClickAction && onClickAction.canExecute) {
+            onClickAction.execute();
         }
-    };
+    }, [onClickAction]);
 
     return (
         <BadgeSample
-            type={props.<%- packageName %>Type}
-            bootstrapStyle={props.bootstrapStyle}
+            type={<%- packageName %>Type}
+            bootstrapStyle={bootstrapStyle}
             className={props.class}
-            clickable={!!props.onClickAction}
-            defaultValue={props.<%- packageName %>Value ? props.<%- packageName %>Value : ""}
-            onClickAction={onClick}
-            style={props.style}
-            value={props.valueAttribute ? props.valueAttribute.displayValue : ""}>
-        </BadgeSample>
+            clickable={!!onClickAction}
+            defaultValue={<%- packageName %>Value ? <%- packageName %>Value : ""}
+            onClickAction={onClickHandler}
+            style={style}
+            value={valueAttribute ? valueAttribute.displayValue : ""} />
     );
 }

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/WidgetName.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/WidgetName.tsx.ejs
@@ -1,0 +1,26 @@
+import { ReactElement, createElement } from "react";
+
+import { <%- name %>ContainerProps } from "../typings/<%- name %>Props";
+import { BadgeSample } from "./components/BadgeSample";
+import "./ui/<%- name %>.css";
+
+export default function <%- name %>(props: <%- name %>ContainerProps): ReactElement | null {
+    const onClick = (): void => {
+        if (props.onClickAction && props.onClickAction.canExecute) {
+            props.onClickAction.execute();
+        }
+    };
+
+    return (
+        <BadgeSample
+            type={props.<%- packageName %>Type}
+            bootstrapStyle={props.bootstrapStyle}
+            className={props.class}
+            clickable={!!props.onClickAction}
+            defaultValue={props.<%- packageName %>Value ? props.<%- packageName %>Value : ""}
+            onClickAction={onClick}
+            style={props.style}
+            value={props.valueAttribute ? props.valueAttribute.displayValue : ""}>
+        </BadgeSample>
+    );
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/WidgetName.xml.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/WidgetName.xml.ejs
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<widget id="<%- packagePathXml %>.<%- packageName %>.<%- name %>" pluginWidget="true" needsEntityContext="true" offlineCapable="true"
+        supportedPlatform="Web"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
+    <name><%- nameCamelCase %></name>
+    <description><%- description %></description>
+    <icon>
+        iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAABp1BMVEUAAABV//9mzP9LtP9Ms/9Jtv9NsvdJsfpLtPpJsfdJsfhJsvhJsvdKsvdJsPhKsPhJsfdJsPhJsfdIsfhJsfdIsPdJsfhJsfhJsPhJsPhIsfhIsPdJsPdKsPdKsfdNsvdOsvdPs/dQs/dRtPdStPdTtPdUtfdWtvdXtvdauPdcuPdeufdeufhguvhiu/hju/hkvPhmvfhnvfhpvvhrv/huwPhvwfhxwfhywvhzwvh4xfl5xfl6xfl8xvl9xvl9x/mByPmCyfmFyvmGyvmJzPmKzPmLzfmNzvqPzvqQz/qT0PqU0PqU0fqX0vqY0vqa0/qe1fqg1vqj1/uk1/un2fup2vut2/uv3Puw3Puw3fuz3vu13/u23/u34Pu44Pu64fu64fy84vy94vy+4/y/4/zD5fzE5fzG5vzH5vzI5/zK6PzL6PzR6/zT7P3U7P3V7f3W7f3Y7v3Z7v3c8P3e8f3f8f3g8f3i8v3l8/3l9P3n9P3r9v7t9/7u9/7v+P7w+P7x+f7y+f70+v71+v74/P75/P76/f77/f78/f78/v79/v7+/v7////6dMsRAAAAG3RSTlMAAwURGxwhMTNic3SEh4iVp7XBzejt7vH5/f6PsMNWAAABsklEQVR4AWIYfGAUjIJRMAqYuYREJKWJAqLCPGwY+jnFpEkBEryMqPr5pEkFgkwo9kuTDviR/S9GhgFSHAgDuKXJAQIIA4TIMkAcEY4i0mQBVrgBkuQZwA43QJo8wIFhQEhEOIBQOutHJozDOP5Crp4e1RhkJ0tKGJFd6oNEdtmJyEIzpaZl5nrRZgaHM/2Pf5/vwXXfyagXgG93bwSAlEolowLMm9w83gibhXH2gKKVdD67gTnWjwCk+VVjMQS4suSnnjMLRVFc9sAHvAX2A9fySaXNBMbEZVUWscaHIMRuqwBgD8hDEbnsRmfjUKJkAQZGCTlO/xWBwIADQLIZBlY441MvfoF1xlFS/4fy+bzXKh4dgNJE7L3eh3tmtuWa+AMcMIY3dgUvZQpGEYmMw2kD7HC+R29UqyoXLaBd0QZxzgXgikLLDSqJTKU5HOcS0MsbA9jPqtwCRvXm2eorBbNIJBw3KJ9O4Yl+AAXdnyaLt7PWN3jRWLvzmAVp94zO5+n41/onfo/UpExxZqI0O7NQr0DhIq9Io7hQpbRYp7hiobRqo6ByFcNWuY6CUTAKRgEAo8X0lBD3V30AAAAASUVORK5CYII=
+    </icon>
+    <properties>
+        <propertyGroup caption="General">
+            <property key="valueAttribute" type="attribute" required="false">
+                <caption>Value attribute</caption>
+                <description>The attribute that contains the <%- packageName %> value</description>
+                <attributeTypes>
+                    <attributeType name="String"/>
+                    <attributeType name="Enum"/>
+                    <attributeType name="Integer"/>
+                    <attributeType name="Decimal"/>
+                    <attributeType name="Long"/>
+                </attributeTypes>
+            </property>
+            <property key="<%- packageName %>Value" type="string" required="false">
+                <caption>Default value</caption>
+                <description>The <%- packageName %> value shown when no value is provided via the attribute</description>
+            </property>
+        </propertyGroup>
+        <propertyGroup caption="Display">
+            <property key="bootstrapStyle" type="enumeration" defaultValue="default">
+                <caption><%- name %> style</caption>
+                <description>The appearance of the <%- packageName %></description>
+                <enumerationValues>
+                    <enumerationValue key="default">Default</enumerationValue>
+                    <enumerationValue key="primary">Primary</enumerationValue>
+                    <enumerationValue key="success">Success</enumerationValue>
+                    <enumerationValue key="info">Info</enumerationValue>
+                    <enumerationValue key="inverse">Inverse</enumerationValue>
+                    <enumerationValue key="warning">Warning</enumerationValue>
+                    <enumerationValue key="danger">Danger</enumerationValue>
+                </enumerationValues>
+            </property>
+            <property key="<%- packageName %>Type" type="enumeration" required="true" defaultValue="badge">
+                <caption>Type</caption>
+                <description>Render it as either a badge or a color label</description>
+                <enumerationValues>
+                    <enumerationValue key="badge">Badge</enumerationValue>
+                    <enumerationValue key="label">Label</enumerationValue>
+                </enumerationValues>
+            </property>
+        </propertyGroup>
+        <propertyGroup caption="Events">
+            <property key="onClickAction" type="action" required="false">
+                <caption>On click action</caption>
+                <description>Action to trigger when button / label is clicked</description>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/components/Alert.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/components/Alert.tsx.ejs
@@ -1,4 +1,4 @@
-import { FunctionComponent, createElement } from "react";
+import { ReactElement, createElement } from "react";
 import classNames from "classnames";
 
 export interface AlertProps {
@@ -7,9 +7,8 @@ export interface AlertProps {
     bootstrapStyle: "default" | "primary" | "success" | "info" | "inverse" | "warning" | "danger";
 }
 
-export const Alert: FunctionComponent<AlertProps> = (props) =>
-    props.message
-        ? (<div className={classNames(`alert alert-${props.bootstrapStyle}`, props.className)}>{props.message}</div>)
+export function Alert({ message, className, bootstrapStyle }: AlertProps): ReactElement | null {
+    return message
+        ? (<div className={classNames(`alert alert-${bootstrapStyle}`, className)}>{message}</div>)
         : null;
-
-Alert.displayName = "Alert";
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/components/Alert.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/components/Alert.tsx.ejs
@@ -1,0 +1,15 @@
+import { FunctionComponent, createElement } from "react";
+import classNames from "classnames";
+
+export interface AlertProps {
+    message?: string;
+    className?: string;
+    bootstrapStyle: "default" | "primary" | "success" | "info" | "inverse" | "warning" | "danger";
+}
+
+export const Alert: FunctionComponent<AlertProps> = (props) =>
+    props.message
+        ? (<div className={classNames(`alert alert-${props.bootstrapStyle}`, props.className)}>{props.message}</div>)
+        : null;
+
+Alert.displayName = "Alert";

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/components/BadgeSample.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/components/BadgeSample.tsx.ejs
@@ -1,0 +1,30 @@
+import { ReactElement, createElement } from "react";
+import classNames from "classnames";
+
+export interface BadgeSampleProps {
+    type: "badge" | "label";
+    defaultValue?: string;
+    className?: string;
+    style?: object;
+    value?: string;
+    bootstrapStyle?: BootstrapStyle;
+    clickable?: boolean;
+    onClickAction?: () => void;
+    getRef?: (node: HTMLElement) => void;
+}
+
+export type BootstrapStyle = "default" | "info" | "inverse" | "primary" | "danger" | "success" | "warning";
+
+export function BadgeSample(props: BadgeSampleProps): ReactElement | null {
+    return (
+        <span
+            className={classNames("widget-<%- packageName %>", props.type, props.className, {
+                [`label-${props.bootstrapStyle}`]: !!props.bootstrapStyle,
+                "widget-<%- packageName %>-clickable": props.clickable
+            })}
+            onClick={props.onClickAction}
+            ref={props.getRef}
+            style={props.style}
+        >{props.value || props.defaultValue}</span>
+    );
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/components/BadgeSample.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/components/BadgeSample.tsx.ejs
@@ -19,9 +19,9 @@ export function BadgeSample(props: BadgeSampleProps): ReactElement {
     const { type, defaultValue, className, style, value, bootstrapStyle, clickable, onClickAction, getRef } = props;
     return (
         <span
-            className={classNames("widget-tsf", type, className, {
+            className={classNames("widget-<%- packageName %>", type, className, {
                 [`label-${bootstrapStyle}`]: !!bootstrapStyle,
-                "widget-tsf-clickable": clickable
+                "widget-<%- packageName %>-clickable": clickable
             })}
             onClick={onClickAction}
             ref={getRef}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/components/BadgeSample.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/components/BadgeSample.tsx.ejs
@@ -1,11 +1,11 @@
-import { ReactElement, createElement } from "react";
+import { ReactElement, CSSProperties, createElement } from "react";
 import classNames from "classnames";
 
 export interface BadgeSampleProps {
     type: "badge" | "label";
     defaultValue?: string;
     className?: string;
-    style?: object;
+    style?: CSSProperties;
     value?: string;
     bootstrapStyle?: BootstrapStyle;
     clickable?: boolean;

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/components/BadgeSample.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/components/BadgeSample.tsx.ejs
@@ -15,16 +15,17 @@ export interface BadgeSampleProps {
 
 export type BootstrapStyle = "default" | "info" | "inverse" | "primary" | "danger" | "success" | "warning";
 
-export function BadgeSample(props: BadgeSampleProps): ReactElement | null {
+export function BadgeSample(props: BadgeSampleProps): ReactElement {
+    const { type, defaultValue, className, style, value, bootstrapStyle, clickable, onClickAction, getRef } = props;
     return (
         <span
-            className={classNames("widget-<%- packageName %>", props.type, props.className, {
-                [`label-${props.bootstrapStyle}`]: !!props.bootstrapStyle,
-                "widget-<%- packageName %>-clickable": props.clickable
+            className={classNames("widget-tsf", type, className, {
+                [`label-${bootstrapStyle}`]: !!bootstrapStyle,
+                "widget-tsf-clickable": clickable
             })}
-            onClick={props.onClickAction}
-            ref={props.getRef}
-            style={props.style}
-        >{props.value || props.defaultValue}</span>
+            onClick={onClickAction}
+            ref={getRef}
+            style={style}
+        >{value || defaultValue}</span>
     );
 }

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/components/__tests__/Alert.spec.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/components/__tests__/Alert.spec.tsx.ejs
@@ -1,0 +1,24 @@
+import { createElement } from "react";
+import { shallow } from "enzyme";
+
+import { Alert } from "../Alert";
+
+describe("Alert", () => {
+    it("renders the structure when an alert message is specified", () => {
+        const message = "This is an error";
+        const alert = shallow(<Alert
+            bootstrapStyle="danger"
+            className="widget-badge-alert"
+            message={message}/>);
+
+        expect(alert.equals(
+            <div className="alert alert-danger widget-badge-alert">{message}</div>
+        )).toEqual(true);
+    });
+
+    it("renders no structure when the alert message is not specified", () => {
+        const alert = shallow(<Alert bootstrapStyle="danger"/>);
+
+        expect(alert.isEmptyRender()).toEqual(true);
+    });
+});

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/components/__tests__/BadgeSample.spec.tsx.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/components/__tests__/BadgeSample.spec.tsx.ejs
@@ -1,0 +1,101 @@
+import { createElement } from "react";
+import { shallow, ShallowWrapper } from "enzyme";
+
+import { BadgeSample, BadgeSampleProps } from "../BadgeSample";
+
+describe("Badge", () => {
+    const createBadge = (props: BadgeSampleProps): ShallowWrapper => shallow(<BadgeSample {...props} />);
+
+    it("should render the structure", () => {
+        const badgeProps: BadgeSampleProps = {
+            type: "badge",
+            bootstrapStyle: "default",
+            value: "0"
+        };
+        const badge = createBadge(badgeProps);
+
+        expect(
+            badge.equals(
+                <span className="widget-<%- packageName %> badge label-default">0</span>
+            )
+        ).toEqual(true);
+    });
+
+    it("should show value when no value or default value provided", () => {
+        const value = "value";
+        const badge = createBadge({ type: "label", value, defaultValue: "default value" });
+
+        expect(badge.text()).toBe(value);
+    });
+
+    it("should show default value when no value is provided", () => {
+        const defaultValue = "default";
+        const badge = createBadge({ type: "label", value: undefined, defaultValue });
+
+        expect(badge.text()).toBe(defaultValue);
+    });
+
+    it("should show no value when no value or default value provided", () => {
+        const badge = createBadge({ type: "label", value: undefined });
+
+        expect(badge.text()).toBe("");
+    });
+
+    it("configured as a label should have the class label", () => {
+        const badge = createBadge({ type: "label" });
+
+        expect(badge.hasClass("label")).toBe(true);
+    });
+
+    it("configured as a badge should have the class badge", () => {
+        const badge = createBadge({ type: "badge" });
+
+        expect(badge.hasClass("badge")).toBe(true);
+    });
+
+    it("with a click action should respond to click events", () => {
+        const badgeProps: BadgeSampleProps = { onClickAction: jest.fn(), type: "badge" };
+        const onClick = badgeProps.onClickAction = jest.fn();
+        const badge = createBadge(badgeProps);
+
+        badge.simulate("click");
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("with the Bootstrap style default should have the class label-default", () => {
+        const badge = createBadge({ bootstrapStyle: "default", type: "badge" });
+
+        expect(badge.hasClass("label-default")).toBe(true);
+    });
+
+    it("with the Bootstrap style primary should have the class label-primary", () => {
+        const badge = createBadge({ bootstrapStyle: "primary", type: "badge" });
+
+        expect(badge.hasClass("label-primary")).toBe(true);
+    });
+
+    it("with the Bootstrap style success should have the class label-success", () => {
+        const badge = createBadge({ bootstrapStyle: "success", type: "badge" });
+
+        expect(badge.hasClass("label-success")).toBe(true);
+    });
+
+    it("with the Bootstrap style info should have the class label-info", () => {
+        const badge = createBadge({ bootstrapStyle: "info", type: "badge" });
+
+        expect(badge.hasClass("label-info")).toBe(true);
+    });
+
+    it("with the Bootstrap style warning should have the class label-warning", () => {
+        const badge = createBadge({ bootstrapStyle: "warning", type: "badge" });
+
+        expect(badge.hasClass("label-warning")).toBe(true);
+    });
+
+    it("with the Bootstrap style danger should have the class label-danger", () => {
+        const badge = createBadge({ bootstrapStyle: "danger", type: "badge" });
+
+        expect(badge.hasClass("label-danger")).toBe(true);
+    });
+});

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/package.xml.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/package.xml.ejs
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<package xmlns="http://www.mendix.com/package/1.0/">
+    <clientModule name="<%- name %>" version="<%- version %>" xmlns="http://www.mendix.com/clientModule/1.0/">
+        <widgetFiles>
+            <widgetFile path="<%- name %>.xml"/>
+        </widgetFiles>
+        <files>
+            <file path="<%- packagePathXml %>/<%- packageName %>"/>
+        </files>
+    </clientModule>
+</package>

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/ui/WidgetName.css.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/ui/WidgetName.css.ejs
@@ -1,0 +1,24 @@
+.widget-<%- packageName %>-clickable {
+    cursor: pointer;
+}
+
+.widget-<%- packageName %> {
+    display: inline-block;
+}
+
+.widget-<%- packageName %>.badge:empty {
+    display: initial;
+    /* Fix padding to stay round */
+    padding: 3px 10px;
+}
+
+.widget-<%- packageName %>.label:empty {
+    display: initial;
+    /* Fix padding to stay square */
+    padding: .2em .8em .3em;
+}
+
+.widget-<%- packageName %>.badge {
+    min-width: 18px;
+    min-height: 18px;
+}

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/tests/e2e/WidgetName.spec.ts.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/tests/e2e/WidgetName.spec.ts.ejs
@@ -1,0 +1,17 @@
+import homepage from "./pages/home.page";
+
+const badgeValue = "Badge";
+
+describe("<%- name %>", () => {
+    it("should render a badge with a caption", () => {
+        homepage.open();
+
+        /**
+         * Create your tests here. Example:
+         * homepage.badge().waitForVisible();
+         *
+         * const widgetValue = homepage.badge().getText();
+         * expect(widgetValue).toContain(badgeValue);
+         */
+    });
+});

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/tests/e2e/pages/home.page.ts.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/tests/e2e/pages/home.page.ts.ejs
@@ -1,0 +1,15 @@
+class HomePage {
+
+    /**
+     * Create your accessors to html elements here. Example:
+     * public get badge() { return $(".widget-badge.badge.mx-name-badge1"); }
+     *
+     * public get label() { return $(".widget-badge.label.mx-name-badge7"); }
+     */
+
+    public open(): void {
+        browser.url("/");
+    }
+}
+const homepage = new HomePage();
+export default homepage;

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/tests/e2e/tsconfig.json
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/tests/e2e/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+      "target": "es6",
+      "module": "commonjs",
+      "moduleResolution": "node",
+      "emitDecoratorMetadata": true,
+      "experimentalDecorators": true,
+      "removeComments": true,
+      "noImplicitAny": false,
+      "outDir": "../../dist/e2e",
+      "types": [
+        "jasmine",
+        "@wdio/sync"
+      ]
+    },
+    "exclude": [
+      "node_modules"
+    ],
+    "compileOnSave": false
+  }

--- a/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/tests/e2e/tsconfig.json
+++ b/packages/tools/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/tests/e2e/tsconfig.json
@@ -1,20 +1,15 @@
 {
-    "compilerOptions": {
-      "target": "es6",
-      "module": "commonjs",
-      "moduleResolution": "node",
-      "emitDecoratorMetadata": true,
-      "experimentalDecorators": true,
-      "removeComments": true,
-      "noImplicitAny": false,
-      "outDir": "../../dist/e2e",
-      "types": [
-        "jasmine",
-        "@wdio/sync"
-      ]
-    },
-    "exclude": [
-      "node_modules"
-    ],
-    "compileOnSave": false
-  }
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "types": ["node", "webdriverio/sync", "@wdio/jasmine-framework", "wdio-image-comparison-service", "@wdio/devtools-service"],
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "removeComments": true,
+    "noImplicitAny": false,
+    "outDir": "../../dist/e2e"
+  },
+  "exclude": ["node_modules"],
+  "compileOnSave": false
+}


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

## This PR contains
- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Add an option to generate function components to generator-widget for Web and Native.

## Relevant changes
- Added new prompt for component type
- Added logic to select Function template if option is set
- Added 8 new templates for function components (js & ts)

## What should be covered while testing?
Generate and test a pluggable-widget using each template

## Extra comments (optional)
In the [react documentation](https://reactjs.org/docs/components-and-props.html) components are introduced as follows:

"The simplest way to define a component is to write a JavaScript function"

We should support this simplest way of defining components in our generator as well.