### PR TITLE
[WC-1043] Add design-mode preview for RichText

### DIFF
--- a/packages/pluggableWidgets/rich-text-web/src/RichText.editorPreview.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.editorPreview.tsx
@@ -1,14 +1,18 @@
 import { createElement, ReactElement } from "react";
-import RichTextPreviewSVGLight from "./assets/rich-text-preview-light.svg";
+import RichTextPreviewSVG from "./assets/rich-text-preview-light.svg";
 import { RichTextPreviewProps } from "../typings/RichTextProps";
 
 export const preview = (props: RichTextPreviewProps): ReactElement => {
-    let doc = decodeURIComponent(RichTextPreviewSVGLight.replace("data:image/svg+xml,", "")).replace(
-        "width='602' height='148'",
-        ""
-    );
-
+    let doc = decodeURI(RichTextPreviewSVG);
     doc = props.stringAttribute ? doc.replace("[No attribute selected]", `[${props.stringAttribute}]`) : doc;
 
-    return <div className="widget-rich-text" style={{ maxWidth: 602 }} dangerouslySetInnerHTML={{ __html: doc }}></div>;
+    return (
+        <div className="widget-rich-text">
+            <img src={doc} alt="" />
+        </div>
+    );
 };
+
+export function getPreviewCss(): string {
+    return require("./ui/RichTextEditorPreview.scss");
+}

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.editorPreview.tsx
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.editorPreview.tsx
@@ -1,1 +1,14 @@
-export const preview = (): null => null;
+import { createElement, ReactElement } from "react";
+import RichTextPreviewSVGLight from "./assets/rich-text-preview-light.svg";
+import { RichTextPreviewProps } from "../typings/RichTextProps";
+
+export const preview = (props: RichTextPreviewProps): ReactElement => {
+    let doc = decodeURIComponent(RichTextPreviewSVGLight.replace("data:image/svg+xml,", "")).replace(
+        "width='602' height='148'",
+        ""
+    );
+
+    doc = props.stringAttribute ? doc.replace("[No attribute selected]", `[${props.stringAttribute}]`) : doc;
+
+    return <div className="widget-rich-text" style={{ maxWidth: 602 }} dangerouslySetInnerHTML={{ __html: doc }}></div>;
+};

--- a/packages/pluggableWidgets/rich-text-web/src/ui/RichTextEditorPreview.scss
+++ b/packages/pluggableWidgets/rich-text-web/src/ui/RichTextEditorPreview.scss
@@ -1,0 +1,5 @@
+.widget-rich-text {
+    > img {
+        max-width: 100%;
+    }
+}


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ❌
- Compatible with Studio ✅
- Cross-browser compatible ✅

#### Feature specific
- Comply with designs ✅
- Comply with PM's requirements ✅

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Add design mode preview for RichText

## Relevant changes
- this PR introduces `preview` implementation for RichText (which was missing)

## What should be covered while testing?
- RichText widget preview in design mode
