### PR TITLE
[WC-960] fix(datagrid-web): column selector checkbox in windows machines

### DIFF
--- a/packages/modules/data-widgets/package.json
+++ b/packages/modules/data-widgets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "data-widgets",
   "moduleName": "Data Widgets",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- We fixed an issue with column selector on Windows machines (Ticket #139234).
+
 ## [2.2.1] - 2022-1-6
 
 ### Changed

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datagrid-web",
   "widgetName": "Datagrid",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/datagrid-web/src/components/ColumnSelector.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/ColumnSelector.tsx
@@ -83,6 +83,7 @@ export function ColumnSelector(props: ColumnSelectorProps): ReactElement {
                             checked={isVisible}
                             disabled={isVisible && props.columns.length - props.hiddenColumns.length === 1}
                             id={`${props.id}_checkbox_toggle_${index}`}
+                            style={{ pointerEvents: "none" }}
                             type="checkbox"
                             tabIndex={-1}
                         />

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="2.2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="2.2.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
-            <widgetFile path="Datagrid.xml"/>
+            <widgetFile path="Datagrid.xml" />
         </widgetFiles>
         <files>
-            <file path="com/mendix/widget/web/datagrid/"/>
+            <file path="com/mendix/widget/web/datagrid/" />
         </files>
     </clientModule>
 </package>


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
When using Windows browsers the checkbox inside each item of column selector accepts events, then triggering it doesnt force the checkbox to behave as expected as the events are in the `li`. This fixes this issue.

## Relevant changes
Added pointerEvents none to the radio button input.

## What should be covered while testing?
Usage of column selector on Windows/Mac and also tests using keyboard.
