### PR TITLE
[WC-1006]: Change maps screenshot threshold

### DIFF
--- a/packages/pluggableWidgets/maps-web/tests/e2e/specs/google.spec.ts
+++ b/packages/pluggableWidgets/maps-web/tests/e2e/specs/google.spec.ts
@@ -13,7 +13,7 @@ describe("Google Maps", () => {
             screenshotElem.waitForDisplayed({ timeout: 5000 });
             browser.pause(3000);
             browser.saveElement(screenshotElem, "googleMaps");
-            expect(browser.checkElement(screenshotElem, "googleMaps")).toEqual(0);
+            expect(browser.checkElement(screenshotElem, "googleMaps")).toBeLessThan(0.5);
         });
     });
 

--- a/packages/pluggableWidgets/maps-web/tests/e2e/specs/here.spec.ts
+++ b/packages/pluggableWidgets/maps-web/tests/e2e/specs/here.spec.ts
@@ -13,7 +13,7 @@ describe("Here Maps", () => {
             screenshotElem.waitForDisplayed({ timeout: 5000 });
             browser.pause(3000);
             browser.saveElement(screenshotElem, "hereMaps");
-            expect(browser.checkElement(screenshotElem, "hereMaps")).toEqual(0);
+            expect(browser.checkElement(screenshotElem, "hereMaps")).toBeLessThan(0.5);
         });
     });
 

--- a/packages/pluggableWidgets/maps-web/tests/e2e/specs/mapbox.spec.ts
+++ b/packages/pluggableWidgets/maps-web/tests/e2e/specs/mapbox.spec.ts
@@ -13,7 +13,7 @@ describe("Mapbox Maps", () => {
             screenshotElem.waitForDisplayed({ timeout: 5000 });
             browser.pause(3000);
             browser.saveElement(screenshotElem, "mapboxMaps");
-            expect(browser.checkElement(screenshotElem, "mapboxMaps")).toEqual(0);
+            expect(browser.checkElement(screenshotElem, "mapboxMaps")).toBeLessThan(0.5);
         });
     });
 

--- a/packages/pluggableWidgets/maps-web/tests/e2e/specs/openstreet.spec.ts
+++ b/packages/pluggableWidgets/maps-web/tests/e2e/specs/openstreet.spec.ts
@@ -13,7 +13,7 @@ describe("OpenStreet Maps", () => {
             screenshotElem.waitForDisplayed({ timeout: 5000 });
             browser.pause(3000);
             browser.saveElement(screenshotElem, "osmMaps");
-            expect(browser.checkElement(screenshotElem, "osmMaps")).toEqual(0);
+            expect(browser.checkElement(screenshotElem, "osmMaps")).toBeLessThan(0.5);
         });
     });
 


### PR DESCRIPTION
## Checklist
- Contains e2e tests ✅ 
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (test)

## What is the purpose of this PR?
Today, the screenshot for maps is very sensitive, and we have some elements being rendered that don't matter for our test, and it's causing some flaky tests. Increasing the threshold should fix that.

## Relevant changes
Changed screenshot element check threshold.

## What should be covered while testing?
Automation should pass.
