### PR TITLE
[NC] Fix automation for new js actions

### DIFF
--- a/scripts/release/createNativeModules.js
+++ b/scripts/release/createNativeModules.js
@@ -123,7 +123,7 @@ async function updateNativeComponentsTestProject(moduleInfo, tmpFolder, nativeWi
     await Promise.all([
         ...jsActions.map(async file => {
             const dest = join(tmpFolderActions, file.replace(jsActionsPath, ""));
-            await rm(dest);
+            await rm(dest, { force: true });
             await copyFile(file, dest);
         })
     ]);


### PR DESCRIPTION
When a new js action is created, it won't exist in the test project. Don't throw an error in this case.