### PR TITLE
Native feedback widget position improvement

### DIFF
--- a/packages/pluggableWidgets/feedback-native/src/Feedback.tsx
+++ b/packages/pluggableWidgets/feedback-native/src/Feedback.tsx
@@ -9,7 +9,8 @@ import {
     Text,
     TextInput,
     TouchableOpacity,
-    View
+    View,
+    ViewStyle
 } from "react-native";
 import Dialog from "react-native-dialog";
 import { captureScreen } from "react-native-view-shot";
@@ -21,6 +22,9 @@ import {
     defaultFeedbackStyle,
     FeedbackStyle,
     floatingButtonContainer,
+    floatingButtonPositionTop,
+    floatingButtonPositionMiddle,
+    floatingButtonPositionBottom,
     imageStyle,
     processStyles,
     switchContainer
@@ -74,8 +78,25 @@ export class Feedback extends Component<FeedbackProps<FeedbackStyle>, State> {
     }
 
     private renderFloatingButton(): JSX.Element | null {
+        let floatingButtonContainerMergedStyle: ViewStyle = {};
+
+        switch (this.props.position) {
+            case "top":
+                floatingButtonContainerMergedStyle = { ...floatingButtonPositionTop };
+                break;
+            case "bottom":
+                floatingButtonContainerMergedStyle = { ...floatingButtonPositionBottom };
+                break;
+            case "middle":
+            default:
+                floatingButtonContainerMergedStyle = { ...floatingButtonPositionMiddle };
+                break;
+        }
         return this.state.status === "initial" ? (
-            <View style={floatingButtonContainer} testID={`${this.props.name}$button`}>
+            <View
+                style={[floatingButtonContainer, floatingButtonContainerMergedStyle]}
+                testID={`${this.props.name}$button`}
+            >
                 <View style={this.styles.floatingButton}>
                     <TouchableOpacity onPress={this.onFeedbackButtonPressHandler}>
                         {this.props.logo && this.props.logo.value ? (

--- a/packages/pluggableWidgets/feedback-native/src/Feedback.xml
+++ b/packages/pluggableWidgets/feedback-native/src/Feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <widget id="com.mendix.widget.native.feedback.Feedback" supportedPlatform="Native" needsEntityContext="true" offlineCapable="true" pluginWidget="true" xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd">
     <name>Feedback</name>
     <description>Allow users to submit feedback directly into the app project.</description>
@@ -19,6 +19,16 @@
             <caption>Logo</caption>
             <category>General</category>
             <description>For customized branding, add a logo to the widget. The recommended size of the image is 90 by 90 pixels.</description>
+        </property>
+        <property key="position" type="enumeration" defaultValue="middle">
+            <caption>Position</caption>
+            <category>General</category>
+            <description>Choose a position for the widget</description>
+            <enumerationValues>
+                <enumerationValue key="top">Top</enumerationValue>
+                <enumerationValue key="middle">Middle</enumerationValue>
+                <enumerationValue key="bottom">Bottom</enumerationValue>
+            </enumerationValues>
         </property>
     </properties>
 </widget>

--- a/packages/pluggableWidgets/feedback-native/src/ui/styles.ts
+++ b/packages/pluggableWidgets/feedback-native/src/ui/styles.ts
@@ -9,8 +9,19 @@ export const floatingButtonContainer: ViewStyle = {
     position: "absolute",
     right: 0,
     top: 0,
-    marginTop: Dimensions.get("window").height / 2 - 100,
     zIndex: 9999
+};
+
+export const floatingButtonPositionTop: ViewStyle = {
+    marginTop: Dimensions.get("window").height * 0.25 - 100
+};
+
+export const floatingButtonPositionMiddle: ViewStyle = {
+    marginTop: Dimensions.get("window").height * 0.5 - 100
+};
+
+export const floatingButtonPositionBottom: ViewStyle = {
+    marginTop: Dimensions.get("window").height * 0.75 - 100
 };
 
 export const imageStyle: ImageStyle = {

--- a/packages/pluggableWidgets/feedback-native/typings/FeedbackProps.d.ts
+++ b/packages/pluggableWidgets/feedback-native/typings/FeedbackProps.d.ts
@@ -6,12 +6,15 @@
 import { CSSProperties } from "react";
 import { DynamicValue, NativeImage } from "mendix";
 
+export type PositionEnum = "top" | "middle" | "bottom";
+
 export interface FeedbackProps<Style> {
     name: string;
     style: Style[];
     sprintrapp: string;
     allowScreenshot: boolean;
     logo?: DynamicValue<NativeImage>;
+    position: PositionEnum;
 }
 
 export interface FeedbackPreviewProps {
@@ -22,4 +25,5 @@ export interface FeedbackPreviewProps {
     sprintrapp: string;
     allowScreenshot: boolean;
     logo: { type: "static"; imageUrl: string } | { type: "dynamic"; entity: string } | null;
+    position: PositionEnum;
 }


### PR DESCRIPTION
## Checklist
- Contains unit tests  ❌
- Contains breaking changes  ❌
- Contains Atlas changes  ❌
- Compatible with: MX 7️⃣, 8️⃣, 9️⃣

#### Native specific
- Works in Android ✅
- Works in iOS ✅
- Works in Tablet ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
To give the ability to adjust the feedback widget's height by 25%/50%/75% of the screen.

## Relevant changes
The position of the feedback widget was always fixed at 50% height and we wanted to add some flexibility to that.