### PR TITLE
[NC-627] Inaccurate Current location using MiN and native

### DIFF
--- a/packages/jsActions/nanoflow-actions-native/CHANGELOG.md
+++ b/packages/jsActions/nanoflow-actions-native/CHANGELOG.md
@@ -6,10 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Fixed
+
 - We fixed the timeout error while getting the current location.
+- We fixed a timeout issue while getting the current location with minimum accuracy.
 
 ### Breaking
-- Get current location/iOS: We changed the library that uses [android.location API](https://developer.android.com/reference/android/location/package-summary), to the new library that uses the [Google Location Services API](https://developer.android.com/training/location/). Regarding this change, you should use `Request location permission` action before using `Get current location` action.
+
+- iOS: We changed the library that uses [android.location API](https://developer.android.com/reference/android/location/package-summary), to the new library that uses the [Google Location Services API](https://developer.android.com/training/location/). Regarding this change, you should use `Request location permission` action before using `Get current location` and `Get current location with minimum accuracy` action.
+- Get current location with minimum accuracy: For good user experience, disable the nanoflow during action using property `Disabled during action` if you’re using `Call a nanoflow button` to run JS Action `Get current location with minimum accuracy`.
 
 ## [2.2.0] Nanoflow Commons - 2022-2-21
 ### Added


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Native specific
- Works in Android ✅ 
- Works in iOS ✅ 
- Works in Tablet ✅ 

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
To solve the timeout issue while getting the current location with minimum accuracy.

## What should be covered while testing?
- `Get Current Location With Minimum Accuracy` should work correctly.
- It should be tested for backward compatibility.

## Extra comments (optional)
- This PR includes `Geolocation`'s library changes. The new library was added to the `MiN` app and merged to master, but has not been released yet, so to test this PR, you will need to build the `MiN` app from [master](https://gitlab.rnd.mendix.com/appdev/appdev/-/tree/master) manually.

- Fixes support ticket [#139889](https://mendixsupport.zendesk.com/agent/tickets/139889)
