### PR TITLE
[WC-1061] Structure preview for Carousel

### DIFF
--- a/packages/pluggableWidgets/carousel-web/src/Carousel.editorConfig.ts
+++ b/packages/pluggableWidgets/carousel-web/src/Carousel.editorConfig.ts
@@ -1,5 +1,18 @@
-import { Properties, transformGroupsIntoTabs, hidePropertiesIn } from "@mendix/piw-utils-internal";
+import {
+    Properties,
+    transformGroupsIntoTabs,
+    hidePropertiesIn,
+    StructurePreviewProps,
+    TextProps,
+    DropZoneProps,
+    ContainerProps,
+    RowLayoutProps,
+    ImageProps
+} from "@mendix/piw-utils-internal";
 import { CarouselPreviewProps } from "../typings/CarouselProps";
+import DotBlue from "./ui/dot_blue.svg";
+import DotGrey from "./ui/dot_grey.svg";
+import DotEmpty from "./ui/dot_empty.svg";
 
 export function getProperties(
     values: CarouselPreviewProps,
@@ -13,4 +26,94 @@ export function getProperties(
         transformGroupsIntoTabs(defaultProperties);
     }
     return defaultProperties;
+}
+
+export function getPreview(values: CarouselPreviewProps, isDarkMode: boolean): StructurePreviewProps | null {
+    const centerLayout = (props: RowLayoutProps): RowLayoutProps =>
+        ({
+            type: "RowLayout",
+            columnSize: "grow",
+            padding: 0,
+            children: [
+                {
+                    type: "Container",
+                    grow: 99,
+                    children: []
+                } as ContainerProps,
+                {
+                    type: "Container",
+                    grow: 1,
+                    children: [props]
+                },
+                {
+                    type: "Container",
+                    grow: 99,
+                    children: []
+                } as ContainerProps
+            ]
+        } as RowLayoutProps);
+    const neutralDots = [
+        {
+            type: "Image",
+            document: decodeURIComponent(DotEmpty.replace("data:image/svg+xml,", "")),
+            width: 8,
+            height: 8
+        } as ImageProps,
+        {
+            type: "Image",
+            document: decodeURIComponent(DotGrey.replace("data:image/svg+xml,", "")),
+            width: 8,
+            height: 8
+        } as ImageProps
+    ];
+    const titleHeader: RowLayoutProps = {
+        type: "RowLayout",
+        columnSize: "grow",
+        backgroundColor: isDarkMode ? "#4F4F4F" : "#F5F5F5",
+        borders: true,
+        borderWidth: 1,
+        children: [
+            {
+                type: "Container",
+                padding: 4,
+                children: [
+                    {
+                        type: "Text",
+                        content: "Carousel",
+                        fontColor: isDarkMode ? "#DEDEDE" : "#6B707B"
+                    } as TextProps
+                ]
+            }
+        ]
+    };
+    const triggerContent = {
+        type: "DropZone",
+        property: values.content,
+        placeholder: "Place widget(s) here",
+        grow: 1
+    } as DropZoneProps;
+    const pagingContent = {
+        type: "Container",
+        padding: 4,
+        children: [
+            centerLayout({
+                type: "RowLayout",
+                children: [
+                    {
+                        type: "Image",
+                        document: decodeURIComponent(DotBlue.replace("data:image/svg+xml,", "")),
+                        width: 8,
+                        height: 8
+                    } as ImageProps,
+                    ...neutralDots,
+                    ...neutralDots
+                ]
+            } as RowLayoutProps)
+        ]
+    } as ContainerProps;
+    return {
+        type: "Container",
+        borders: true,
+        children: [titleHeader, triggerContent, values.showPagination ? pagingContent : null]
+    } as ContainerProps;
 }

--- a/packages/pluggableWidgets/carousel-web/src/ui/dot_blue.svg
+++ b/packages/pluggableWidgets/carousel-web/src/ui/dot_blue.svg
@@ -1,0 +1,3 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="18" cy="18" r="18" fill="#007AFF"/>
+</svg>

--- a/packages/pluggableWidgets/carousel-web/src/ui/dot_empty.svg
+++ b/packages/pluggableWidgets/carousel-web/src/ui/dot_empty.svg
@@ -1,0 +1,3 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="18" cy="18" r="18" fill="white" fill-opacity="0.01"/>
+</svg>

--- a/packages/pluggableWidgets/carousel-web/src/ui/dot_grey.svg
+++ b/packages/pluggableWidgets/carousel-web/src/ui/dot_grey.svg
@@ -1,0 +1,3 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="18" cy="18" r="18" fill="#CFCFCF"/>
+</svg>


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

#### Feature specific
- Comply with designs ✅
- Comply with PM's requirements ✅

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Adding structure preview for new version of carousel

## Relevant changes
Added three type of dots. Blue, Transparent and Grey.
`Blue` is the active one, `grey` unselected one and `transparent` is for making space between `blue` and `grey` dots.
It was not possible to do with current structure mode api's, because when I use padding in a container it was breaking svg images, instead of dot's they became rectangular.

## What should be covered while testing?

## Extra comments (optional)
 `...neutralDots,
...neutralDots`
I copied the variable because somehow it wasn't working with function. If anyone knows why just let me know