### PR TITLE
[UIA-47] Fix multiple executions of on open handler in Notifications widget

### DIFF
--- a/packages/pluggableWidgets/notifications-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/notifications-native/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this widget will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- We fixed the 'On open' action being triggered twice when tapping a notification while the app was in a background or quit state.
 
 ## [3.1.0] - 2022-1-24
 

--- a/packages/pluggableWidgets/notifications-native/src/Notifications.tsx
+++ b/packages/pluggableWidgets/notifications-native/src/Notifications.tsx
@@ -2,6 +2,7 @@ import messaging, { FirebaseMessagingTypes } from "@react-native-firebase/messag
 import PushNotification from "react-native-push-notification";
 import { executeAction } from "@mendix/piw-utils-internal";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Platform } from "react-native";
 import { ActionValue, ValueStatus, Option } from "mendix";
 import "@react-native-firebase/app";
 
@@ -18,10 +19,11 @@ interface IPushNotification {
     channelId?: string;
     foreground: boolean;
     data: ActionData & {
-        actionIdentifier?: string;
-        userInteraction?: number;
-        messageId: string;
-    }; // iOS
+        actionIdentifier?: string; // iOS
+        userInteraction?: number; // iOS
+        "gcm.message_id"?: string; // iOS
+        "google.message_id"?: string; // Android
+    };
 }
 
 interface ActionData {
@@ -128,13 +130,10 @@ export function Notifications(props: NotificationsProps<undefined>): null {
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-expect-error - see comment top top of file
                 onNotification(notification: IPushNotification) {
-                    let messageId = "";
-                    if ("google.message_id" in notification.data) {
-                        messageId = notification.data["google.message_id"];
-                    }
-                    if ("gcm.message_id" in notification.data) {
-                        messageId = notification.data["gcm.message_id"];
-                    }
+                    const messageId =
+                        Platform.OS === "ios"
+                            ? notification.data["gcm.message_id"]
+                            : notification.data["google.message_id"];
 
                     handleNotification(
                         messageId,


### PR DESCRIPTION
#### Native specific
- Works in Android ✅
- Works in iOS ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fix the multiple executions of the 'On open' action in the Notifications widget, which occured when tapping a notification while the app is running in a background or exit state.

## Relevant changes
We added logic to maintain a set of processed notifications (on basis of the messageId), and use this to make sure notifications are processed only once.