### PR TITLE
[NC] Automation: add logging (to be reverted)

### DIFF
--- a/scripts/release/createNativeModules.js
+++ b/scripts/release/createNativeModules.js
@@ -1,5 +1,5 @@
 const { basename, join } = require("path");
-const { readdir, copyFile, rm } = require("fs/promises");
+const { readdir, copyFile, rm, stat } = require("fs/promises");
 const {
     execShellCommand,
     getFiles,
@@ -134,6 +134,7 @@ async function updateNativeComponentsTestProject(moduleInfo, tmpFolder, nativeWi
                 const dest = join(tmpFolder, "widgets", basename(src));
                 await rm(dest, { force: true });
                 await copyFile(src, dest);
+                console.log(`Mode of ${dest}: ${unixFilePermissions((await stat(dest)).mode)}`);
             })
         ]);
     }
@@ -178,4 +179,8 @@ async function updateNativeComponentsTestProjectWithAtlas(moduleInfo, tmpFolder)
     } else {
         console.warn(`Nothing to commit from repo ${tmpFolder}`);
     }
+}
+
+function unixFilePermissions(mode) {
+    return "0" + (mode & parseInt("777", 8)).toString(8);
 }

--- a/scripts/release/module-automation/commons.js
+++ b/scripts/release/module-automation/commons.js
@@ -1,5 +1,5 @@
 const { basename, extname, join, resolve } = require("path");
-const { access, readdir, copyFile, readFile, writeFile, rename, rm, rmdir, mkdir } = require("fs/promises");
+const { access, readdir, copyFile, readFile, writeFile, rename, rm, rmdir, mkdir, stat } = require("fs/promises");
 const { exec } = require("child_process");
 
 const regex = {
@@ -272,6 +272,12 @@ async function exportModuleWithWidgets(moduleName, mpkOutput, widgetsFolders) {
         const fileName = basename(src);
         const dest = join(widgetsDestination, fileName);
         widgetEntries.push(fileName);
+        console.log(`Mode of ${basename(src)} copied from ${src}: ${unixFilePermissions((await stat(src)).mode)}`);
+        try {
+            console.log(`Mode of ${dest}: ${unixFilePermissions((await stat(dest)).mode)}`);
+        } catch (e) {
+            console.log(`Destination ${dest} doesnt exist`);
+        }
         await copyFile(src, dest);
     }
     // Add entries to the package.xml
@@ -314,3 +320,7 @@ module.exports = {
     unzip,
     exportModuleWithWidgets
 };
+
+function unixFilePermissions(mode) {
+    return "0" + (mode & parseInt("777", 8)).toString(8);
+}


### PR DESCRIPTION
Native release automation is experiencing permission errors. I investigated locally with no success. 

These changes add some logging that hopefully uncovers the issue (which seems to only occur on CI)

After pinpointing the issue, the logs will be reverted in a subsequent MR.