### PR TITLE
[WC-969] fix(datagrid-dropdown-filter-web): fixing filtering using multiple attributes

### DIFF
--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- We fixed an issue when selecting an invalid value for an attribute was cleaning the filter if used in Gallery or Data grid 2 header. Now it will match the correct attribute and apply the filter anyway (Ticket #138870).
+
 ## [2.2.0] - 2021-12-23
 
 ### Added

--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/package.json
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datagrid-dropdown-filter-web",
   "widgetName": "DatagridDropdownFilter",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/DatagridDropdownFilter.tsx
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/DatagridDropdownFilter.tsx
@@ -157,24 +157,16 @@ function getFilterCondition(
     const { id, type } = listAttribute;
     const filterAttribute = attribute(id);
 
-    if (
-        values.some(
-            filterOption => !listAttribute.universe?.includes(checkValue(filterOption.value, listAttribute.type))
-        )
-    ) {
-        return undefined;
+    const filters = values
+        .filter(filterOption => listAttribute.universe?.includes(checkValue(filterOption.value, listAttribute.type)))
+        .map(filter => equals(filterAttribute, literal(checkValue(filter.value, type))));
+
+    if (filters.length > 1) {
+        return or(...filters);
     }
 
-    if (values.length > 1) {
-        return or(...values.map(filter => equals(filterAttribute, literal(checkValue(filter.value, type)))));
-    }
-
-    const [filterValue] = values;
-    if (filterValue.value) {
-        return equals(filterAttribute, literal(checkValue(filterValue.value, type)));
-    }
-
-    return undefined;
+    const [filterValue] = filters;
+    return filterValue;
 }
 
 function checkValue(value: string, type: string): boolean | string {

--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/package.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="DatagridDropdownFilter" version="2.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="DatagridDropdownFilter" version="2.2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
-            <widgetFile path="DatagridDropdownFilter.xml"/>
+            <widgetFile path="DatagridDropdownFilter.xml" />
         </widgetFiles>
         <files>
-            <file path="com/mendix/widget/web/datagriddropdownfilter/"/>
+            <file path="com/mendix/widget/web/datagriddropdownfilter/" />
         </files>
     </clientModule>
 </package>


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
When using Dropdown filter inside Data grid 2 header or Gallery and selecting multiple attributes (Enumeration or Boolean), the filter was being applied only if there was no invalid values selected, which shouldn't be the case. This PR fixes the behavior of Dropdown filter and applies the filter conditions for the attribute that contains the values.

## Relevant changes
Changed how the filter conditions were being applied. Removed a check if there was some invalid value (return undefined 😵‍💫 )

## What should be covered while testing?
Test using Data grid and Gallery. While testing Data grid, it should also be verified if normal filtering using data grid columns was not affected.
