### PR TITLE
improve usability to have the striped color start from even rows

### DIFF
--- a/packages/modules/atlas-core/CHANGELOG.md
+++ b/packages/modules/atlas-core/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this widget will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- improve usability to have the striped color of datagrids, listview and templategrids to start from even rows
+
+### Fixed
+- templategrid striped color from fixed hex color value to the correct variable
 
 ## [3.1.1] Atlas Core - 2022-2-18
 ### Fixed

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_data-grid.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_data-grid.scss
@@ -65,7 +65,7 @@
             background-color: transparent;
 
             tbody tr {
-                &:nth-of-type(odd) {
+                &:nth-of-type(even) {
                     background-color: transparent;
                 }
 

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_list-view.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_list-view.scss
@@ -45,7 +45,7 @@
 
     // List items striped
     .listview-striped.mx-listview {
-        & > ul > li:nth-child(2n + 1) {
+        & > ul > li:nth-child(even) {
             background-color: $grid-bg-striped;
         }
     }

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_template-grid.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/helpers/_template-grid.scss
@@ -37,8 +37,8 @@
 
     // Striped
     .templategrid-striped.mx-templategrid {
-        .mx-templategrid-row:nth-child(odd) .mx-templategrid-item {
-            background-color: #f9f9f9;
+        .mx-templategrid-row:nth-child(even) .mx-templategrid-item {
+            background-color: $grid-bg-striped;
         }
     }
 


### PR DESCRIPTION
improve usability to have the striped color start from even rows, so that you have a nice clean view when you only have one row in your data, and striped style when more than one row.

Also fixed templategrid striped color from hex color to the correct variable

## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ✅
- Compatible with: MX  9️⃣

#### Web specific
- Contains e2e tests  ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Native specific
- Works in Android ✅ 
- Works in iOS ✅ 
- Works in Tablet ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

**_Please remove unnecessary emojis and sections and this comment before proceeding_**

## This PR contains
- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
_improve usability to have the striped color start from even rows, so that you have a delightful clean view when you only have 1 row in your data, and the striped style when there is more than one row. Also fixed templategrid striped color from hex color to the correct variable_

## Relevant changes
_templategrid, datagrid and listviews striped style color now start from even rows, templategrid had a fixed hex color for striped rows , now uses the variable_

## What should be covered while testing?
_that the striped style is still working for listviews, templategrids and datagrids_

## Extra comments (optional)
_Please add extra comments or delete the section if not required_
