### PR TITLE
Added CSS Logical Properties to Atlas Web Content...

### DIFF
--- a/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_breadcrumb.scss
+++ b/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_breadcrumb.scss
@@ -27,8 +27,8 @@
 .breadcrumb-item + .breadcrumb-item {
     &::before {
         display: inline-block;
-        padding-right: $spacing-small;
-        padding-left: $spacing-small;
+        padding-inline-start: $spacing-small;
+        padding-inline-end: $spacing-small;
         content: "/";
         color: $gray-light;
     }

--- a/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_card.scss
+++ b/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_card.scss
@@ -20,8 +20,8 @@
 
 .card-overlay {
     position: absolute;
-    bottom: 0;
-    left: 0;
+    inset-block-end: 0;
+    inset-inline-start: 0;
     width: 100%;
     background: rgba(0, 0, 0, 0.6);
     background: linear-gradient(

--- a/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_chat.scss
+++ b/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_chat.scss
@@ -42,12 +42,15 @@
 
         .mx-listview-loadMore {
             position: absolute;
-            top: 0;
-            right: 0;
-            left: 0;
+            inset-block-start: 0;
+            inset-inline-end: 0;
+            inset-inline-start: 0;
             display: block;
             width: 50%;
-            margin: 15px auto;
+            margin-block-start: 15px;
+            margin-block-end: 15px;
+            margin-inline-start:auto ;
+            margin-inline-end: auto;
             color: #ffffff;
             background-color: $brand-primary;
             box-shadow: 0 2px 20px 0 rgba(0, 0, 0, 0.05);
@@ -60,7 +63,10 @@
 }
 
 .chat-avatar {
-    margin: 0 20px 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 20px;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-radius: 50%;
 }
 
@@ -79,15 +85,15 @@
 
     &::after {
         position: absolute;
-        top: 10px;
-        right: 100%;
+        inset-block-start: 10px;
+        inset-inline-end: 100%;
         width: 0;
         height: 0;
         content: "";
         border: 10px solid transparent;
-        border-top: 0;
-        border-right-color: $bg-color;
-        border-left: 0;
+        border-block-start: 0;
+        border-inline-end-color: $bg-color;
+        border-inline-start: 0;
     }
 }
 
@@ -111,7 +117,7 @@
 
     .chat-textbox {
         flex: 1;
-        margin-right: $spacing-large;
+        margin-inline-end: $spacing-large;
         margin-bottom: 0;
 
         .form-control {
@@ -126,18 +132,21 @@
     justify-content: flex-end;
 
     .chat-avatar {
-        margin: 0 0 0 20px;
+        margin-block-start: 0;
+        margin-block-end: 0;
+        margin-inline-start: 20px;
+        margin-inline-end: 0;
     }
 
     .chat-message-balloon {
         background-color: $color-primary-lighter;
 
         &::after {
-            left: 100%;
+            inset-inline-start: 100%;
             border: 10px solid transparent;
-            border-top: 0;
-            border-right: 0;
-            border-left-color: $color-primary-lighter;
+            border-block-start: 0;
+            border-inline-end: 0;
+            border-inline-start-color: $color-primary-lighter;
         }
     }
 

--- a/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_controlgroup.scss
+++ b/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_controlgroup.scss
@@ -6,20 +6,20 @@
 .controlgroup {
     .btn,
     .btn-group {
-        margin-right: $spacing-small;
+        margin-inline-end: $spacing-small;
         margin-bottom: $spacing-small;
 
         &:last-child {
-            margin-right: 0;
+            margin-inline-end: 0;
         }
         .btn {
-            margin-right: 0;
+            margin-inline-end: 0;
             margin-bottom: 0;
         }
     }
     .btn-group {
         .btn + .btn {
-            margin-left: -1px;
+            margin-inline-start: -1px;
         }
     }
 }

--- a/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_heroheader.scss
+++ b/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_heroheader.scss
@@ -26,7 +26,7 @@
 .headerhero-backgroundimage {
     position: absolute;
     z-index: 0;
-    top: 0;
+    inset-block-start: 0;
     height: 100%;
     width: 100%;
     filter: $header-bgimage-filter;

--- a/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_master-detail.scss
+++ b/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_master-detail.scss
@@ -6,7 +6,7 @@
 .masterdetail {
     background: #fff;
     .masterdetail-master {
-        border-right: 1px solid $border-color-default;
+        border-inline-end: 1px solid $border-color-default;
     }
     .masterdetail-detail {
         padding: $spacing-large;

--- a/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_pageblocks.scss
+++ b/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_pageblocks.scss
@@ -21,7 +21,7 @@
     .fullpage-overlay {
         position: absolute;
         z-index: 10;
-        inset-block-start: 0;
+        inset-block-end: 0;
         inset-inline-start: 0;
         width: 100%;
     }

--- a/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_pageblocks.scss
+++ b/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_pageblocks.scss
@@ -21,8 +21,8 @@
     .fullpage-overlay {
         position: absolute;
         z-index: 10;
-        bottom: 0;
-        left: 0;
+        inset-block-start: 0;
+        inset-inline-start: 0;
         width: 100%;
     }
 }

--- a/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_wizard.scss
+++ b/packages/theming/atlas/src/themesource/atlas_web_content/web/buildingblocks/_wizard.scss
@@ -45,7 +45,7 @@
     &::before {
         position: absolute;
         z-index: 0;
-        top: $wizard-step-number-size / 2;
+        inset-block-start: $wizard-step-number-size / 2;
         display: block;
         width: 100%;
         height: 2px;
@@ -57,8 +57,8 @@
 //Wizard arrow
 .wizard-arrow .wizard-step {
     height: $wizard-step-height;
-    margin-left: calc(0px - (#{$wizard-step-height} / 2));
-    padding-left: ($wizard-step-height / 2);
+    margin-inline-start: calc(0px - (#{$wizard-step-height} / 2));
+    padding-inline-start: ($wizard-step-height / 2);
     background-color: $wizard-default-bg;
     justify-content: flex-start;
     border: 1px solid $wizard-default-border-color;
@@ -66,33 +66,33 @@
     &::after {
         position: absolute;
         z-index: 1;
-        left: 100%;
-        margin-left: calc(0px - ((#{$wizard-step-height} / 2) - 1px));
+        inset-inline-start: 100%;
+        margin-inline-start: calc(0px - ((#{$wizard-step-height} / 2) - 1px));
         content: " ";
         border-style: solid;
         border-color: transparent;
     }
     &::after {
-        top: 0;
+        inset-block-start: 0;
         border-width: calc((#{$wizard-step-height} / 2) - 1px);
-        border-left-color: $wizard-default-bg;
+        border-inline-start-color: $wizard-default-bg;
     }
     &::before {
-        top: -1px;
+        inset-block-start: -1px;
         border-width: $wizard-step-height / 2;
-        border-left-color: $wizard-default-border-color;
+        border-inline-start-color: $wizard-default-border-color;
     }
 
     &:first-child {
-        margin-left: 0;
-        padding-left: 0;
-        border-top-left-radius: $border-radius-default;
-        border-bottom-left-radius: $border-radius-default;
+        margin-inline-start: 0;
+        padding-inline-start: 0;
+        border-start-start-radius: $border-radius-default;
+        border-end-start-radius: $border-radius-default;
     }
 
     &:last-child {
-        border-top-right-radius: $border-radius-default;
-        border-bottom-right-radius: $border-radius-default;
+        border-start-end-radius: $border-radius-default;
+        border-end-end-radius: $border-radius-default;
         &::before,
         &::after {
             display: none;
@@ -128,7 +128,7 @@
         color: $wizard-active-color;
     }
     &::after {
-        border-left-color: $wizard-active-bg;
+        border-inline-start-color: $wizard-active-bg;
     }
 }
 


### PR DESCRIPTION
Changed all the margins and paddings to logical properties to support both LTR and RTL layout. So no need to add extra css for RTL layout

## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ✅ 
- Contains Atlas changes ✅ 
- Compatible with: MX 7️⃣, 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ✅ 
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Native specific
- Works in Android ✅ 
- Works in iOS ✅ 
- Works in Tablet ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

**_Please remove unnecessary emojis and sections and this comment before proceeding_**

## This PR contains
- [x] Feature

## What is the purpose of this PR?
Added Logical Properties to support both LTR and RTL layouts

## Relevant changes
Added logical properties to Atlas Web Content, usually when changing the layout to RTL all the padding and margins are collapsed, so with this update we taking advantage of logical properties to support both LTR and RTL layout

## What should be covered while testing?
Layout and widgets

## Extra comments (optional)
Property | Logical Property

margin-top | margin-block-start
margin-left | margin-inline-start
margin-right | margin-inline-end
margin-bottom | margin-block-end

Property | Logical Property
padding-top | padding-block-start
padding-left | padding-inline-start
padding-right | padding-inline-end
padding-bottom | padding-block-end

and more...