### PR TITLE
[WC-959] fix(popup-menu-web): fixing correctPosition function

### DIFF
--- a/packages/pluggableWidgets/popup-menu-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/popup-menu-web/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- We fixed an issue while showing the popup items using Firefox on Windows (Ticket #139529).
+
 ## [3.2.0] - 2021-12-23
 
 ### Added

--- a/packages/pluggableWidgets/popup-menu-web/package.json
+++ b/packages/pluggableWidgets/popup-menu-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "popup-menu-web",
   "widgetName": "PopupMenu",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/pluggableWidgets/popup-menu-web/src/components/PopupMenu.tsx
+++ b/packages/pluggableWidgets/popup-menu-web/src/components/PopupMenu.tsx
@@ -155,8 +155,10 @@ function correctPosition(element: HTMLElement, position: PositionEnum): void {
         do {
             if (isBehindElement(element, node, 3) && isElementVisibleByUser(dynamicDocument, dynamicWindow, node)) {
                 return unBlockAbsoluteElement(element, boundingRect, node.getBoundingClientRect(), position);
-            } else {
+            } else if (node.parentElement) {
                 node = node.parentElement as HTMLElement;
+            } else {
+                break;
             }
         } while (node.parentElement);
     }

--- a/packages/pluggableWidgets/popup-menu-web/src/package.xml
+++ b/packages/pluggableWidgets/popup-menu-web/src/package.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="PopupMenu" version="3.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="PopupMenu" version="3.2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
-            <widgetFile path="PopupMenu.xml"/>
+            <widgetFile path="PopupMenu.xml" />
         </widgetFiles>
         <files>
-            <file path="com/mendix/widget/web/popupmenu"/>
+            <file path="com/mendix/widget/web/popupmenu" />
         </files>
     </clientModule>
 </package>


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅ 
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
While using Firefox on windows the element being passed does not contain parentElement, so it throws an error as the function is expecting a parent (It was not counted while developing the function). Note: Firefox uses `<html class="dj_gecko dj_ff95 dj_contentbox" lang="en-US">` which does not contains a parent. So this PR fixes the function.

## Relevant changes
Added extra check to verify if the current element contains a parent before iterate again.

## What should be covered while testing?
General usage on Max/Windows and multiple browsers.
