### PR TITLE
[WTF-1075] Prepare XML for reference set support 

### DIFF
--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/WidgetXml.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/WidgetXml.ts
@@ -53,6 +53,7 @@ export interface Property {
     category?: string[];
     description?: string[];
     attributeTypes?: AttributeTypes[];
+    associationTypes?: AssociationTypes[];
     returnType?: ReturnType[];
     properties?: Properties[];
     enumerationValues?: Enumeration[];
@@ -66,6 +67,16 @@ export interface AttributeType {
 
 export interface AttributeTypes {
     attributeType: AttributeType[];
+}
+
+export interface AssociationType {
+    $: {
+        name: string;
+    };
+}
+
+export interface AssociationTypes {
+    associationType: AssociationType[];
 }
 
 export interface ReturnType {

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/association.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/association.ts
@@ -7,6 +7,9 @@ export const associationInput = `<?xml version="1.0" encoding="utf-8"?>
             <property key="reference" type="association" selectableObjects="optionsSource">
                 <caption>Reference</caption>
                 <description/>
+                <associationTypes>
+                    <associationType name="Reference"/>
+                </associationTypes>
             </property>
              <property key="optionsSource" type="datasource" isList="true" required="false">
                 <caption>Universe Data source</caption>
@@ -32,6 +35,9 @@ export const associationInputNative = `<?xml version="1.0" encoding="utf-8"?>
             <property key="reference" type="association" selectableObjects="optionsSource">
                 <caption>Reference</caption>
                 <description/>
+                <associationTypes>
+                    <associationType name="Reference"/>
+                </associationTypes>
             </property>
              <property key="optionsSource" type="datasource" isList="true" required="false">
                 <caption>Universe Data source</caption>

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
@@ -123,6 +123,9 @@ function toClientPropType(
                 ? `ListAttributeValue<${uniqueTypes.join(" | ")}>`
                 : `EditableValue<${uniqueTypes.join(" | ")}>`;
         case "association":
+            if (!prop.associationTypes?.length) {
+                throw new Error("[XML] Association property requires associationTypes element");
+            }
             return "ModifiableValue<ObjectItem>";
         case "expression":
             if (!prop.returnType || prop.returnType.length === 0) {


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

## This PR contains
- [x] Other (tooling update for not publicly released feature)

## What is the purpose of this PR?
Update the XML structure for the unreleased `association` property to make it forwards-compatible with future support for reference sets.

## Relevant changes
The widget generator now recognizes and enforces the presence of the new `associationTypes` element in the XML structure for the `association` property.

## What should be covered while testing?
Existing unit tests have been updated and cover everything.