### PR TITLE
[WC-1046] widget generator double quote in user answers

### DIFF
--- a/packages/tools/generator-widget/CHANGELOG.md
+++ b/packages/tools/generator-widget/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- We fixed an issue with generator producing invalid package.json file when user provides answers that has double quotes. (Ticket 142686) 
+
 ## [9.2.0] - 2022-01-07
 
 ### Added

--- a/packages/tools/generator-widget/generators/app/lib/prompttexts.js
+++ b/packages/tools/generator-widget/generators/app/lib/prompttexts.js
@@ -6,7 +6,7 @@ function promptWidgetProperties(mxProjectDir, widgetName) {
             type: "input",
             name: "name",
             validate: input => {
-                if (/^([a-zA-Z-]+)$/.test(input)) {
+                if (/^([a-zA-Z]+)$/.test(input)) {
                     return true;
                 }
                 return "Your widget name can only contain one or more letters (a-z & A-Z). Please provide a valid name";

--- a/packages/tools/generator-widget/generators/app/lib/prompttexts.js
+++ b/packages/tools/generator-widget/generators/app/lib/prompttexts.js
@@ -18,52 +18,28 @@ function promptWidgetProperties(mxProjectDir, widgetName) {
             type: "input",
             name: "description",
             message: "Enter a description for your widget",
-            default: "My widget description",
-            validate: input => {
-                if (/^[\w\s!?.'"-]+$/gi.test(input)) {
-                    return true;
-                }
-                return "Your widget description can only contain one or more letters, quotes or punctuation marks. Please provide a valid description";
-            }
+            default: "My widget description"
         },
         {
             type: "input",
             name: "organization",
             message: "Organization name",
             default: "Mendix",
-            store: true,
-            validate: input => {
-                if (/^[^"]+$/gi.test(input)) {
-                    return true;
-                }
-                return "Double quotes not allowed, please remove quotes from your answer";
-            }
+            store: true
         },
         {
             type: "input",
             name: "copyright",
             message: "Add a copyright",
             default: "© Mendix Technology BV 2022. All rights reserved.",
-            store: true,
-            validate: input => {
-                if (/^[^"]+$/gi.test(input)) {
-                    return true;
-                }
-                return "Double quotes not allowed, please remove quotes from your answer";
-            }
+            store: true
         },
         {
             type: "input",
             name: "license",
             message: "Add a license",
             default: "Apache-2.0",
-            store: true,
-            validate: input => {
-                if (/^[^"]+$/gi.test(input)) {
-                    return true;
-                }
-                return "Double quotes not allowed, please remove quotes from your answer";
-            }
+            store: true
         },
         {
             type: "input",
@@ -82,25 +58,13 @@ function promptWidgetProperties(mxProjectDir, widgetName) {
             name: "author",
             message: "Author",
             default: "John",
-            store: true,
-            validate: input => {
-                if (/^[^"]+$/gi.test(input)) {
-                    return true;
-                }
-                return "Double quotes not allowed, please remove quotes from your answer";
-            }
+            store: true
         },
         {
             type: "input",
             name: "projectPath",
             message: "Mendix project path",
-            default: mxProjectDir ? mxProjectDir : "./tests/testProject",
-            validate: input => {
-                if (/^[^"]+$/gi.test(input)) {
-                    return true;
-                }
-                return "Double quotes not allowed, please remove quotes from your answer";
-            }
+            default: mxProjectDir ? mxProjectDir : "./tests/testProject"
         },
         {
             type: "list",

--- a/packages/tools/generator-widget/generators/app/lib/prompttexts.js
+++ b/packages/tools/generator-widget/generators/app/lib/prompttexts.js
@@ -6,7 +6,7 @@ function promptWidgetProperties(mxProjectDir, widgetName) {
             type: "input",
             name: "name",
             validate: input => {
-                if (/^([a-zA-Z]+)$/.test(input)) {
+                if (/^([a-zA-Z-]+)$/.test(input)) {
                     return true;
                 }
                 return "Your widget name can only contain one or more letters (a-z & A-Z). Please provide a valid name";
@@ -18,28 +18,52 @@ function promptWidgetProperties(mxProjectDir, widgetName) {
             type: "input",
             name: "description",
             message: "Enter a description for your widget",
-            default: "My widget description"
+            default: "My widget description",
+            validate: input => {
+                if (/^[\w\s!?.'"-]+$/gi.test(input)) {
+                    return true;
+                }
+                return "Your widget description can only contain one or more letters, quotes or punctuation marks. Please provide a valid description";
+            }
         },
         {
             type: "input",
             name: "organization",
             message: "Organization name",
             default: "Mendix",
-            store: true
+            store: true,
+            validate: input => {
+                if (/^[^"]+$/gi.test(input)) {
+                    return true;
+                }
+                return "Double quotes not allowed, please remove quotes from your answer";
+            }
         },
         {
             type: "input",
             name: "copyright",
             message: "Add a copyright",
             default: "© Mendix Technology BV 2022. All rights reserved.",
-            store: true
+            store: true,
+            validate: input => {
+                if (/^[^"]+$/gi.test(input)) {
+                    return true;
+                }
+                return "Double quotes not allowed, please remove quotes from your answer";
+            }
         },
         {
             type: "input",
             name: "license",
             message: "Add a license",
             default: "Apache-2.0",
-            store: true
+            store: true,
+            validate: input => {
+                if (/^[^"]+$/gi.test(input)) {
+                    return true;
+                }
+                return "Double quotes not allowed, please remove quotes from your answer";
+            }
         },
         {
             type: "input",
@@ -58,13 +82,25 @@ function promptWidgetProperties(mxProjectDir, widgetName) {
             name: "author",
             message: "Author",
             default: "John",
-            store: true
+            store: true,
+            validate: input => {
+                if (/^[^"]+$/gi.test(input)) {
+                    return true;
+                }
+                return "Double quotes not allowed, please remove quotes from your answer";
+            }
         },
         {
             type: "input",
             name: "projectPath",
             message: "Mendix project path",
-            default: mxProjectDir ? mxProjectDir : "./tests/testProject"
+            default: mxProjectDir ? mxProjectDir : "./tests/testProject",
+            validate: input => {
+                if (/^[^"]+$/gi.test(input)) {
+                    return true;
+                }
+                return "Double quotes not allowed, please remove quotes from your answer";
+            }
         },
         {
             type: "list",

--- a/packages/tools/generator-widget/generators/app/templates/packages/package_native.json.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/packages/package_native.json.ejs
@@ -2,17 +2,17 @@
   "name": "<%- packageName %>",
   "widgetName": "<%- name %>",
   "version": "<%- version %>",
-  "description": "<%- description %>",
-  "copyright": "<%- copyright %>",
-  "author": "<%- author %>",
+  "description": <%- JSON.stringify(description) %>,
+  "copyright": <%- JSON.stringify(copyright) %>,
+  "author": <%- JSON.stringify(author) %>,
   "engines": {
     "node": ">=12"
   },
-  "license": "<%- license %>",
+  "license": <%- JSON.stringify(license) %>,
   "config": {
-    "projectPath": "<%- projectPath %>/"
+    "projectPath": <%- JSON.stringify(projectPath) %>
   },
-  "packagePath": "<%- packagePath %>",
+  "packagePath": <%- JSON.stringify(packagePath) %>,
   "scripts": {
     "start": "pluggable-widgets-tools start:native",
     "build": "pluggable-widgets-tools build:native",
@@ -26,9 +26,6 @@
   "jest-junit": {
     "output": "./dist/testresults/TESTS-Jest.xml"
   },<% } %>
-  "bugs": {
-    "url": "https://github.com/<%- author %>/<%- packageName %>/issues"
-  },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": "^9.0.0"<% if (isLanguageTS) { %>,
     "@types/big.js": "^6.0.2",<% if (hasUnitTests) { %>

--- a/packages/tools/generator-widget/generators/app/templates/packages/package_web.json.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/packages/package_web.json.ejs
@@ -2,19 +2,19 @@
   "name": "<%- packageName %>",
   "widgetName": "<%- name %>",
   "version": "<%- version %>",
-  "description": "<%- description.replace(/["]/gi, '\\"') %>",
-  "copyright": "<%- copyright %>",
-  "author": "<%- author %>",
+  "description": <%- JSON.stringify(description) %>,
+  "copyright": <%- JSON.stringify(copyright) %>,
+  "author": <%- JSON.stringify(author) %>,
   "engines": {
     "node": ">=12"
   },
-  "license": "<%- license %>",
+  "license": <%- JSON.stringify(license) %>,
   "config": {
-    "projectPath": "<%- projectPath %>/",
+    "projectPath": <%- JSON.stringify(projectPath + '/') %>,
     "mendixHost": "http://localhost:8080",
     "developmentPort": 3000
   },
-  "packagePath": "<%- packagePath %>",
+  "packagePath": <%- JSON.stringify(packagePath) %>,
   "scripts": {
     "start": "pluggable-widgets-tools start:server",
     "dev": "pluggable-widgets-tools start:web",

--- a/packages/tools/generator-widget/generators/app/templates/packages/package_web.json.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/packages/package_web.json.ejs
@@ -2,7 +2,7 @@
   "name": "<%- packageName %>",
   "widgetName": "<%- name %>",
   "version": "<%- version %>",
-  "description": "<%- description %>",
+  "description": "<%- description.replace(/["]/gi, '\\"') %>",
   "copyright": "<%- copyright %>",
   "author": "<%- author %>",
   "engines": {

--- a/packages/tools/generator-widget/generators/app/templates/packages/package_web.json.ejs
+++ b/packages/tools/generator-widget/generators/app/templates/packages/package_web.json.ejs
@@ -10,7 +10,7 @@
   },
   "license": <%- JSON.stringify(license) %>,
   "config": {
-    "projectPath": <%- JSON.stringify(projectPath + '/') %>,
+    "projectPath": <%- JSON.stringify(projectPath) %>,
     "mendixHost": "http://localhost:8080",
     "developmentPort": 3000
   },

--- a/packages/tools/generator-widget/package.json
+++ b/packages/tools/generator-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/generator-widget",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Mendix Pluggable Widgets Generator",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 7️⃣, 8️⃣, 9️⃣

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
- Fix widget generator

## Relevant changes
- Add double quote validation for user prompts
- Allow double quotes in description answer (by doing escaping on user input)

## What should be covered while testing?
User input (answers)
