### PR TITLE
[NC-462] Fix geolocation timeout issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78533,6 +78533,11 @@
 			"resolved": "https://registry.npmjs.org/react-native-geocoder/-/react-native-geocoder-0.5.0.tgz",
 			"integrity": "sha1-/0ucVdV2ikeE7vzLQRdhyC4GdXk="
 		},
+		"react-native-geolocation-service": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/react-native-geolocation-service/-/react-native-geolocation-service-5.2.0.tgz",
+			"integrity": "sha512-ai7xd6QbLl6WMyEbPfXSaXyYQ/L6CDcPjOZAJYboqwNPclAqxGkzJHJQyvBNy9J410EIrDJg0p9KyaciXmxyCw=="
+		},
 		"react-native-gesture-handler": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.8.0.tgz",

--- a/packages/jsActions/nanoflow-actions-native/CHANGELOG.md
+++ b/packages/jsActions/nanoflow-actions-native/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - We fixed a bug where the `Speed` was not being defined while using `Get current location` action.
 - We removed some unwanted files from the module.
+- We fixed the timeout error while getting the current location.
+
+### Breaking
+- Get current location/iOS: We changed the library that uses [android.location API](https://developer.android.com/reference/android/location/package-summary), to the new library that uses the [Google Location Services API](https://developer.android.com/training/location/). Regarding this change, you should use `Request location permission` action before using `Get current location` action.
 
 ## [2.1.2] Nanoflow Commons - 2021-10-25
 ### Fixed

--- a/packages/jsActions/nanoflow-actions-native/package.json
+++ b/packages/jsActions/nanoflow-actions-native/package.json
@@ -26,6 +26,7 @@
     "@react-native-community/async-storage": "1.12.1",
     "@react-native-community/geolocation": "2.0.2",
     "react-native-geocoder": "0.5.0",
+    "react-native-geolocation-service": "5.2.0",
     "invariant": "^2.2.4"
   },
   "devDependencies": {

--- a/packages/jsActions/nanoflow-actions-native/src/geolocation/RequestLocationPermission.ts
+++ b/packages/jsActions/nanoflow-actions-native/src/geolocation/RequestLocationPermission.ts
@@ -4,8 +4,9 @@
 // - the code between BEGIN USER CODE and END USER CODE
 // Other code you write will be lost the next time you deploy the project.
 
-import { PermissionsAndroid, Platform } from "react-native";
 import Geolocation, { GeolocationStatic } from "@react-native-community/geolocation";
+
+import type { GeolocationServiceStatic, AuthorizationResult } from "../../typings/Geolocation";
 
 /**
  * On the native platform a request for permission should be made before the `GetCurrentLocation` action would work.
@@ -14,32 +15,142 @@ import Geolocation, { GeolocationStatic } from "@react-native-community/geolocat
 export async function RequestLocationPermission(): Promise<boolean> {
     // BEGIN USER CODE
 
-    if (navigator && navigator.product === "ReactNative") {
-        if (!navigator.geolocation) {
-            (navigator.geolocation as GeolocationStatic) = Geolocation;
+    let reactNativeModule: typeof import("react-native") | undefined;
+    let geolocationModule:
+        | Geolocation
+        | GeolocationStatic
+        | typeof import("react-native-geolocation-service")
+        | undefined;
+
+    const hasPermissionIOS = async (): Promise<boolean> => {
+        const openSetting = (): void => {
+            reactNativeModule?.Linking.openSettings().catch(() => {
+                reactNativeModule?.Alert.alert("Unable to open settings.");
+            });
+        };
+
+        return (geolocationModule as GeolocationServiceStatic)
+            .requestAuthorization("whenInUse")
+            .then((status: AuthorizationResult) => {
+                if (status === "granted") {
+                    return true;
+                }
+
+                if (status === "denied") {
+                    reactNativeModule?.Alert.alert("Location permission denied.");
+                }
+
+                if (status === "disabled") {
+                    reactNativeModule?.Alert.alert(
+                        "Location Services must be enabled to determine your location.",
+                        "",
+                        [
+                            { text: "Go to Settings", onPress: openSetting },
+                            {
+                                text: "Don't Use Location"
+                            }
+                        ]
+                    );
+                }
+
+                return false;
+            });
+    };
+
+    const hasPermissionAndroid = async (): Promise<boolean | undefined> => {
+        if (typeof reactNativeModule?.Platform?.Version === "number" && reactNativeModule?.Platform?.Version < 23) {
+            return true;
         }
 
-        if (Platform.OS === "android") {
-            const locationPermission = PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION;
+        const androidLocationPermission = reactNativeModule?.PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION;
 
-            return PermissionsAndroid.check(locationPermission).then(hasPermission =>
+        if (!androidLocationPermission) {
+            return false;
+        }
+
+        return reactNativeModule?.PermissionsAndroid.check(androidLocationPermission).then(hasPermission =>
+            hasPermission
+                ? true
+                : reactNativeModule?.PermissionsAndroid?.request(androidLocationPermission).then(status => {
+                      if (status === reactNativeModule?.PermissionsAndroid.RESULTS.GRANTED) {
+                          return true;
+                      }
+
+                      if (status === reactNativeModule?.PermissionsAndroid.RESULTS.DENIED) {
+                          reactNativeModule.ToastAndroid.show(
+                              "Location permission denied by user.",
+                              reactNativeModule.ToastAndroid.LONG
+                          );
+                      } else if (status === reactNativeModule?.PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) {
+                          reactNativeModule.ToastAndroid.show(
+                              "Location permission revoked by user.",
+                              reactNativeModule.ToastAndroid.LONG
+                          );
+                      }
+
+                      return false;
+                  })
+        );
+    };
+
+    const hasLocationPermission = async (): Promise<boolean> => {
+        if (reactNativeModule?.Platform.OS === "ios") {
+            const hasPermission = await hasPermissionIOS();
+            return hasPermission;
+        }
+
+        if (reactNativeModule?.Platform.OS === "android") {
+            const hasPermission = await hasPermissionAndroid();
+            return hasPermission ?? false;
+        }
+
+        return Promise.reject(new Error("Unsupported platform"));
+    };
+
+    const hasLocationPermissionForOldLibrary = async (): Promise<boolean | undefined> => {
+        if (reactNativeModule?.Platform.OS === "android") {
+            const locationPermission = reactNativeModule.PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION;
+
+            return reactNativeModule.PermissionsAndroid.check(locationPermission).then(hasPermission =>
                 hasPermission
                     ? true
-                    : PermissionsAndroid.request(locationPermission).then(
-                          status => status === PermissionsAndroid.RESULTS.GRANTED
+                    : reactNativeModule?.PermissionsAndroid.request(locationPermission).then(
+                          status => status === reactNativeModule?.PermissionsAndroid.RESULTS.GRANTED
                       )
             );
-        } else if (navigator.geolocation && (navigator.geolocation as GeolocationStatic).requestAuthorization) {
+        } else if (geolocationModule && (geolocationModule as GeolocationStatic).requestAuthorization) {
             try {
-                (navigator.geolocation as GeolocationStatic).requestAuthorization();
+                (geolocationModule as GeolocationStatic).requestAuthorization();
                 return Promise.resolve(true);
             } catch (error) {
                 return Promise.reject(error);
             }
         }
-    }
 
-    return Promise.reject(new Error("No permission request for location is required for web/hybrid platform"));
+        return false;
+    };
+
+    if (navigator && navigator.product === "ReactNative") {
+        reactNativeModule = require("react-native");
+
+        if (!reactNativeModule) {
+            return Promise.reject(new Error("React Native module could not be found"));
+        }
+
+        if (reactNativeModule.NativeModules.RNFusedLocation) {
+            geolocationModule = (await import("react-native-geolocation-service")).default;
+            return hasLocationPermission();
+        } else if (reactNativeModule.NativeModules.RNCGeolocation) {
+            geolocationModule = Geolocation;
+            return (await hasLocationPermissionForOldLibrary()) ?? false;
+        } else {
+            return Promise.reject(new Error("Geolocation module could not be found"));
+        }
+    } else if (navigator && navigator.geolocation) {
+        return Promise.reject(new Error("No permission request for location is required for web/hybrid platform"));
+    } else {
+        return Promise.reject(new Error("Geolocation module could not be found"));
+    }
 
     // END USER CODE
 }

--- a/packages/jsActions/nanoflow-actions-native/typings/Geolocation.d.ts
+++ b/packages/jsActions/nanoflow-actions-native/typings/Geolocation.d.ts
@@ -1,0 +1,22 @@
+import type {
+    AuthorizationLevel,
+    AuthorizationResult,
+    GeoError,
+    GeoPosition,
+    GeoOptions,
+    getCurrentPosition,
+    requestAuthorization,
+    watchPosition,
+    clearWatch,
+    stopObserving
+} from "react-native-geolocation-service";
+
+type GeolocationServiceStatic = {
+    getCurrentPosition: typeof getCurrentPosition;
+    requestAuthorization: typeof requestAuthorization;
+    watchPosition: typeof watchPosition;
+    clearWatch: typeof clearWatch;
+    stopObserving: typeof stopObserving;
+};
+
+export type { GeolocationServiceStatic, AuthorizationLevel, AuthorizationResult, GeoError, GeoPosition, GeoOptions };


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Native specific
- Works in Android ✅
- Works in iOS ✅
- Works in Tablet ✅

## This PR contains
- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
To solve the timeout error while getting the current location on android.

## Relevant changes
Added a new library for location service.

## What should be covered while testing?
- `Get Current Location`, `Get Current Location Minimum Accuracy`, and `Request Location Permission` should work correctly.
- It should be tested for backward compatibility.

## Extra comments (optional)
- To test this PR, you need to build the MiN app from [this branch](https://gitlab.rnd.mendix.com/appdev/appdev/-/tree/nc/fix/geolocation).

- Fixes support ticket [#127540](https://mendixsupport.zendesk.com/agent/tickets/127540)
