### PR TITLE
[WC-975]: use client resolutions instead of inner to fix offscreen position

### DIFF
--- a/packages/pluggableWidgets/popup-menu-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/popup-menu-web/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- We fixed an issue with the popup menu going off the screen when placed on the edge of the page using Firefox on Windows.
+
 ## [3.2.1] - 2022-1-19
 
 ### Fixed

--- a/packages/pluggableWidgets/popup-menu-web/package.json
+++ b/packages/pluggableWidgets/popup-menu-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "popup-menu-web",
   "widgetName": "PopupMenu",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/pluggableWidgets/popup-menu-web/src/package.xml
+++ b/packages/pluggableWidgets/popup-menu-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="PopupMenu" version="3.2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="PopupMenu" version="3.2.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="PopupMenu.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/popup-menu-web/src/utils/document.ts
+++ b/packages/pluggableWidgets/popup-menu-web/src/utils/document.ts
@@ -4,7 +4,7 @@ function isElementBlockedTop(dynamicWindow: Window, srcRect: DOMRect, blockingRe
     return (
         srcRect.top < blockingRect.bottom &&
         srcRect.bottom >= blockingRect.bottom &&
-        srcRect.y + srcRect.height < dynamicWindow.innerHeight
+        srcRect.y + srcRect.height < dynamicWindow.document.documentElement.clientHeight
     );
 }
 
@@ -174,13 +174,19 @@ export function isElementVisibleByUser(
     if (elementCenter.x < 0) {
         return false;
     }
-    if (elementCenter.x > (dynamicDocument.documentElement.clientWidth || dynamicWindow.innerWidth)) {
+    if (
+        elementCenter.x >
+        (dynamicDocument.documentElement.clientWidth || dynamicWindow.document.documentElement.clientWidth)
+    ) {
         return false;
     }
     if (elementCenter.y < 0) {
         return false;
     }
-    if (elementCenter.y > (dynamicDocument.documentElement.clientHeight || dynamicWindow.innerHeight)) {
+    if (
+        elementCenter.y >
+        (dynamicDocument.documentElement.clientHeight || dynamicWindow.document.documentElement.clientHeight)
+    ) {
         return false;
     }
     let pointContainer: Element | null = dynamicDocument.elementFromPoint(elementCenter.x, elementCenter.y);
@@ -200,8 +206,8 @@ export function isElementPartiallyOffScreen(dynamicWindow: Window, rect: DOMRect
     return (
         rect.x < 0 ||
         rect.y < 0 ||
-        rect.x + rect.width > dynamicWindow.innerWidth ||
-        rect.y + rect.height > dynamicWindow.innerHeight
+        rect.x + rect.width > dynamicWindow.document.documentElement.clientWidth ||
+        rect.y + rect.height > dynamicWindow.document.documentElement.clientHeight
     );
 }
 
@@ -220,17 +226,18 @@ export function moveAbsoluteElementOnScreen(
         element.style.top = topValue + "px";
         boundingRect.y += topValue;
     }
-    if (boundingRect.x + boundingRect.width > dynamicWindow.innerWidth) {
+    if (boundingRect.x + boundingRect.width > dynamicWindow.document.documentElement.clientWidth) {
         const rightValue = Math.round(
-            getPixelValueAsNumber(element, "right") + (boundingRect.x + boundingRect.width - dynamicWindow.innerWidth)
+            getPixelValueAsNumber(element, "right") +
+                (boundingRect.x + boundingRect.width - dynamicWindow.document.documentElement.clientWidth)
         );
         element.style.right = rightValue + "px";
         boundingRect.x -= rightValue;
     }
-    if (boundingRect.y + boundingRect.height > dynamicWindow.innerHeight) {
+    if (boundingRect.y + boundingRect.height > dynamicWindow.document.documentElement.clientHeight) {
         const bottomValue = Math.round(
             getPixelValueAsNumber(element, "bottom") +
-                (boundingRect.y + boundingRect.height - dynamicWindow.innerHeight)
+                (boundingRect.y + boundingRect.height - dynamicWindow.document.documentElement.clientHeight)
         );
         element.style.top = "unset"; // Unset top defined in PopupMenu.scss
         element.style.bottom = bottomValue + "px";


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fix the issue described in WC-959 and WC-975 regarding the popup menu being shown off screen when placed on the edge of the page and configured in the direction outside the page. The problem on Firefox windows was that when the user toggles the popup menu, the display is changed from `flex` to `none`. When that happens, it was put on the page and actually increases the size of the page (confirmed by the introduced scrollbars). 

The problem is that our current implementation uses `window.innerHeight` and `window.innerWidth` to determine how much it should push back the popup menu back onto the page. But because of the page size increase, it's now different and the element is pushed back less than it should.

So instead of relying on the window inner resolutions, I changed the implementation to rely on the client resolutions, which is the widht and the height of the user's browser and isn't affected by the page size change. 


## What should be covered while testing?
@leonardomendix 
- make sure that previous configurations don't get messed up (cuz I had to make changes in util functions) 
- popup menu on the edge of the page in the direction outside the page are shown inside the page + don't show scrollbars