### PR TITLE
[WC-956] Fix hacked colors library in PIW-tools 9.6

### DIFF
--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [9.6.2] - 2022-01-10
+
+### Fixed
+- We fixed `colors` dependency version to 1.4.0.
+
 ## [9.6.1] - 2021-11-18
 
 ### Added

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.6.1",
+  "version": "9.6.2",
   "description": "Mendix Pluggable Widgets Tools",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2021. All rights reserved.",
@@ -64,7 +64,7 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.1",
     "big.js": "^6.0.2",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "concurrently": "^6.0.0",
     "core-js": "^3.6.5",
     "dotenv": "^8.2.0",
@@ -134,5 +134,11 @@
     "test": "npm run test:src && cross-env LIMIT_TESTS=true npm run test:scripts",
     "test:src": "jest",
     "test:scripts": "npm run prepare && node tests/commands.js"
+  },
+  "overrides": {
+    "colors": "1.4.0"
+  },
+  "resolutions": {
+    "colors": "1.4.0"
   }
 }


### PR DESCRIPTION
Backporting https://github.com/mendix/widgets-resources/pull/1212 to 9.6.x branch