### PR TITLE
[BUILD] Set 'merge' as merge method

### DIFF
--- a/.github/workflows/UpdateWidgetsOverview.yml
+++ b/.github/workflows/UpdateWidgetsOverview.yml
@@ -37,4 +37,4 @@ jobs:
         with:
           token: ${{ secrets.GH_PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: rebase
+          merge-method: merge


### PR DESCRIPTION
## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Auto-merging of the widgets overview was set to rebase, but our repo does not allow that

## Relevant changes
Set merge method of auto-created PRs for the widgets overview to 'merge'