### PR TITLE
[WC-1000] Use calc for calculations with mixing units

### DIFF
--- a/packages/modules/atlas-core/CHANGELOG.md
+++ b/packages/modules/atlas-core/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- Added support for setting variables using relative length CSS units.
+
 ## [3.1.1] Atlas Core - 2022-2-18
 ### Fixed
 - We fixed an issue with logo covering the whole login page when opening in firefox (Ticket 141170).

--- a/packages/modules/atlas-core/package.json
+++ b/packages/modules/atlas-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlas-core",
   "moduleName": "Atlas Core",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "repository": {

--- a/packages/modules/atlas-web-content/CHANGELOG.md
+++ b/packages/modules/atlas-web-content/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- Added support for setting variables using relative length CSS units.
+
 ## [3.0.6] - 2021-09-28
 
 ### Changed

--- a/packages/modules/atlas-web-content/package.json
+++ b/packages/modules/atlas-web-content/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlas-web-content",
   "moduleName": "Atlas Web Content",
-  "version": "3.0.6",
+  "version": "3.1.0",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "repository": {

--- a/packages/theming/atlas/src/theme/web/custom-variables.scss
+++ b/packages/theming/atlas/src/theme/web/custom-variables.scss
@@ -618,10 +618,10 @@ $screen-lg: 992px;
 $screen-xl: 1200px;
 
 // So media queries don't overlap when required, provide a maximum (used for max-width)
-$screen-xs-max: ($screen-sm - 1);
-$screen-sm-max: ($screen-md - 1);
-$screen-md-max: ($screen-lg - 1);
-$screen-lg-max: ($screen-xl - 1);
+$screen-xs-max: calc(#{$screen-sm} - 1px);
+$screen-sm-max: calc(#{$screen-md} - 1px);
+$screen-md-max: calc(#{$screen-lg} - 1px);
+$screen-lg-max: calc(#{$screen-xl} - 1px);
 
 //== Settings
 //## Enable or disable your desired framework features

--- a/packages/theming/atlas/src/themesource/atlas_core/web/_variables.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/_variables.scss
@@ -169,7 +169,6 @@ $navtopbar-sub-color: #aaa !default;
 $navtopbar-sub-color-hover: $brand-primary !default;
 $navtopbar-sub-color-active: $brand-primary !default;
 
-
 //== Cards
 // Shadow color
 $shadow-color-border: rgba($gray-primary, 0.5);
@@ -179,7 +178,6 @@ $shadow-color: rgba($gray-primary, 0.66);
 $shadow-small: 0 2px 4px 0;
 $shadow-medium: 0 5px 7px 0;
 $shadow-large: 0 8px 10px 0;
-
 
 //## Used in layouts/base
 $navtopbar-border-color: $topbar-border-color !default;
@@ -635,10 +633,10 @@ $screen-lg: 992px !default;
 $screen-xl: 1200px !default;
 
 // So media queries don't overlap when required, provide a maximum (used for max-width)
-$screen-xs-max: ($screen-sm - 1) !default;
-$screen-sm-max: ($screen-md - 1) !default;
-$screen-md-max: ($screen-lg - 1) !default;
-$screen-lg-max: ($screen-xl - 1) !default;
+$screen-xs-max: calc(#{$screen-sm} - 1px) !default;
+$screen-sm-max: calc(#{$screen-md} - 1px) !default;
+$screen-md-max: calc(#{$screen-lg} - 1px) !default;
+$screen-lg-max: calc(#{$screen-xl} - 1px) !default;
 
 //== Settings
 //## Enable or disable your desired framework features

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_tab-container.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_tab-container.scss
@@ -142,8 +142,8 @@
                 text-align: center;
 
                 & > a {
-                    width: ($spacing-medium * 2) + 1;
-                    height: ($spacing-medium * 2) + 1;
+                    width: calc((#{$spacing-medium} * 2) + 1px);
+                    height: calc((#{$spacing-medium} * 2) + 1px);
                     margin: auto;
                     padding: 0;
                     text-align: center;

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_badge.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_badge.scss
@@ -47,12 +47,12 @@
     .widget-badge.badge:empty {
         display: initial;
         /* Fix padding to stay round */
-        padding: $spacing-smaller ($spacing-small + 2px);
+        padding: $spacing-smaller calc(#{$spacing-small} + 2px);
     }
 
     .widget-badge.label:empty {
         display: initial;
         /* Fix padding to stay square */
-        padding: $spacing-smaller ($spacing-small + 2px);
+        padding: $spacing-smaller calc(#{$spacing-small} + 2px);
     }
 }

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_button.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_button.scss
@@ -79,7 +79,7 @@
     .mx-link {
         img {
             //height: auto; // MXUI override who set the height on 16px default
-            height: $font-size-default + 4px;
+            height: calc(#{$font-size-default} + 4px);
             margin-right: 4px;
             vertical-align: text-top;
         }

--- a/packages/theming/atlas/src/themesource/atlas_core/web/layouts/_layout-atlas-responsive.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/layouts/_layout-atlas-responsive.scss
@@ -115,7 +115,7 @@
                     display: flex;
                     padding: $spacing-small;
                     align-items: center;
-                    min-height: $topbar-minimalheight + 4px;
+                    min-height: calc(#{$topbar-minimalheight} + 4px);
                     background: $navsidebar-sub-bg;
                 }
 

--- a/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_wizard.scss
+++ b/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_wizard.scss
@@ -57,7 +57,7 @@
 //Wizard arrow
 .wizard-arrow .wizard-step {
     height: $wizard-step-height;
-    margin-left: 0 - ($wizard-step-height / 2);
+    margin-left: calc(0px - (#{$wizard-step-height} / 2));
     padding-left: ($wizard-step-height / 2);
     background-color: $wizard-default-bg;
     justify-content: flex-start;
@@ -67,14 +67,14 @@
         position: absolute;
         z-index: 1;
         left: 100%;
-        margin-left: 0 - (($wizard-step-height / 2) - 1);
+        margin-left: calc(0px - ((#{$wizard-step-height} / 2) - 1px));
         content: " ";
         border-style: solid;
         border-color: transparent;
     }
     &::after {
         top: 0;
-        border-width: (($wizard-step-height / 2) - 1);
+        border-width: calc((#{$wizard-step-height} / 2) - 1px);
         border-left-color: $wizard-default-bg;
     }
     &::before {


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ✅ 
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Add `calc` around calculations that could mix units, in particular where we in atlas assumed the use of certain units (pixels). The problem is that you can't do e.g. normal addition between a pixel and rem value. Instead, we have to wrap it with a CSS `calc` function.
