### PR TITLE
[WTF-1053] Finish Update pluggable widget tools for association property

### DIFF
--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/association.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/association.ts
@@ -4,7 +4,7 @@ export const associationInput = `<?xml version="1.0" encoding="utf-8"?>
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../xsd/widget.xsd">
     <properties>
         <propertyGroup caption="General">
-            <property key="reference" type="association" universeDataSource="optionsSource">
+            <property key="reference" type="association" selectableObjects="optionsSource">
                 <caption>Reference</caption>
                 <description/>
             </property>
@@ -29,7 +29,7 @@ export const associationInputNative = `<?xml version="1.0" encoding="utf-8"?>
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../xsd/widget.xsd">
     <properties>
         <propertyGroup caption="General">
-            <property key="reference" type="association" universeDataSource="optionsSource">
+            <property key="reference" type="association" selectableObjects="optionsSource">
                 <caption>Reference</caption>
                 <description/>
             </property>


### PR DESCRIPTION
`universeDataSource` attribute for an association property in a pluggable widget XML definition is being renamed into `selectableObjects`. The unit tests that run for typings-generator within pluggable-widgets-tools are adjusted in this PR, for the aforementioned change.

## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)
