### PR TITLE
[WC-1021] Fix RichText in FireFox

### DIFF
--- a/packages/pluggableWidgets/rich-text-web/rollup.config.js
+++ b/packages/pluggableWidgets/rich-text-web/rollup.config.js
@@ -27,11 +27,15 @@ function copyCKEditorDirToDist(outDir) {
                     /* we need to empty every single css (excluding editor and dialog) inside the folder to avoid duplicate bundling,
                      because even if the file is not imported anywhere it will be compiled inside RichText.js and RichText.mjs */
                     /* we need editor and dialog because it's required for loading styles on iframe elements (basically every dropdown,popup items from toolbar) */
-                    if (
-                        extname(src) === ".css" &&
-                        !(basename(src) === "editor.css" || basename(src) === "dialog.css")
-                    ) {
-                        return through((chunk, enc, done) => done(null, ""));
+                    if (extname(src) === ".css") {
+                        switch (basename(src)) {
+                            case "editor.css":
+                            case "editor_gecko.css":
+                            case "dialog.css":
+                                return;
+                            default:
+                                return through((chunk, enc, done) => done(null, ""));
+                        }
                     }
                 },
                 overwrite: true,

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.tsx
@@ -1,79 +1,39 @@
-import { ReactNode, createElement, useCallback } from "react";
+import { ReactNode, createElement, useMemo, useRef, useCallback } from "react";
 import { RichTextEditor as RichTextComponent } from "./components/RichText";
 import { RichTextContainerProps } from "../typings/RichTextProps";
-import { GroupType, createCustomToolbar, ToolbarItems } from "./utils/ckeditorPresets";
 import { debounce, executeAction } from "@mendix/piw-utils-internal";
-import { getPreset, defineAdvancedGroups } from "./utils/ckeditorConfigs";
-import { CKEditorConfig } from "ckeditor4-react";
 import loadingCircleSvg from "./ui/loading-circle.svg";
 import "./ui/RichText.scss";
+import { useEditorSettings } from "./utils/useEditorSettings";
 
 export default function RichText(props: RichTextContainerProps): ReactNode {
+    const [editorSettings, editorKey] = useEditorSettings(props);
+    const attributeRef = useRef(props.stringAttribute);
+    attributeRef.current = props.stringAttribute;
+
+    const onChange = useMemo(() => {
+        return debounce((value: string) => {
+            attributeRef.current.setValue(value);
+            if (props.onChange) {
+                executeAction(props.onChange);
+            }
+        }, 500);
+    }, [props.onChange, attributeRef]);
+
+    const onKeyPress = useCallback(() => executeAction(props.onKeyPress), [props.onKeyPress]);
+
     if (props.stringAttribute.status !== "available") {
         return <img src={loadingCircleSvg} className="widget-rich-text-loading-spinner" alt="" aria-hidden />;
     }
-    const onKeyChange = useCallback(() => executeAction(props.onChange), [props.onChange]);
-    const onKeyPress = useCallback(() => executeAction(props.onKeyPress), [props.onKeyPress]);
-    const onChangeFn = useCallback(
-        debounce((value: string) => props.stringAttribute.setValue(value), 500),
-        [props.stringAttribute]
-    );
-    const defineToolbar = (): CKEditorConfig => {
-        const { advancedConfig, toolbarConfig, preset } = props;
-        if (preset !== "custom") {
-            return getPreset(preset);
-        } else {
-            const groupKeys = Object.keys(props).filter((key: string) => (key.includes("Group") ? key : null));
-            let groupItems: ToolbarItems[] | string[];
-            if (toolbarConfig === "basic") {
-                groupItems = groupKeys
-                    .filter((groupName: GroupType) => props[groupName])
-                    .map((groupName: GroupType) =>
-                        groupName.includes("separator") ? "/" : groupName.replace("Group", "").toLowerCase()
-                    );
-            } else {
-                groupItems = defineAdvancedGroups(advancedConfig);
-            }
 
-            return createCustomToolbar(groupItems, toolbarConfig === "basic");
-        }
-    };
-    const plugins = [];
-    if (props.codeHighlight) {
-        plugins.push("codesnippet");
-    }
     return (
         <RichTextComponent
-            advancedConfig={props.advancedConfig}
-            advancedContentFilter={
-                props.advancedContentFilter === "custom"
-                    ? {
-                          allowedContent: props.allowedContent,
-                          disallowedContent: props.disallowedContent
-                      }
-                    : null
-            }
-            sanitizeContent={props.sanitizeContent}
-            name={props.name}
-            editorType={props.editorType}
-            readOnlyStyle={props.readOnlyStyle}
-            readOnly={props.stringAttribute.readOnly}
-            enterMode={props.enterMode}
-            shiftEnterMode={props.shiftEnterMode}
-            spellChecker={props.spellChecker}
-            toolbar={defineToolbar()}
-            plugins={plugins}
-            value={props.stringAttribute.value}
-            onValueChange={onChangeFn}
+            key={editorKey}
+            onChange={onChange}
             onKeyPress={onKeyPress}
-            onKeyChange={onKeyChange}
-            dimensions={{
-                width: props.width,
-                widthUnit: props.widthUnit,
-                height: props.height,
-                heightUnit: props.heightUnit
-            }}
-            tabIndex={props.tabIndex}
+            readOnlyStyle={props.stringAttribute.readOnly ? props.readOnlyStyle : undefined}
+            editorSettings={editorSettings}
+            value={props.stringAttribute.value ?? ""}
         />
     );
 }

--- a/packages/pluggableWidgets/rich-text-web/src/components/MainEditor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/MainEditor.tsx
@@ -1,6 +1,0 @@
-import { useCKEditor, CKEditorHookProps } from "ckeditor4-react";
-
-export const MainEditor = ({ config }: { config: CKEditorHookProps<string> }): null => {
-    useCKEditor(config);
-    return null;
-};

--- a/packages/pluggableWidgets/rich-text-web/src/components/RichText.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/RichText.tsx
@@ -10,9 +10,10 @@ export interface RichTextSettings {
     sanitizeContent?: boolean;
 }
 
-interface RichTextEditorProps {
+export interface RichTextEditorProps {
     value: string;
     editorSettings: RichTextSettings;
+    name?: string;
     onChange?: (value: string) => void;
     onKeyPress?: () => void;
     readOnlyStyle?: ReadOnlyStyleEnum;
@@ -20,6 +21,7 @@ interface RichTextEditorProps {
 
 export function RichTextEditor({
     value,
+    name,
     editorSettings,
     onChange,
     onKeyPress,
@@ -67,9 +69,9 @@ export function RichTextEditor({
     return (
         <div
             className={classNames("widget-rich-text", readOnlyStyle && `editor-${readOnlyStyle}`)}
-            style={{ width: editorSettings.config?.width }}
+            style={{ width: editorSettings.config?.width, height: editorSettings.config?.height }}
         >
-            <div ref={setElement} style={status !== "ready" ? { visibility: "hidden" } : undefined} />
+            <div id={name} ref={setElement} style={status !== "ready" ? { visibility: "hidden" } : undefined} />
         </div>
     );
 }

--- a/packages/pluggableWidgets/rich-text-web/src/components/__tests__/RichText.spec.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/__tests__/RichText.spec.tsx
@@ -1,39 +1,43 @@
 import { createElement } from "react";
 import "@testing-library/jest-dom";
-import { RichTextEditor, RichTextProps } from "../RichText";
-import { CKEditorConfig } from "ckeditor4-react";
+import { RichTextEditor, RichTextEditorProps } from "../RichText";
 import { getPreset, defineEnterMode, getToolbarGroupByName, defineAdvancedGroups } from "../../utils/ckeditorConfigs";
 import { mount, ReactWrapper } from "enzyme";
 import renderer from "react-test-renderer";
-import { getDimensions, Dimensions } from "@mendix/piw-utils-internal";
 import { TOOLBAR_GROUP, ToolbarGroup } from "../../utils/ckeditorPresets";
 import { AdvancedConfigType } from "../../../typings/RichTextProps";
+
+declare global {
+    interface Window {
+        CKEDITOR: any;
+    }
+}
 
 describe("RichText", () => {
     window.mx = {
         remoteUrl: ""
     };
-    const defaultRichTextProps: RichTextProps = {
-        advancedConfig: null,
-        dimensions: {
-            width: 100,
-            height: 100,
-            heightUnit: "percentageOfWidth",
-            widthUnit: "percentage"
-        },
-        plugins: [],
+    const defaultRichTextProps: RichTextEditorProps = {
         value: "Simple Text",
-        sanitizeContent: false,
-        advancedContentFilter: null,
-        readOnly: false,
         name: "RichText_Div",
-        spellChecker: false,
         readOnlyStyle: "text",
-        editorType: "classic",
-        enterMode: "paragraph",
-        shiftEnterMode: "paragraph",
-        toolbar: getPreset("basic"),
-        tabIndex: 1
+        editorSettings: {
+            sanitizeContent: false,
+            type: "classic",
+            config: {
+                advancedConfig: null,
+                width: "480px",
+                height: "320px",
+                plugins: [],
+                advancedContentFilter: null,
+                readOnly: false,
+                spellChecker: false,
+                enterMode: "paragraph",
+                shiftEnterMode: "paragraph",
+                toolbar: getPreset("basic"),
+                tabIndex: 1
+            }
+        }
     };
 
     function renderRichText(props = defaultRichTextProps): ReactWrapper {
@@ -54,32 +58,10 @@ describe("RichText", () => {
         expect(richTextElement?.getElements().length).toBeGreaterThan(0);
 
         const styleProps = richTextElement.getElements()[0].props.style;
-        const dimensions = getDimensions(defaultRichTextProps.dimensions as Dimensions);
-        expect(styleProps.width).toEqual(dimensions.width);
-        expect(styleProps.height).toEqual(dimensions.height);
+        expect(styleProps.width).toEqual(defaultRichTextProps.editorSettings.config!.width);
+        expect(styleProps.height).toEqual(defaultRichTextProps.editorSettings.config!.height);
 
         expect(richText.find(`.editor-${defaultRichTextProps.readOnlyStyle}`)).toEqual({});
-    });
-
-    it("renders MainEditor component with correct props", () => {
-        const richText = renderRichText();
-        const mainEditor = richText.find("MainEditor");
-        expect(mainEditor).toBeDefined();
-        const props = mainEditor.props() as CKEditorConfig;
-        const dimensions = getDimensions(defaultRichTextProps.dimensions as Dimensions);
-        const toolbar = getPreset("basic");
-        expect(props.config.initContent).toEqual(defaultRichTextProps.value);
-        expect(props.config.config).toMatchObject({
-            autoGrow_minHeight: 300,
-            toolbarCanCollapse: true,
-            autoGrow_onStartup: true,
-            width: dimensions.width,
-            height: dimensions.height,
-            enterMode: 1,
-            shiftEnterMode: 1,
-            disableNativeSpellChecker: !defaultRichTextProps.spellChecker,
-            ...toolbar
-        });
     });
 
     it("renders editor in read only mode with specified style", () => {

--- a/packages/pluggableWidgets/rich-text-web/src/components/__tests__/__snapshots__/RichText.spec.tsx.snap
+++ b/packages/pluggableWidgets/rich-text-web/src/components/__tests__/__snapshots__/RichText.spec.tsx.snap
@@ -2,16 +2,21 @@
 
 exports[`RichText render DOM structure 1`] = `
 <div
-  className="widget-rich-text"
+  className="widget-rich-text editor-text"
   style={
     Object {
-      "height": "auto",
-      "width": "100%",
+      "height": "320px",
+      "width": "480px",
     }
   }
 >
   <div
     id="RichText_Div"
+    style={
+      Object {
+        "visibility": "hidden",
+      }
+    }
   />
 </div>
 `;

--- a/packages/pluggableWidgets/rich-text-web/src/utils/useEditorSettings.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/useEditorSettings.ts
@@ -1,0 +1,118 @@
+import { useMemo } from "react";
+import { CKEditorConfig } from "ckeditor4-react";
+import { RichTextSettings } from "../components/RichText";
+import { RichTextContainerProps } from "../../typings/RichTextProps";
+import { getDimensions } from "@mendix/piw-utils-internal";
+import { addPlugin, defineAdvancedGroups, getPreset } from "./ckeditorConfigs";
+import { createCustomToolbar, GroupType, ToolbarItems } from "./ckeditorPresets";
+
+type ConfigReducer = {
+    (config: CKEditorConfig, props: RichTextContainerProps): CKEditorConfig;
+    getDeps: (props: RichTextContainerProps) => any[];
+};
+
+const mapProps: ConfigReducer = (config, props) => {
+    config.tabIndex = props.tabIndex;
+    config.readOnly = props.stringAttribute.readOnly;
+    config.disableNativeSpellChecker = !props.spellChecker;
+
+    return config;
+};
+
+mapProps.getDeps = props => [props.tabIndex, props.stringAttribute.readOnly, props.spellChecker];
+
+const editorWidth: ConfigReducer = (config, props) => {
+    const { width, height } = getDimensions(props);
+    config.width = width;
+    config.height = height;
+
+    return config;
+};
+
+editorWidth.getDeps = props => [props.width, props.widthUnit, props.height, props.heightUnit];
+
+const contentFilter: ConfigReducer = (config, props) => {
+    if (props.advancedContentFilter === "custom") {
+        config.allowedContent = props.allowedContent;
+        config.disallowedContent = props.disallowedContent;
+    }
+
+    return config;
+};
+
+contentFilter.getDeps = props => [props.advancedContentFilter];
+
+const plugins: ConfigReducer = (config, props) => {
+    if (props.codeHighlight) {
+        addPlugin("codesnippet", config);
+    }
+
+    return config;
+};
+
+plugins.getDeps = props => [props.codeHighlight];
+
+const toolbar: ConfigReducer = (config, props) => {
+    const { advancedConfig, toolbarConfig, preset } = props;
+    if (preset !== "custom") {
+        return Object.assign(config, getPreset(preset));
+    } else {
+        const groupKeys = Object.keys(props).filter((key: string) => (key.includes("Group") ? key : null));
+        let groupItems: ToolbarItems[] | string[];
+        if (toolbarConfig === "basic") {
+            groupItems = groupKeys
+                .filter((groupName: GroupType) => props[groupName])
+                .map((groupName: GroupType) =>
+                    groupName.includes("separator") ? "/" : groupName.replace("Group", "").toLowerCase()
+                );
+        } else {
+            groupItems = defineAdvancedGroups(advancedConfig);
+        }
+
+        return Object.assign(config, createCustomToolbar(groupItems, toolbarConfig === "basic"));
+    }
+};
+
+toolbar.getDeps = props => [props.advancedConfig, props.toolbarConfig, props.preset];
+
+const configReducers = [mapProps, editorWidth, toolbar, plugins, contentFilter];
+
+function createConfig(props: RichTextContainerProps): CKEditorConfig {
+    const initConfig: CKEditorConfig = {
+        autoGrow_minHeight: 300,
+        toolbarCanCollapse: true,
+        autoGrow_onStartup: true
+    };
+
+    return configReducers.reduce((config, fn) => fn(config, props), initConfig);
+}
+
+type EditorSettingsKey = string;
+
+type UseEditorSettingsResult = [RichTextSettings, EditorSettingsKey];
+
+/**
+ * This hook is intended to calculate CKEditor config.
+ * As CKEditor don't allow dynamic configuration, along with
+ * config we need calculate key. Key will be used to remount editor
+ * every time config is changed.
+ */
+export function useEditorSettings(props: RichTextContainerProps): UseEditorSettingsResult {
+    const getDependencies = (): any[] => {
+        const selectors = [() => [props.editorType, props.sanitizeContent], ...configReducers.map(fn => fn.getDeps)];
+
+        return selectors.map(fn => fn(props)).flat();
+    };
+    return useMemo(
+        () => [
+            {
+                type: props.editorType,
+                config: createConfig(props),
+                sanitizeContent: props.sanitizeContent
+            },
+            Date.now().toString()
+        ],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        getDependencies()
+    );
+}

--- a/packages/pluggableWidgets/rich-text-web/src/utils/useEditorSettings.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/utils/useEditorSettings.ts
@@ -21,7 +21,7 @@ const mapProps: ConfigReducer = (config, props) => {
 
 mapProps.getDeps = props => [props.tabIndex, props.stringAttribute.readOnly, props.spellChecker];
 
-const editorWidth: ConfigReducer = (config, props) => {
+const editorDimensions: ConfigReducer = (config, props) => {
     const { width, height } = getDimensions(props);
     config.width = width;
     config.height = height;
@@ -29,7 +29,7 @@ const editorWidth: ConfigReducer = (config, props) => {
     return config;
 };
 
-editorWidth.getDeps = props => [props.width, props.widthUnit, props.height, props.heightUnit];
+editorDimensions.getDeps = props => [props.width, props.widthUnit, props.height, props.heightUnit];
 
 const contentFilter: ConfigReducer = (config, props) => {
     if (props.advancedContentFilter === "custom") {
@@ -75,7 +75,7 @@ const toolbar: ConfigReducer = (config, props) => {
 
 toolbar.getDeps = props => [props.advancedConfig, props.toolbarConfig, props.preset];
 
-const configReducers = [mapProps, editorWidth, toolbar, plugins, contentFilter];
+const configReducers = [mapProps, editorDimensions, toolbar, plugins, contentFilter];
 
 function createConfig(props: RichTextContainerProps): CKEditorConfig {
     const initConfig: CKEditorConfig = {


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fix RichText in firefox and some minor fixes

## Relevant changes
- Fix for rollup config -- we exclude `editor_gecko.css` from being "cleard", so now CKEditor load correct styling
- Added fix for memoization of CKEditor config and introduce effect for syncing editor value with value from attribute (if changed outside of editor)

## What should be covered while testing?
- RichText in Firefox
- 2 instances of RichText on page connected to same attribute. Value changes in 1st editor should reflect in 2nd editor.