### PR TITLE
[NC-685] Switch doesn't work after upgrade RN to 66

### DIFF
--- a/packages/pluggableWidgets/switch-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/switch-native/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed the `Illegal Cast Exception` issue caused by React Native 0.66 upgrade.
+- We added default thumb and track color.
+
 ## [1.0.0] - 2022-1-24
 
 ### Added

--- a/packages/pluggableWidgets/switch-native/package.json
+++ b/packages/pluggableWidgets/switch-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "switch-native",
   "widgetName": "Switch",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/pluggableWidgets/switch-native/src/Switch.tsx
+++ b/packages/pluggableWidgets/switch-native/src/Switch.tsx
@@ -53,7 +53,7 @@ export function Switch(props: Props): ReactElement {
                 <SwitchComponent
                     disabled={!editable}
                     testID={name}
-                    style={inputStyle}
+                    style={{ ...inputStyle, backgroundColor: undefined }} // Adding default background color to fix bug in RN. TODO: Undo change with RN 0.68
                     onValueChange={editable ? onChangeCallback : undefined}
                     value={booleanAttribute.value}
                     trackColor={{

--- a/packages/pluggableWidgets/switch-native/src/__tests__/Switch.spec.tsx
+++ b/packages/pluggableWidgets/switch-native/src/__tests__/Switch.spec.tsx
@@ -122,7 +122,7 @@ describe("Switch", () => {
         const props = createProps();
 
         switchWrapper = mount(<Switch {...props} />);
-        expect(getSwitchComponent().props()).toEqual(expect.objectContaining({ ios_backgroundColor: undefined }));
+        expect(getSwitchComponent().props()).toEqual(expect.objectContaining({ ios_backgroundColor: "#CED0D3" }));
     });
 
     it("with android device renders property", () => {

--- a/packages/pluggableWidgets/switch-native/src/package.xml
+++ b/packages/pluggableWidgets/switch-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Switch" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Switch" version="1.0.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Switch.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/switch-native/src/ui/Styles.ts
+++ b/packages/pluggableWidgets/switch-native/src/ui/Styles.ts
@@ -40,13 +40,25 @@ export const defaultSwitchStyle: SwitchStyle = {
     },
     input: {
         // thumbColorOn, thumbColorOff, trackColorOn, trackColorOff and all TextStyle properties are allowed
-        marginRight: Platform.select({ android: -3 })
+        marginRight: Platform.select({ android: -3 }),
+        thumbColorOn: "#F3F5FF",
+        trackColorOn: "#264AE5",
+        thumbColorOff: "#FFF",
+        trackColorOff: "#CED0D3"
     },
     inputDisabled: {
         // thumbColorOn, thumbColorOff, trackColorOn, trackColorOff and all TextStyle properties are allowed
+        thumbColorOn: "#F8F8F8",
+        trackColorOn: "#9DA1A8",
+        thumbColorOff: "#F8F8F8",
+        trackColorOff: "#CED0D3"
     },
     inputError: {
         // thumbColorOn, thumbColorOff, trackColorOn, trackColorOff and all TextStyle properties are allowed
+        thumbColorOn: "#F3F5FF",
+        trackColorOn: "#E33F4E",
+        thumbColorOff: "#FFF",
+        trackColorOff: "#E33F4E"
     },
     validationMessage: {
         // All TextStyle properties are allowed


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Native specific
- Works in Android ✅ 
- Works in iOS ✅ 
- Works in Tablet ✅ 

## This PR contains
- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fixed the `Illegal Cast Exception` ([you can find more details here](https://github.com/facebook/react-native/pull/32468)) issue caused by React Native 0.66 upgrade and added default thumb and track color if the widget is using without Atlas template.

## What should be covered while testing?
- The switch widget should work as expected with React Native 0.66.
- The switch widget should look as expected without the Atlas template.

## Extra comments (optional)
- To test this PR, you should build the MiN app from this branch ([moo/update-rn66](https://gitlab.rnd.mendix.com/appdev/appdev/-/tree/moo/update-rn66)) and download the last build of Mendix Studio Pro from the same branch.
-  This issue will be fixed with React Native 0.68. With React Native 0.68+ upgrade, don't forget to undo changes mentioned by comment.
