### PR TITLE
[WC-956] fix(pluggable-widgets-tools): fix colors version

### DIFF
--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- We fixed `colors` dependency version to 1.4.0.
+
 ## [9.9.1] - 2022-01-07
 
 ### Added

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.9.1",
+  "version": "9.9.2",
   "description": "Mendix Pluggable Widgets Tools",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
@@ -65,7 +65,7 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.1",
     "big.js": "^6.0.2",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "concurrently": "^6.0.0",
     "core-js": "^3.6.5",
     "dotenv": "^8.2.0",
@@ -136,5 +136,11 @@
     "test": "npm run test:src && cross-env LIMIT_TESTS=true npm run test:scripts",
     "test:src": "jest",
     "test:scripts": "npm run prepare && node tests/commands.js"
+  },
+  "overrides": {
+    "colors": "1.4.0"
+  },
+  "resolutions": {
+    "colors": "1.4.0"
   }
 }


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fixes issue described in https://github.com/Marak/colors.js/issues/285

## Relevant changes
Fixed version of colors and resolutions.

## What should be covered while testing?
General usage of bootstrapped widgets.