### PR TITLE
[WTF-1022] Update pluggable widget tools for association property

### DIFF
--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/WidgetXml.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/WidgetXml.ts
@@ -37,6 +37,7 @@ export interface Property {
             | "file"
             | "datasource"
             | "attribute"
+            | "association"
             | "expression"
             | "enumeration"
             | "object"

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
@@ -21,6 +21,8 @@ import { content, contentGroup, contentGroupNative, contentNative } from "./inpu
 import { nativeResult, webResult, webResultGroup } from "./outputs";
 import { attributeLinkedActionInput, attributeNestedLinkedActionInput } from "./inputs/atribute-linked-action";
 import { attributeLinkedActionOutput, attributeNestedLinkedActionOutput } from "./outputs/atribute-linked-action";
+import { associationInput, associationInputNative } from "./inputs/association";
+import { associationNativeOutput, associationWebOutput } from "./outputs/association";
 
 describe("Generating tests", () => {
     it("Generates a parsed typing from XML for native", () => {
@@ -121,6 +123,16 @@ describe("Generating tests", () => {
     it("Generates a parsed typing from XML for widget with attribute nested linked action", () => {
         const newContent = generateFullTypesFor(attributeNestedLinkedActionInput);
         expect(newContent).toBe(attributeNestedLinkedActionOutput);
+    });
+
+    it("Generates a parsed typing from XML for web using association", () => {
+        const newContent = generateFullTypesFor(associationInput);
+        expect(newContent).toBe(associationWebOutput);
+    });
+
+    it("Generates a parsed typing from XML for native using association", () => {
+        const newContent = generateNativeTypesFor(associationInputNative);
+        expect(newContent).toBe(associationNativeOutput);
     });
 });
 

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/association.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/association.ts
@@ -1,0 +1,49 @@
+export const associationInput = `<?xml version="1.0" encoding="utf-8"?>
+<widget id="mendix.mywidget.MyWidget" needsEntityContext="true" offlineCapable="true" pluginWidget="true"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../xsd/widget.xsd">
+    <properties>
+        <propertyGroup caption="General">
+            <property key="reference" type="association" universeDataSource="optionsSource">
+                <caption>Reference</caption>
+                <description/>
+            </property>
+             <property key="optionsSource" type="datasource" isList="true" required="false">
+                <caption>Universe Data source</caption>
+                <description />
+            </property>
+            <property key="displayValue" dataSource="optionsSource" type="attribute">
+                <caption>Display value</caption>
+                <description>Display value</description>
+                <attributeTypes>
+                    <attributeType name="String"/>
+                </attributeTypes>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>`;
+
+export const associationInputNative = `<?xml version="1.0" encoding="utf-8"?>
+<widget id="mendix.mywidget.MyWidget" needsEntityContext="true" offlineCapable="true" pluginWidget="true" supportedPlatform="Native"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../xsd/widget.xsd">
+    <properties>
+        <propertyGroup caption="General">
+            <property key="reference" type="association" universeDataSource="optionsSource">
+                <caption>Reference</caption>
+                <description/>
+            </property>
+             <property key="optionsSource" type="datasource" isList="true" required="false">
+                <caption>Universe Data source</caption>
+                <description />
+            </property>
+            <property key="displayValue" dataSource="optionsSource" type="attribute">
+                <caption>Display value</caption>
+                <description>Display value</description>
+                <attributeTypes>
+                    <attributeType name="String"/>
+                </attributeTypes>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>`;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
@@ -1,0 +1,36 @@
+export const associationWebOutput = `/**
+ * This file was generated from MyWidget.xml
+ * WARNING: All changes made to this file will be overwritten
+ * @author Mendix UI Content Team
+ */
+import { CSSProperties } from "react";
+import { ListValue, ListAttributeValue, ModifiableValue } from "mendix";
+
+export interface MyWidgetContainerProps {
+    name: string;
+    class: string;
+    style?: CSSProperties;
+    tabIndex?: number;
+    reference: ModifiableValue<ObjectItem>;
+    optionsSource?: ListValue;
+    displayValue?: ListAttributeValue<string>;
+}
+
+export interface MyWidgetPreviewProps {
+    className: string;
+    style: string;
+    styleObject?: CSSProperties;
+    readOnly: boolean;
+    reference: string;
+    optionsSource: {} | { type: string } | null;
+    displayValue: string;
+}
+`;
+
+export const associationNativeOutput = `export interface MyWidgetProps<Style> {
+    name: string;
+    style: Style[];
+    reference: ModifiableValue<ObjectItem>;
+    optionsSource?: ListValue;
+    displayValue?: ListAttributeValue<string>;
+}`;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generate.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generate.ts
@@ -15,6 +15,7 @@ const mxExports = [
     "ListAttributeValue",
     "ListExpressionValue",
     "ListWidgetValue",
+    "ModifiableValue",
     "WebIcon",
     "WebImage"
 ];

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
@@ -122,6 +122,8 @@ function toClientPropType(
             return prop.$.dataSource
                 ? `ListAttributeValue<${uniqueTypes.join(" | ")}>`
                 : `EditableValue<${uniqueTypes.join(" | ")}>`;
+        case "association":
+            return "ModifiableValue<ObjectItem>";
         case "expression":
             if (!prop.returnType || prop.returnType.length === 0) {
                 throw new Error("[XML] Expression property requires returnType element");

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
@@ -50,6 +50,7 @@ function toPreviewPropType(prop: Property, generatedTypes: string[]): string {
             // { type: string } is included here due to an incorrect API output before 9.2 (PAG-1400)
             return "{} | { type: string } | null";
         case "attribute":
+        case "association":
         case "expression":
             return "string";
         case "enumeration":


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ❌ 
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Feature specific (??)
- Comply with designs ✅
- Comply with PM's requirements ✅

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
The most recent addition to the widgets API, namely, the association property is implemented in the widget types generator to provide a client component with the corresponding prop types.

## Relevant changes (??)
_Please add a high level explanation of what was changed and how the initial problem was solved_

## What should be covered while testing? (??)
_..._
