### PR TITLE
[NC-664] Reduce module sizes

### DIFF
--- a/configs/jsactions/rollup.config.js
+++ b/configs/jsactions/rollup.config.js
@@ -81,20 +81,12 @@ export default async args => {
                                   }
                               }
 
-                              const destinationFolder = join(cwd, "tests/testProject/", jsActionTargetFolder);
-                              const destinations = [
-                                  destinationFolder,
-                                  ...[
-                                      process.env.MX_PROJECT_PATH
-                                          ? join(process.env.MX_PROJECT_PATH, jsActionTargetFolder)
-                                          : undefined
-                                  ]
-                              ];
-
-                              destinations.filter(Boolean).forEach(destination => {
+                              // this is helpful to copy the files and folders to a test project path for dev/testing purposes.
+                              if (process.env.MX_PROJECT_PATH) {
+                                  const destination = join(process.env.MX_PROJECT_PATH, jsActionTargetFolder);
                                   mkdirSync(destination, { recursive: true });
                                   copy(outDir, destination, { filter: ["**/*"], overwrite: true });
-                              });
+                              }
                           }
                       ])
                     : null

--- a/configs/jsactions/rollup.config.js
+++ b/configs/jsactions/rollup.config.js
@@ -61,7 +61,6 @@ export default async args => {
                           async () => {
                               if (!isWeb) {
                                   if (args.configProject === "nativemobileresources") {
-                                      // todo: whats concerning, is that fbjs is being installed in monorepo node_modules via something that ISNT a js action dependency...
                                       // `fbjs/lib/invariant` is being used silently by @react-native-community/cameraroll; it is not listed as a dependency not peerDependency.
                                       // https://github.dev/react-native-cameraroll/react-native-cameraroll/blob/7c269a837d095a2cb5f4ce13b54ab3060455b17f/js/CameraRoll.js#L14
                                       const path = join(outDir, "node_modules", "fbjs", "lib");
@@ -71,7 +70,6 @@ export default async args => {
                                           join(path, "invariant.js")
                                       );
                                   } else if (args.configProject === "nanoflowcommons") {
-                                      // todo: whats concerning, is that invariant is being installed in monorepo node_modules via something that ISNT a js action dependency...
                                       // `invariant` is being used silently by @react-native-community/geolocation; it is not listed as a dependency not peerDependency.
                                       // https://github.dev/react-native-geolocation/react-native-geolocation/blob/1786929f2be581da91082ff857c2393da5e597b3/js/implementation.native.js#L13
                                       await copyAsync(

--- a/configs/jsactions/rollup.config.js
+++ b/configs/jsactions/rollup.config.js
@@ -61,7 +61,7 @@ export default async args => {
                           async () => {
                               if (!isWeb) {
                                   if (args.configProject === "nativemobileresources") {
-                                      // `fbjs/lib/invariant` is being used silently by @react-native-community/cameraroll; it is not listed as a dependency not peerDependency.
+                                      // `fbjs/lib/invariant` is being used silently by @react-native-community/cameraroll; it is not listed as a dependency nor peerDependency.
                                       // https://github.dev/react-native-cameraroll/react-native-cameraroll/blob/7c269a837d095a2cb5f4ce13b54ab3060455b17f/js/CameraRoll.js#L14
                                       const path = join(outDir, "node_modules", "fbjs", "lib");
                                       mkdirSync(path, { recursive: true });
@@ -70,7 +70,7 @@ export default async args => {
                                           join(path, "invariant.js")
                                       );
                                   } else if (args.configProject === "nanoflowcommons") {
-                                      // `invariant` is being used silently by @react-native-community/geolocation; it is not listed as a dependency not peerDependency.
+                                      // `invariant` is being used silently by @react-native-community/geolocation; it is not listed as a dependency nor peerDependency.
                                       // https://github.dev/react-native-geolocation/react-native-geolocation/blob/1786929f2be581da91082ff857c2393da5e597b3/js/implementation.native.js#L13
                                       await copyAsync(
                                           dirname(require.resolve("invariant")),

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,6 +129,7 @@
 				"fast-glob": "^3.0.0",
 				"fast-json-patch": "^3.1.0",
 				"fast-xml-parser": "^4.0.1",
+				"fbjs": "^3.0.4",
 				"find-free-port": "^2.0.0",
 				"fork-ts-checker-webpack-plugin": "^5.2.1",
 				"fs-extra": "^9.0.1",
@@ -16998,6 +16999,14 @@
 				"yarn": ">=1"
 			}
 		},
+		"node_modules/cross-fetch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+			"integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+			"dependencies": {
+				"node-fetch": "2.6.7"
+			}
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -21169,31 +21178,23 @@
 			}
 		},
 		"node_modules/fbjs": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
-			"integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.4.tgz",
+			"integrity": "sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==",
 			"dependencies": {
-				"core-js": "^2.4.1",
+				"cross-fetch": "^3.1.5",
 				"fbjs-css-vars": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
 				"loose-envify": "^1.0.0",
 				"object-assign": "^4.1.0",
 				"promise": "^7.1.1",
 				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.18"
+				"ua-parser-js": "^0.7.30"
 			}
 		},
 		"node_modules/fbjs-css-vars": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
 			"integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
-		},
-		"node_modules/fbjs/node_modules/core-js": {
-			"version": "2.6.11",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-			"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-			"deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
-			"hasInstallScript": true
 		},
 		"node_modules/fbjs/node_modules/promise": {
 			"version": "7.3.1",
@@ -38025,6 +38026,36 @@
 				"react-native": "*"
 			}
 		},
+		"node_modules/react-native-reanimated/node_modules/core-js": {
+			"version": "2.6.12",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+			"deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+			"hasInstallScript": true
+		},
+		"node_modules/react-native-reanimated/node_modules/fbjs": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+			"integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+			"dependencies": {
+				"core-js": "^2.4.1",
+				"fbjs-css-vars": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.18"
+			}
+		},
+		"node_modules/react-native-reanimated/node_modules/promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"dependencies": {
+				"asap": "~2.0.3"
+			}
+		},
 		"node_modules/react-native-segmented-control-tab": {
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/react-native-segmented-control-tab/-/react-native-segmented-control-tab-3.4.1.tgz",
@@ -43821,9 +43852,19 @@
 			}
 		},
 		"node_modules/ua-parser-js": {
-			"version": "0.7.22",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-			"integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==",
+			"version": "0.7.31",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
+			"integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/ua-parser-js"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/faisalman"
+				}
+			],
 			"engines": {
 				"node": "*"
 			}
@@ -61184,6 +61225,14 @@
 				"cross-spawn": "^7.0.1"
 			}
 		},
+		"cross-fetch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+			"integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+			"requires": {
+				"node-fetch": "2.6.7"
+			}
+		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -64484,25 +64533,19 @@
 			}
 		},
 		"fbjs": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
-			"integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.4.tgz",
+			"integrity": "sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==",
 			"requires": {
-				"core-js": "^2.4.1",
+				"cross-fetch": "^3.1.5",
 				"fbjs-css-vars": "^1.0.0",
-				"isomorphic-fetch": "^2.1.1",
 				"loose-envify": "^1.0.0",
 				"object-assign": "^4.1.0",
 				"promise": "^7.1.1",
 				"setimmediate": "^1.0.5",
-				"ua-parser-js": "^0.7.18"
+				"ua-parser-js": "^0.7.30"
 			},
 			"dependencies": {
-				"core-js": {
-					"version": "2.6.11",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
-				},
 				"promise": {
 					"version": "7.3.1",
 					"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -77958,6 +78001,36 @@
 			"integrity": "sha512-3sF46jts9MbktgIasf0sTM8uhOYO5a5Q3YyQ4X1jjSE82n/fY2nW3XTFsLGfLEpK2ir4XSDhQWVgFHazaXZTww==",
 			"requires": {
 				"fbjs": "^1.0.0"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.6.12",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+				},
+				"fbjs": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+					"integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+					"requires": {
+						"core-js": "^2.4.1",
+						"fbjs-css-vars": "^1.0.0",
+						"isomorphic-fetch": "^2.1.1",
+						"loose-envify": "^1.0.0",
+						"object-assign": "^4.1.0",
+						"promise": "^7.1.1",
+						"setimmediate": "^1.0.5",
+						"ua-parser-js": "^0.7.18"
+					}
+				},
+				"promise": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+					"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+					"requires": {
+						"asap": "~2.0.3"
+					}
+				}
 			}
 		},
 		"react-native-segmented-control-tab": {
@@ -82584,9 +82657,9 @@
 			"integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
 		},
 		"ua-parser-js": {
-			"version": "0.7.22",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-			"integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
+			"version": "0.7.31",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
+			"integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ=="
 		},
 		"uglify-es": {
 			"version": "3.3.9",

--- a/packages/jsActions/mobile-resources-native/CHANGELOG.md
+++ b/packages/jsActions/mobile-resources-native/CHANGELOG.md
@@ -1,69 +1,89 @@
 # Changelog
+
 All notable changes to this widget will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+-   Reduce module size by removing unused dependencies. This should speed up interaction with Team Server.
+
 ## [3.5.1] Native Mobile Resources - 2022-3-9
 
-
 ## [3.2.0] Feedback
+
 ### Changed
 
 -   We have updated the feedback API
 
 ## [3.1.1] Notifications
+
 ### Fixed
-- We fixed the 'On open' action being triggered twice when tapping a notification while the app was in a background or quit state.
+
+-   We fixed the 'On open' action being triggered twice when tapping a notification while the app was in a background or quit state.
 
 ## [3.5.0] Native Mobile Resources - 2022-2-21
+
 ### Fixed
-- We updated the `HasNotificationPermission` action to prevent an incorrect result when permission was not yet requested on iOS. This is due to a change in the hasPermission method in react-native-firebase.
+
+-   We updated the `HasNotificationPermission` action to prevent an incorrect result when permission was not yet requested on iOS. This is due to a change in the hasPermission method in react-native-firebase.
 
 ### Added
-- Dark theme icons for JS Actions
+
+-   Dark theme icons for JS Actions
 
 ## [2.1.1] Accordion
+
 ### Fixed
-- All accordion groups will now be expanded when the widget is configured as non-collapsible.
+
+-   All accordion groups will now be expanded when the widget is configured as non-collapsible.
 
 ## [2.2.0] Badge
+
 ### Added
 
 -   Structure mode preview
 
 ## [3.2.0] BarcodeScanner
+
 ### Added
 
 -   Structure mode preview
 
 ## [1.2.0] ColorPicker
+
 ### Added
 
 -   Structure mode preview
 
 ## [4.2.0] ProgressBar
+
 ### Added
 
 -   Structure mode preview
 
 ## [2.2.0] RangeSlider
+
 ### Added
 
 -   Structure mode preview
 
 ## [2.2.0] Slider
+
 ### Added
 
 -   Structure mode preview
 
 ## [3.2.0] VideoPlayer
+
 ### Added
 
 -   Structure mode preview
 
 ## [3.1.1] WebView
+
 ### Fixed
 
 -   Fixed 'Open links externally' behavior. Webview no longer directly opens externally when this option is selected and url contains unexpected capitals (in http(s) part) or does not end with a slash.
@@ -75,333 +95,481 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [3.4.2] Native Mobile Resources - 2022-2-7
 
 ### Fixed
-- Rating and Image widgets have been updated.
+
+-   Rating and Image widgets have been updated.
 
 ## [1.0.1] Image
+
 ### Fixed
-- The version of a react-native-vector-icons now matches that which is included in Native Template.
+
+-   The version of a react-native-vector-icons now matches that which is included in Native Template.
 
 ## [2.1.1] Rating
+
 ### Fixed
-- The widget has been refactored and now includes a version of react-native-vector-icons that matches Native Template.
+
+-   The widget has been refactored and now includes a version of react-native-vector-icons that matches Native Template.
 
 ## [3.4.0] Native Mobile Resources - 2022-1-24
 
 ## [2.1.0] Accordion
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [2.1.0] ActivityIndicator
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [3.1.0] Animation
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [3.1.0] AppEvents
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [2.1.0] BackgroundImage
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [2.1.0] Badge
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [2.1.0] BarChart
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [3.1.0] BarcodeScanner
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [3.1.0] BottomSheet
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [2.1.0] Carousel
+
 ### Added
-- Update light and dark theme icons for Tile and List view.
+
+-   Update light and dark theme icons for Tile and List view.
 
 ## [1.1.0] ColorPicker
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [3.1.0] Feedback
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [3.1.0] FloatingActionButton
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [1.0.0] Image
+
 ### Added
-- We introduced the widget
+
+-   We introduced the widget
 
 ## [3.1.0] IntroScreen
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [2.1.0] LineChart
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [2.1.0] ListViewSwipe
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [3.1.0] Maps
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [3.1.0] Notifications
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [1.1.0] PieDoughnutChart
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [2.1.0] PopupMenu
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [4.1.0] ProgressBar
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [3.1.0] ProgressCircle
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [3.1.0] QRCode
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [2.1.0] RangeSlider
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [2.1.0] Rating
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [2.1.0] Repeater
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [2.1.0] SafeAreaView
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [2.1.0] Signature
+
 ### Added
-- Light and dark theme icons for Tile and List view.
+
+-   Light and dark theme icons for Tile and List view.
 
 ## [2.1.0] Slider
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [1.0.0] Switch
+
 ### Added
- - We added this widget.
+
+-   We added this widget.
 
 ## [2.1.0] ToggleButtons
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [3.1.0] VideoPlayer
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [3.1.0] WebView
+
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [1.0.0] Radio Buttons
+
 ### Added
-- We introduced this widget.
+
+-   We introduced this widget.
 
 ## [3.3.1] Native Mobile Resources - 2021-10-25
+
 ### Fixed
-- We removed some unwanted files from the module.
-- We added a check to avoid a superfluous warning message on iOS regarding Push Notifications.
+
+-   We removed some unwanted files from the module.
+-   We added a check to avoid a superfluous warning message on iOS regarding Push Notifications.
 
 ## [3.3.0] Native Mobile Resources - 2021-10-14
 
 ## [1.0.0] Pie Doughnut Chart
+
 ### Added
- - We added this new chart widget to display data in Pie or Doughnut chart representation.
+
+-   We added this new chart widget to display data in Pie or Doughnut chart representation.
 
 ## [3.2.0] Native Mobile Resources - 2021-9-28
 
 ## [2.0.0] Accordion
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [2.0.0] ActivityIndicator
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [3.0.0] Animation
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [3.0.0] AppEvents
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [2.0.0] BackgroundImage
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [2.0.0] Badge
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [2.0.0] BarChart
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [3.0.0] BarcodeScanner
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [3.0.0] BottomSheet
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [2.0.0] Carousel
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [1.0.0] ColorPicker
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [3.0.0] Feedback
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [3.0.0] FloatingActionButton
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [3.0.0] IntroScreen
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [2.0.0] LineChart
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [2.0.0] ListViewSwipe
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [3.0.0] Maps
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [3.0.0] Notifications
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [2.0.0] PopupMenu
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [4.0.0] ProgressBar
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [3.0.0] ProgressCircle
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [3.0.0] QRCode
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [2.0.0] RangeSlider
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [2.0.0] Rating
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [2.0.0] Repeater
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [2.0.0] SafeAreaView
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [2.0.0] Slider
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [2.0.0] ToggleButtons
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [3.0.0] VideoPlayer
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [3.0.0] WebView
+
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.
 
 ## [3.1.4] Native Mobile Resources - 2021-09-21
 
 ### Changed
-- The version of Native Mobile Resources is now stored in `themesource` directory in a file named `.version`. When this module is added to your Mendix project, the `.version` file will appear in `themesource/nativemobileresources` directory. Previously, the version was stored in a constant, seen in Studio Pro's Project Explorer. 
+
+-   The version of Native Mobile Resources is now stored in `themesource` directory in a file named `.version`. When this module is added to your Mendix project, the `.version` file will appear in `themesource/nativemobileresources` directory. Previously, the version was stored in a constant, seen in Studio Pro's Project Explorer.
 
 ### Fixed
-- We fixed an issue with some widget bundles erroneously including react-dom and thus were very large.
-- We fixed an issue with native release (production) bundles that were being mangled incorrectly, causing runtime errors.
+
+-   We fixed an issue with some widget bundles erroneously including react-dom and thus were very large.
+-   We fixed an issue with native release (production) bundles that were being mangled incorrectly, causing runtime errors.
 
 ### [1.0.1] Bar Chart
 
 #### Fixed
-- We have fixed the data source consistency check for MX 9.2 and above.
+
+-   We have fixed the data source consistency check for MX 9.2 and above.
 
 ### [1.0.1] Line Chart
 
 #### Fixed
-- We have fixed the data source consistency check for MX 9.2 and above.
+
+-   We have fixed the data source consistency check for MX 9.2 and above.
 
 ### [2.1.2] Maps
 
 #### Fixed
-- We fixed an issue where dynamic markers added on the fly were not added to the maps.
-- We fixed an issue where latitude or longitude with a value of 0 gave unexpected results.
+
+-   We fixed an issue where dynamic markers added on the fly were not added to the maps.
+-   We fixed an issue where latitude or longitude with a value of 0 gave unexpected results.
 
 ### [1.1.0] Slider
 
 #### Fixed
-- We fixed an issue where the widget sometimes threw a validation error when the step size property included decimals.
+
+-   We fixed an issue where the widget sometimes threw a validation error when the step size property included decimals.
 
 ## [3.1.0] Native Mobile Resources - 2021-08-26
 
 ### [2.1.0] Notifications widget
 
 #### Added
-- handle local notification "On open" actions. Note: local notification's do not handle "On receive" actions, despite being able to configure these in Studio Pro.
+
+-   handle local notification "On open" actions. Note: local notification's do not handle "On receive" actions, despite being able to configure these in Studio Pro.
 
 #### Fixed
-- a configured "Actions" property will receive the correct value; a concatenation of matching action names.
+
+-   a configured "Actions" property will receive the correct value; a concatenation of matching action names.
 
 ## [3.0.0] Native Mobile Resources - 2021-07-14
 
 ### Changed
-- TakePicture and TakePictureAdvanced actions support Android 11.
-- TakePicture and TakePictureAdvanced actions no longer support 'either' as a value for the parameter "pictureSource". You can model an action sheet using the Bottom sheet widget in the case where you want to offer to users "take picture" or "choose picture from image library" functionality.
+
+-   TakePicture and TakePictureAdvanced actions support Android 11.
+-   TakePicture and TakePictureAdvanced actions no longer support 'either' as a value for the parameter "pictureSource". You can model an action sheet using the Bottom sheet widget in the case where you want to offer to users "take picture" or "choose picture from image library" functionality.

--- a/packages/jsActions/mobile-resources-native/package.json
+++ b/packages/jsActions/mobile-resources-native/package.json
@@ -37,7 +37,7 @@
     "react-native-touch-id": "4.4.1",
     "url-parse": "^1.4.7",
     "react-native-permissions": "3.0.4",
-    "fbjs": "^3.0.4"
+    "fbjs": "3.0.4"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/jsActions/mobile-resources-native/package.json
+++ b/packages/jsActions/mobile-resources-native/package.json
@@ -37,7 +37,7 @@
     "react-native-touch-id": "4.4.1",
     "url-parse": "^1.4.7",
     "react-native-permissions": "3.0.4",
-    "fbjs": "1.0.0"
+    "fbjs": "^3.0.4"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/jsActions/mobile-resources-native/package.json
+++ b/packages/jsActions/mobile-resources-native/package.json
@@ -36,7 +36,8 @@
     "react-native-sound": "0.11.0",
     "react-native-touch-id": "4.4.1",
     "url-parse": "^1.4.7",
-    "react-native-permissions": "3.0.4"
+    "react-native-permissions": "3.0.4",
+    "fbjs": "1.0.0"
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",

--- a/packages/jsActions/mobile-resources-native/src/camera/TakePicture.ts
+++ b/packages/jsActions/mobile-resources-native/src/camera/TakePicture.ts
@@ -53,7 +53,7 @@ export async function TakePicture(
 
     // V3 dropped the feature of providing an action sheet so users can decide on which action to take, camera or library.
     const nativeVersionMajor = NativeModules.ImagePickerManager.showImagePicker ? 2 : 4;
-    const RNPermissions = nativeVersionMajor === 4 ? require("react-native-permissions") : null;
+    const RNPermissions = nativeVersionMajor === 4 ? (await import("react-native-permissions")).default : null;
 
     try {
         const uri = await takePicture();
@@ -178,9 +178,9 @@ export async function TakePicture(
         let requestResult: string;
 
         async function requestAndroidPermission(): Promise<string> {
-            requestResult = await RNPermissions.request(RNPermissions.PERMISSIONS.ANDROID.CAMERA);
+            requestResult = await RNPermissions!.request(RNPermissions!.PERMISSIONS.ANDROID.CAMERA);
 
-            if (requestResult === RNPermissions.RESULTS.DENIED) {
+            if (requestResult === RNPermissions!.RESULTS.DENIED) {
                 // re-enter request flow. note, if a request is denied twice, result = blocked.
                 requestResult = await requestAndroidPermission();
             }
@@ -189,16 +189,16 @@ export async function TakePicture(
         }
 
         // https://github.com/zoontek/react-native-permissions#android-flow
-        const statusResult = await RNPermissions.check(RNPermissions.PERMISSIONS.ANDROID.CAMERA);
+        const statusResult = await RNPermissions!.check(RNPermissions!.PERMISSIONS.ANDROID.CAMERA);
 
         switch (statusResult) {
-            case RNPermissions.RESULTS.UNAVAILABLE:
+            case RNPermissions!.RESULTS.UNAVAILABLE:
                 throw new Error("The camera is unavailable.");
-            case RNPermissions.RESULTS.BLOCKED:
+            case RNPermissions!.RESULTS.BLOCKED:
                 throw new Error("Camera access for this app is currently blocked.");
-            case RNPermissions.RESULTS.DENIED:
+            case RNPermissions!.RESULTS.DENIED:
                 requestResult = await requestAndroidPermission();
-                if (requestResult === RNPermissions.RESULTS.BLOCKED) {
+                if (requestResult === RNPermissions!.RESULTS.BLOCKED) {
                     throw new Error("Camera access for this app is currently blocked.");
                 }
                 break;

--- a/packages/jsActions/mobile-resources-native/src/camera/TakePictureAdvanced.ts
+++ b/packages/jsActions/mobile-resources-native/src/camera/TakePictureAdvanced.ts
@@ -59,7 +59,7 @@ export async function TakePictureAdvanced(
 
     // V3 dropped the feature of providing an action sheet so users can decide on which action to take, camera or library.
     const nativeVersionMajor = NativeModules.ImagePickerManager.showImagePicker ? 2 : 4;
-    const RNPermissions = nativeVersionMajor === 4 ? require("react-native-permissions") : null;
+    const RNPermissions = nativeVersionMajor === 4 ? (await import("react-native-permissions")).default : null;
     const resultObject = await createMxObject("NativeMobileResources.ImageMetaData");
 
     try {
@@ -228,9 +228,9 @@ export async function TakePictureAdvanced(
         let requestResult: string;
 
         async function requestAndroidPermission(): Promise<string> {
-            requestResult = await RNPermissions.request(RNPermissions.PERMISSIONS.ANDROID.CAMERA);
+            requestResult = await RNPermissions!.request(RNPermissions!.PERMISSIONS.ANDROID.CAMERA);
 
-            if (requestResult === RNPermissions.RESULTS.DENIED) {
+            if (requestResult === RNPermissions!.RESULTS.DENIED) {
                 // re-enter request flow. note, if a request is denied twice, result = blocked.
                 requestResult = await requestAndroidPermission();
             }
@@ -239,16 +239,16 @@ export async function TakePictureAdvanced(
         }
 
         // https://github.com/zoontek/react-native-permissions#android-flow
-        const statusResult = await RNPermissions.check(RNPermissions.PERMISSIONS.ANDROID.CAMERA);
+        const statusResult = await RNPermissions!.check(RNPermissions!.PERMISSIONS.ANDROID.CAMERA);
 
         switch (statusResult) {
-            case RNPermissions.RESULTS.UNAVAILABLE:
+            case RNPermissions!.RESULTS.UNAVAILABLE:
                 throw new Error("The camera is unavailable.");
-            case RNPermissions.RESULTS.BLOCKED:
+            case RNPermissions!.RESULTS.BLOCKED:
                 throw new Error("Camera access for this app is currently blocked.");
-            case RNPermissions.RESULTS.DENIED:
+            case RNPermissions!.RESULTS.DENIED:
                 requestResult = await requestAndroidPermission();
-                if (requestResult === RNPermissions.RESULTS.BLOCKED) {
+                if (requestResult === RNPermissions!.RESULTS.BLOCKED) {
                     throw new Error("Camera access for this app is currently blocked.");
                 }
                 break;

--- a/packages/jsActions/nanoflow-actions-native/CHANGELOG.md
+++ b/packages/jsActions/nanoflow-actions-native/CHANGELOG.md
@@ -1,36 +1,48 @@
 # Changelog
+
 All notable changes to this widget will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [2.3.0] Nanoflow Commons - 2022-3-9
 ### Fixed
 
-- We fixed the timeout error while getting the current location.
-- We fixed a timeout issue while getting the current location with minimum accuracy.
+-   Reduce module size by removing unused dependencies. This should speed up interaction with Team Server.
+
+## [2.3.0] Nanoflow Commons - 2022-3-9
+
+### Fixed
+
+-   We fixed the timeout error while getting the current location.
+-   We fixed a timeout issue while getting the current location with minimum accuracy.
 
 ### Breaking
 
-- iOS: We changed the library that uses [android.location API](https://developer.android.com/reference/android/location/package-summary), to the new library that uses the [Google Location Services API](https://developer.android.com/training/location/). Regarding this change, you should use `Request location permission` action before using `Get current location` and `Get current location with minimum accuracy` action.
-- Get current location with minimum accuracy: For good user experience, disable the nanoflow during action using property `Disabled during action` if you’re using `Call a nanoflow button` to run JS Action `Get current location with minimum accuracy`.
+-   iOS: We changed the library that uses [android.location API](https://developer.android.com/reference/android/location/package-summary), to the new library that uses the [Google Location Services API](https://developer.android.com/training/location/). Regarding this change, you should use `Request location permission` action before using `Get current location` and `Get current location with minimum accuracy` action.
+-   Get current location with minimum accuracy: For good user experience, disable the nanoflow during action using property `Disabled during action` if you’re using `Call a nanoflow button` to run JS Action `Get current location with minimum accuracy`.
 
 ## [2.2.0] Nanoflow Commons - 2022-2-21
+
 ### Added
-- We introduce a new `Get current location with minimum accuracy` action to acquire more precise locations.
-- Dark theme icons for JS Actions
+
+-   We introduce a new `Get current location with minimum accuracy` action to acquire more precise locations.
+-   Dark theme icons for JS Actions
 
 ### Fixed
-- We fixed a bug where the `Speed` was not being defined while using `Get current location` action.
-- We removed some unwanted files from the module.
+
+-   We fixed a bug where the `Speed` was not being defined while using `Get current location` action.
+-   We removed some unwanted files from the module.
 
 ## [2.1.2] Nanoflow Commons - 2021-10-25
+
 ### Fixed
-- We fixed a problem with toggle sidebar action when executed in Native apps.
-- We removed some unwanted files from the module.
+
+-   We fixed a problem with toggle sidebar action when executed in Native apps.
+-   We removed some unwanted files from the module.
 
 ## [2.1.0] Nanoflow Commons - 2021-9-28
 
 ### Added
-- We added a toolbox tile image for all JS actions in Studio & Studio Pro.
+
+-   We added a toolbox tile image for all JS actions in Studio & Studio Pro.

--- a/packages/jsActions/nanoflow-actions-native/src/other/GenerateUniqueID.ts
+++ b/packages/jsActions/nanoflow-actions-native/src/other/GenerateUniqueID.ts
@@ -19,27 +19,27 @@ async function initializeCounter(): Promise<void> {
     currentCounter = JSON.parse((await getItem(COUNTER_STORE)) || "-1");
 }
 
-function getItem(key: string): Promise<any> {
+async function getItem(key: string): Promise<any> {
     if (navigator && navigator.product === "ReactNative") {
-        const AsyncStorage = require("@react-native-community/async-storage").default;
+        const AsyncStorage = (await import("@react-native-community/async-storage")).default;
         return AsyncStorage.getItem(key);
     }
     if (window) {
-        const value = window.localStorage.getItem(key);
-        return Promise.resolve(value);
+        return window.localStorage.getItem(key);
     }
-    return Promise.reject(new Error("No storage API available"));
+
+    throw new Error("No storage API available");
 }
-function setItem(key: string, value: string): Promise<void> {
+async function setItem(key: string, value: string): Promise<void> {
     if (navigator && navigator.product === "ReactNative") {
-        const AsyncStorage = require("@react-native-community/async-storage").default;
+        const AsyncStorage = (await import("@react-native-community/async-storage")).default;
         return AsyncStorage.setItem(key, value);
     }
     if (window) {
-        window.localStorage.setItem(key, value);
-        return Promise.resolve();
+        return window.localStorage.setItem(key, value);
     }
-    return Promise.reject(new Error("No storage API available"));
+
+    throw new Error("No storage API available");
 }
 // END EXTRA CODE
 

--- a/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-collect-dependencies.js
@@ -104,12 +104,15 @@ async function getTransitiveDependencies(packagePath, isExternal) {
             .map(dependency => dependency[0]);
 
         for (const dependency of dependencies) {
+            if (isExternal(dependency)) {
+                continue;
+            }
             const resolvedPackagePath = await resolvePackage(
                 dependency,
                 nextPath,
                 optionalDependencies.includes(dependency) || optionalPeerDependencies.includes(dependency)
             );
-            if (isExternal(dependency) || !resolvedPackagePath) {
+            if (!resolvedPackagePath) {
                 continue;
             }
             queue.push(resolvedPackagePath);

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,45 +1,51 @@
 ## How to release widgets & modules to the appstore (`./marketplaceRelease.js`)
 
 #### Web Widgets
+
 1. Trigger the "Create Web Release" action manually in GitHub with the argument containing the widget name. Eg: "accordion-web".
-2. That's it! 
+2. That's it!
     - The content should now be released in GitHub.
     - The content should now be released in the MX Marketplace. Double check to verify.
 
 #### Web Modules
+
 1. Trigger the "Create Web Release" action manually in GitHub with the argument containing the module name. Eg "data-widgets".
-2. That's it! 
+2. That's it!
     - The content should now be released in GitHub.
     - The content should now be released in the MX Marketplace. Double check to verify.
 
 #### Atlas Core
+
 1. Trigger the "Create Web Release" action manually in GitHub with the argument "atlas-core".
 2. That's it!
     - The content should now be released in GitHub as a draft. Approve and publish it.
     - Then another GitHub action `MarketplaceRelease` will take care of releasing the module to the MX Marketplace. Double check to verify.
 
 #### Native Modules
+
 1. Make sure each changed widget has an appropriate change to it's `package.json` & `package.xml` (version bump) and changelog before releasing.
 1. Each widget or module's (e.g. `mobile-resources-native` or `nanoflow-actions-native`) `minimumMXVersion` (`package.json`) should match the Mendix project (`NativeComponentsTestProject`) Studio Pro version.
-1. On `master`, once all changes are merged, add a tag to the commit you want to create a release from. The tag should 
-be formatted like ${PackageName}-v${Major}.${Minor}.${Patch}. The automation script uses the version part to bump the 
-module's `package.json` version. Push this tag to GitHub, this will trigger a GitHub action.
-    - Example: `mobile-resources-native-v3.0.0`
-    - Example: `nanoflow-actions-native-v3.0.0`
-1. That's it! 
+1. On `master`, once all changes are merged, add a tag to the commit you want to create a release from. The tag should
+   be formatted like ${PackageName}-v${Major}.${Minor}.${Patch}. The automation script uses the version part to bump the
+   module's `package.json` version. Push this tag to GitHub, this will trigger a GitHub action. - Example: `mobile-resources-native-v3.0.0` - Example: `nanoflow-actions-native-v3.0.0`
+1. That's it!
     - The content should now be released in GitHub.
     - The content should now be released in the MX Marketplace. Double check to verify.
 
+Note: regarding JS actions and widgets, the automation will delete existing JS action and widgets from the test project before copying over that which comes from the widget resources repository. This is useful to avoid retaining stale files/dependencies, for example, as the codebase changes and thus sourcecode files/dependencies change.
+
 #### Hybrid Modules
+
 1. Add a tag to the commit you want to create a release from. The tag should be formatted like ${PackageName}-v${Major}.${Minor}.${Patch}
     - Example: `mobile-resources-hybrid-v1.0.0`
-1. That's it! 
+1. That's it!
     - The content should now be released in GitHub.
     - The content should now be released in the MX Marketplace. Double check to verify.
 
 #### Atlas Native Content Module
+
 1. Add a tag to the commit you want to create a release from. The tag should be formatted like ${PackageName}-v${Major}.${Minor}.${Patch}
     - Example: `atlas-content-native-v4.0.0`
-1. That's it! 
+1. That's it!
     - The content should now be released in GitHub.
     - The content should now be released in the MX Marketplace. Double check to verify.

--- a/scripts/release/createNativeModules.js
+++ b/scripts/release/createNativeModules.js
@@ -116,25 +116,30 @@ async function updateNativeComponentsTestProject(moduleInfo, tmpFolder, nativeWi
     const jsActions = await getFiles(jsActionsPath);
     const tmpFolderActions = join(tmpFolder, `javascriptsource/${moduleInfo.moduleFolderNameInModeler}/actions`);
 
-    console.log("Updating NativeComponentsTestProject..");
+    console.log("Updating NativeComponentsTestProject...");
     await cloneRepo(moduleInfo.testProjectUrl, tmpFolder);
 
-    console.log("Copying JS actions..");
+    console.log("Deleting existing JS Actions from test project...");
+    await rm(tmpFolderActions, { force: true, recursive: true }); // this is useful to avoid retaining stale dependencies in the test project.
+    await mkdir(tmpFolderActions);
+    console.log("Copying widget resources JS actions into test project...");
     await Promise.all([
         ...jsActions.map(async file => {
             const dest = join(tmpFolderActions, file.replace(jsActionsPath, ""));
-            await rm(dest, { force: true });
             await mkdir(dirname(dest), { recursive: true });
             await copyFile(file, dest);
         })
     ]);
     if (nativeWidgetFolders) {
-        console.log("Copying widgets..");
+        console.log("Deleting existing widgets from test project...");
+        const widgetsDir = join(tmpFolder, "widgets");
+        await rm(widgetsDir, { force: true, recursive: true }); // this is useful to avoid retaining stale widgets in the test project.
+        await mkdir(widgetsDir);
+        console.log("Copying widget resources widgets into test project...");
         await Promise.all([
             ...nativeWidgetFolders.map(async folder => {
                 const src = (await getFiles(folder, [`.mpk`]))[0];
-                const dest = join(tmpFolder, "widgets", basename(src));
-                await rm(dest, { force: true });
+                const dest = join(widgetsDir, basename(src));
                 await copyFile(src, dest);
             })
         ]);


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Native specific
- Works in Android ✅ 
- Works in iOS ✅ 
- Works in Tablet ✅ 

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other - remove unused dependencies and fix automation

## What is the purpose of this PR?
Our modules, Native Mobile Resources and Nanoflow Commons, were bloated in size and file count. This MR addresses this by removing unneeded dependencies (or parts thereof). 

Bonus: correct 3 js actions to use dynamic import using `import` statement intead of `require` syntax, because then the dependency that is dynamically imported is analysed/handled properly by rollup and added to the Native Dependency Management `.json` file (for native template) and node_modules in modules's folder. Previously, the dependency was *manually* added to the Native Components Test Project :( 

- Generate Unique ID
- Take Picture
- Take Picture Advance

Bonus: fix automation - instead of only adding new widgets and js actions, clear existing files and folders before copying over js actions and widgets. This avoids retaining stale files/dependencies. 

Bonus: during rollup build for js actions, no longer copy compiled output to `tests/testProject` as no workflow is using this.

Bonus: explicitly depend on `fbjs` in NMR. This will be stripped to just `fbjs/lib/invairant` by rollup.

## Relevant changes

1) Applying rollup.config changes results in the following changes to Native Components Test Project:

- deleted stale dependency `react-native-device-info` from NMR (is external)
- deleted `lib/commonsjs` + `lib/module` build variants of `react-native-image-picker` from NMR. These were stale artefacts. Metro uses the `.ts`.
- deleted `fbjs` from NC node_modules. No sourcecode or dependency uses it. `invariant` remains.
- deleted 99% of `fbjs` from NMR. Keep `fbjs/lib/invariant.js` as cameraroll uses it.

_Before change:_
Native Components Test Project commit cd346ab6f
NMR: 6.73mb 2,299 files
NC: 3.59mb 1,788 files

_after changes:_
NMR: 3.08mb 567 files
NC: 576kb, 144 files

2) Automation for NMR + NC will delete existing js action and widgets from the test project before copying over compiled js actions and widgets from widget resources. This avoids retaining anything stale as code changes.

## What should be covered while testing?
- Build custom native apps for android and iOS and perform regression tests using both NMR + NC (on both Android and iOS,  as bundles are different) ✅ 
  - check `GetDeviceInfo` (js action) + Intro Screen widget ✅ 
- On the latest MiN app on android and iOS, perform a smoke test of Generate Unique ID, Take Picture, and Take Picture Advance. For picture actions, particularly around permission requests. ✅ 
- Smoke test SaveToPictureLibrary js action, since now it only has one file from `fbjs`. ✅  
- Measure the performance of apps created with a native starter app ✅ 
  - Time taken when starter app with marketplace modules uploaded to Team server   
  - Time taken when starter app with branch modules uploaded to Team server   


**Test Result can be found in [NC-664]**(https://mendix.atlassian.net/browse/NC-664)


[NC-664]: https://mendix.atlassian.net/browse/NC-664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ