### PR TITLE
[NC] Automation: correct automation's excluded files regex

### DIFF
--- a/scripts/release/createNativeModules.js
+++ b/scripts/release/createNativeModules.js
@@ -12,7 +12,8 @@ const {
     cloneRepo,
     createMPK,
     createGithubRelease,
-    exportModuleWithWidgets
+    exportModuleWithWidgets,
+    regex
 } = require("./module-automation/commons");
 
 const repoRootPath = join(__dirname, "../../");
@@ -61,7 +62,7 @@ async function createNativeMobileResourcesModule() {
     const moduleChangelogs = await updateChangelogs(nativeWidgetFolders, moduleInfo);
     await commitAndCreatePullRequest(moduleInfo);
     await updateNativeComponentsTestProject(moduleInfo, tmpFolder, nativeWidgetFolders);
-    const mpkOutput = await createMPK(tmpFolder, moduleInfo, "^(resources|userlib)/.*");
+    const mpkOutput = await createMPK(tmpFolder, moduleInfo, regex.excludeFiles);
     await exportModuleWithWidgets(moduleInfo.moduleNameInModeler, mpkOutput, nativeWidgetFolders);
     await createGithubRelease(moduleInfo, moduleChangelogs, mpkOutput);
     await execShellCommand(`rm -rf ${tmpFolder}`);
@@ -83,7 +84,7 @@ async function createNanoflowCommonsModule() {
     const moduleChangelogs = await updateModuleChangelogs(moduleInfo);
     await commitAndCreatePullRequest(moduleInfo);
     await updateNativeComponentsTestProject(moduleInfo, tmpFolder);
-    const mpkOutput = await createMPK(tmpFolder, moduleInfo, "^(resources|userlib)/.*");
+    const mpkOutput = await createMPK(tmpFolder, moduleInfo, regex.excludeFiles);
     await createGithubRelease(moduleInfo, moduleChangelogs, mpkOutput);
     await execShellCommand(`rm -rf ${tmpFolder}`);
     console.log("Done.");
@@ -103,7 +104,7 @@ async function createAtlasNativeContentModule() {
     const moduleChangelogs = await updateModuleChangelogs(moduleInfo);
     await commitAndCreatePullRequest(moduleInfo);
     await updateNativeComponentsTestProjectWithAtlas(moduleInfo, tmpFolder);
-    const mpkOutput = await createMPK(tmpFolder, moduleInfo, "^(resources|userlib)/.*");
+    const mpkOutput = await createMPK(tmpFolder, moduleInfo, regex.excludeFiles);
     await createGithubRelease(moduleInfo, moduleChangelogs, mpkOutput);
     await execShellCommand(`rm -rf ${tmpFolder}`);
     console.log("Done.");

--- a/scripts/release/createNativeModules.js
+++ b/scripts/release/createNativeModules.js
@@ -61,7 +61,7 @@ async function createNativeMobileResourcesModule() {
     const moduleChangelogs = await updateChangelogs(nativeWidgetFolders, moduleInfo);
     await commitAndCreatePullRequest(moduleInfo);
     await updateNativeComponentsTestProject(moduleInfo, tmpFolder, nativeWidgetFolders);
-    const mpkOutput = await createMPK(tmpFolder, moduleInfo, `(resources|userlib)[\\/]`);
+    const mpkOutput = await createMPK(tmpFolder, moduleInfo, "^(resources|userlib)/.*");
     await exportModuleWithWidgets(moduleInfo.moduleNameInModeler, mpkOutput, nativeWidgetFolders);
     await createGithubRelease(moduleInfo, moduleChangelogs, mpkOutput);
     await execShellCommand(`rm -rf ${tmpFolder}`);
@@ -83,7 +83,7 @@ async function createNanoflowCommonsModule() {
     const moduleChangelogs = await updateModuleChangelogs(moduleInfo);
     await commitAndCreatePullRequest(moduleInfo);
     await updateNativeComponentsTestProject(moduleInfo, tmpFolder);
-    const mpkOutput = await createMPK(tmpFolder, moduleInfo, `(resources|userlib)[\\/]`);
+    const mpkOutput = await createMPK(tmpFolder, moduleInfo, "^(resources|userlib)/.*");
     await createGithubRelease(moduleInfo, moduleChangelogs, mpkOutput);
     await execShellCommand(`rm -rf ${tmpFolder}`);
     console.log("Done.");
@@ -103,7 +103,7 @@ async function createAtlasNativeContentModule() {
     const moduleChangelogs = await updateModuleChangelogs(moduleInfo);
     await commitAndCreatePullRequest(moduleInfo);
     await updateNativeComponentsTestProjectWithAtlas(moduleInfo, tmpFolder);
-    const mpkOutput = await createMPK(tmpFolder, moduleInfo, `(resources|userlib)[\\/]`);
+    const mpkOutput = await createMPK(tmpFolder, moduleInfo, "^(resources|userlib)/.*");
     await createGithubRelease(moduleInfo, moduleChangelogs, mpkOutput);
     await execShellCommand(`rm -rf ${tmpFolder}`);
     console.log("Done.");

--- a/scripts/release/createWebModules.js
+++ b/scripts/release/createWebModules.js
@@ -74,7 +74,7 @@ async function createDataWidgetsModule() {
     }
     await commitAndCreatePullRequest(moduleInfo);
     await updateTestProject(tmpFolder, dataWidgetsFolders, moduleInfo);
-    const mpkOutput = await createMPK(tmpFolder, moduleInfo, `(resources|userlib)[\\/]`);
+    const mpkOutput = await createMPK(tmpFolder, moduleInfo, "^(resources|userlib)/.*");
 
     await exportModuleWithWidgets(moduleInfo.moduleNameInModeler, mpkOutput, dataWidgetsFolders);
 
@@ -126,7 +126,7 @@ async function commonActions(moduleInfo, widgets) {
     }
     await commitAndCreatePullRequest(moduleInfo);
     await updateTestProjectWithWidgetsAndAtlas(moduleInfo, tmpFolder, widgets);
-    const mpkOutput = await createMPK(tmpFolder, moduleInfo, `(resources|userlib)[\\/]`);
+    const mpkOutput = await createMPK(tmpFolder, moduleInfo, "^(resources|userlib)/.*");
     await createGithubReleaseFrom({
         title: `${moduleInfo.nameWithSpace} - Marketplace Release v${moduleInfo.version}`,
         body: moduleChangelogs.replace(/"/g, "'"),

--- a/scripts/release/createWebModules.js
+++ b/scripts/release/createWebModules.js
@@ -11,7 +11,8 @@ const {
     createMPK,
     createGithubReleaseFrom,
     exportModuleWithWidgets,
-    updateModuleChangelogs
+    updateModuleChangelogs,
+    regex
 } = require("./module-automation/commons");
 
 const repoRootPath = join(__dirname, "../../");
@@ -74,7 +75,7 @@ async function createDataWidgetsModule() {
     }
     await commitAndCreatePullRequest(moduleInfo);
     await updateTestProject(tmpFolder, dataWidgetsFolders, moduleInfo);
-    const mpkOutput = await createMPK(tmpFolder, moduleInfo, "^(resources|userlib)/.*");
+    const mpkOutput = await createMPK(tmpFolder, moduleInfo, regex.excludeFiles);
 
     await exportModuleWithWidgets(moduleInfo.moduleNameInModeler, mpkOutput, dataWidgetsFolders);
 
@@ -126,7 +127,7 @@ async function commonActions(moduleInfo, widgets) {
     }
     await commitAndCreatePullRequest(moduleInfo);
     await updateTestProjectWithWidgetsAndAtlas(moduleInfo, tmpFolder, widgets);
-    const mpkOutput = await createMPK(tmpFolder, moduleInfo, "^(resources|userlib)/.*");
+    const mpkOutput = await createMPK(tmpFolder, moduleInfo, regex.excludeFiles);
     await createGithubReleaseFrom({
         title: `${moduleInfo.nameWithSpace} - Marketplace Release v${moduleInfo.version}`,
         body: moduleChangelogs.replace(/"/g, "'"),

--- a/scripts/release/module-automation/commons.js
+++ b/scripts/release/module-automation/commons.js
@@ -14,10 +14,11 @@ const {
 } = require("fs/promises");
 const { exec } = require("child_process");
 
-const regex = {
+export const regex = {
     changelogs: /(?<=## \[unreleased\]\n)((?!## \[\d+\.\d+\.\d+\])\W|\w)*/i,
     changelogsIncludingUnreleased: /## \[unreleased\]\n?((?!## \[\d+\.\d+\.\d+\])\W|\w)*/i,
-    releasedVersions: /(?<=## \[)\d+\.\d+\.\d+(?=\])/g
+    releasedVersions: /(?<=## \[)\d+\.\d+\.\d+(?=\])/g,
+    excludeFiles: "^(resources|userlib)/.*"
 };
 
 async function setLocalGitCredentials(workingDirectory) {


### PR DESCRIPTION
The previous regex didn't match files as desired; JS actions' node_modules were deleted from output .mpk, causing the bundler to break when running Studio Pro

This updated regex matches files in `resources/` and `userlib/`, meaning that all files in these directories will be excluded from the output mpk