### PR TITLE
[UIA-51] fix(notifications): incorrect truthy result in hasPermission check

### DIFF
--- a/packages/jsActions/mobile-resources-native/CHANGELOG.md
+++ b/packages/jsActions/mobile-resources-native/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this widget will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- We updated the `HasNotificationPermission` action to prevent an incorrect result when permission was not yet requested on iOS. This is due to a change in the hasPermission method in react-native-firebase.
 
 ## [3.3.1] Native Mobile Resources - 2021-10-25
 ### Fixed

--- a/packages/jsActions/mobile-resources-native/src/notifications/HasNotificationPermission.ts
+++ b/packages/jsActions/mobile-resources-native/src/notifications/HasNotificationPermission.ts
@@ -20,7 +20,7 @@ export async function HasNotificationPermission(): Promise<boolean> {
     }
 
     return NativeModules.RNFBMessagingModule.hasPermission().then((authStatus: number) => {
-        if (authStatus) {
+        if (authStatus && authStatus > 0) {
             return Promise.resolve(true);
         } else {
             return Promise.resolve(false);

--- a/packages/jsActions/mobile-resources-native/src/notifications/HasNotificationPermission.ts
+++ b/packages/jsActions/mobile-resources-native/src/notifications/HasNotificationPermission.ts
@@ -15,12 +15,21 @@ export async function HasNotificationPermission(): Promise<boolean> {
     // BEGIN USER CODE
     // Documentation https://rnfirebase.io/docs/v5.x.x/notifications/receiving-notifications
 
+    const enum permissionStatus {
+        NotDetermined = -1,
+        Denied = 0,
+        Authorized = 1,
+        Provisional = 2
+    }
+
+    const allowedAuthorizationStatuses = [permissionStatus.Authorized, permissionStatus.Provisional];
+
     if (NativeModules && !NativeModules.RNFBMessagingModule) {
         return Promise.reject(new Error("Firebase module is not available in your app"));
     }
 
     return NativeModules.RNFBMessagingModule.hasPermission().then((authStatus: number) => {
-        if (authStatus && authStatus > 0) {
+        if (allowedAuthorizationStatuses.includes(authStatus)) {
             return Promise.resolve(true);
         } else {
             return Promise.resolve(false);


### PR DESCRIPTION
See https://github.com/invertase/react-native-firebase/issues/3448. When the authorization status for notifications in iOS is 'not determined' (-1), this currently resolves as true, which is incorrect.

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
To solve the incorrect result in the `HasNotificationPermission` action (part of Native Mobile Resources), which happens when the authorization status is 'Not determined' (-1) on iOS. This currently results in true.

## Relevant changes
Added an additional check on the returned auth status number, to prevent -1 being considered as true

## Extra comments
Fixes support ticket #135991
