### PR TITLE
[WC-1021] Fix RichText in firefox

### DIFF
--- a/packages/pluggableWidgets/rich-text-web/rollup.config.js
+++ b/packages/pluggableWidgets/rich-text-web/rollup.config.js
@@ -27,10 +27,7 @@ function copyCKEditorDirToDist(outDir) {
                     /* we need to empty every single css (excluding editor and dialog) inside the folder to avoid duplicate bundling,
                      because even if the file is not imported anywhere it will be compiled inside RichText.js and RichText.mjs */
                     /* we need editor and dialog because it's required for loading styles on iframe elements (basically every dropdown,popup items from toolbar) */
-                    if (
-                        extname(src) === ".css" &&
-                        !(basename(src) === "editor.css" || basename(src) === "dialog.css")
-                    ) {
+                    if (extname(src) === ".css" && !/(editor(_gecko)?|dialog).css/gi.test(basename(src))) {
                         return through((chunk, enc, done) => done(null, ""));
                     }
                 },

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.tsx
@@ -11,7 +11,6 @@ import "./ui/RichText.scss";
 export default function RichText(props: RichTextContainerProps): ReactNode {
     const onKeyChange = useCallback(() => executeAction(props.onChange), [props.onChange]);
     const onKeyPress = useCallback(() => executeAction(props.onKeyPress), [props.onKeyPress]);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     const onChangeFn = useCallback(
         debounce((value: string) => props.stringAttribute.setValue(value), 500),
         [props.stringAttribute]

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.tsx
@@ -9,15 +9,18 @@ import loadingCircleSvg from "./ui/loading-circle.svg";
 import "./ui/RichText.scss";
 
 export default function RichText(props: RichTextContainerProps): ReactNode {
-    if (props.stringAttribute.status !== "available") {
-        return <img src={loadingCircleSvg} className="widget-rich-text-loading-spinner" alt="" aria-hidden />;
-    }
     const onKeyChange = useCallback(() => executeAction(props.onChange), [props.onChange]);
     const onKeyPress = useCallback(() => executeAction(props.onKeyPress), [props.onKeyPress]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     const onChangeFn = useCallback(
         debounce((value: string) => props.stringAttribute.setValue(value), 500),
         [props.stringAttribute]
     );
+
+    if (props.stringAttribute.status !== "available") {
+        return <img src={loadingCircleSvg} className="widget-rich-text-loading-spinner" alt="" aria-hidden />;
+    }
+
     const defineToolbar = (): CKEditorConfig => {
         const { advancedConfig, toolbarConfig, preset } = props;
         if (preset !== "custom") {

--- a/packages/pluggableWidgets/rich-text-web/src/components/MainEditor.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/MainEditor.tsx
@@ -1,6 +1,24 @@
-import { useCKEditor, CKEditorHookProps } from "ckeditor4-react";
+import { useCKEditor, CKEditorHookProps, CKEditorInstance } from "ckeditor4-react";
 
-export const MainEditor = ({ config }: { config: CKEditorHookProps<string> }): null => {
+export interface MainEditoProps {
+    config: CKEditorHookProps<string>;
+    editorRef?: (editor: CKEditorInstance | null) => void;
+}
+export const MainEditor = ({ config, editorRef }: MainEditoProps): null => {
+    Object.assign(config.config, {
+        on: {
+            instanceReady() {
+                if (editorRef) {
+                    editorRef(this);
+                }
+            },
+            destroy() {
+                if (editorRef) {
+                    editorRef(null);
+                }
+            }
+        }
+    });
     useCKEditor(config);
     return null;
 };

--- a/packages/pluggableWidgets/rich-text-web/src/components/RichText.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/RichText.tsx
@@ -38,7 +38,7 @@ export const RichTextEditor = (props: RichTextProps): ReactElement => {
               width: "100%",
               height: "100%"
           };
-    const [ckeditorConfig, setCkeditorConfig] = useState<CKEditorHookProps<"change">>({
+    const [ckeditorConfig, setCkeditorConfig] = useState<CKEditorHookProps<"change" | "key">>({
         element,
         editorUrl: `${window.mx.remoteUrl}widgets/ckeditor/ckeditor.js`,
         type: editorType,
@@ -56,13 +56,15 @@ export const RichTextEditor = (props: RichTextProps): ReactElement => {
         },
         initContent: value,
         dispatchEvent: ({ type, payload }) => {
+            if (type === CKEditorEventAction.key) {
+                if (props.onKeyPress) {
+                    props.onKeyPress();
+                }
+            }
             if (type === CKEditorEventAction.change) {
                 const value = payload.editor.getData();
                 if (props.onKeyChange) {
                     props.onKeyChange();
-                }
-                if (props.onKeyPress) {
-                    props.onKeyPress();
                 }
                 if (props?.onValueChange) {
                     const content = props.sanitizeContent ? sanitizeHtml(value) : value;
@@ -70,7 +72,7 @@ export const RichTextEditor = (props: RichTextProps): ReactElement => {
                 }
             }
         },
-        subscribeTo: ["change"]
+        subscribeTo: ["change", "key"]
     });
     const key = useMemo(() => Date.now(), [ckeditorConfig]);
     useEffect(() => {

--- a/packages/pluggableWidgets/rich-text-web/src/components/RichText.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/components/RichText.tsx
@@ -87,33 +87,29 @@ export const RichTextEditor = (props: RichTextProps): ReactElement => {
         },
         subscribeTo: ["change", "key"]
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    const key = useMemo(() => Date.now(), [ckeditorConfig]);
-    useEffect(
-        () => {
-            const config = { ...props.toolbar };
-            if (plugins?.length) {
-                plugins.forEach((plugin: PluginName) => addPlugin(plugin, config));
-            }
-            if (advancedContentFilter) {
-                config.allowedContent = advancedContentFilter.allowedContent;
-                config.disallowedContent = advancedContentFilter.disallowedContent;
-            }
 
-            setCkeditorConfig({
-                ...ckeditorConfig,
-                initContent: value,
-                element,
-                config: {
-                    ...ckeditorConfig.config,
-                    ...config,
-                    readOnly: props.readOnly
-                }
-            });
-        },
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [element]
-    );
+    const key = useMemo(() => Date.now(), [ckeditorConfig]);
+    useEffect(() => {
+        const config = { ...props.toolbar };
+        if (plugins?.length) {
+            plugins.forEach((plugin: PluginName) => addPlugin(plugin, config));
+        }
+        if (advancedContentFilter) {
+            config.allowedContent = advancedContentFilter.allowedContent;
+            config.disallowedContent = advancedContentFilter.disallowedContent;
+        }
+
+        setCkeditorConfig({
+            ...ckeditorConfig,
+            initContent: value,
+            element,
+            config: {
+                ...ckeditorConfig.config,
+                ...config,
+                readOnly: props.readOnly
+            }
+        });
+    }, [element]);
 
     useEffect(() => {
         const editor = editorInstanceRef.current;


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

#### Feature specific
- Comply with designs ✅
- Comply with PM's requirements ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
- Fix CSS styling issue in Firefox
- Fix "Event -> On key press" action execution
- Fix focus reset issue

## Relevant changes
- `rollup.config.js` add regexp to copy content of critical editor dependencies
- change `dispatchEvent` function to react on "key" actions
- change `components/ReactText.tsx` to update value without re-rendering

## What should be covered while testing?
- RichText focus
- RichtText in firefox
- RichtText "On key press" event
