### PR TITLE
[WC-1048] Copy assets into widget's assets folder instead of inlining to comply with CSP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
 				"@rollup/plugin-replace": "^2.4.1",
 				"@rollup/plugin-typescript": "^8.3.0",
 				"@rollup/plugin-url": "^6.1.0",
+				"@rollup/pluginutils": "^4.2.0",
 				"@testing-library/dom": "^8.1.0",
 				"@testing-library/jest-dom": "^5.14.1",
 				"@testing-library/react": "^12.0.0",
@@ -7974,6 +7975,32 @@
 				}
 			}
 		},
+		"node_modules/@rollup/plugin-babel/node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-babel/node_modules/@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+		},
+		"node_modules/@rollup/plugin-babel/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+		},
 		"node_modules/@rollup/plugin-commonjs": {
 			"version": "20.0.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-20.0.0.tgz",
@@ -7993,6 +8020,32 @@
 			"peerDependencies": {
 				"rollup": "^2.38.3"
 			}
+		},
+		"node_modules/@rollup/plugin-commonjs/node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-commonjs/node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+		},
+		"node_modules/@rollup/plugin-commonjs/node_modules/@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
 		},
 		"node_modules/@rollup/plugin-commonjs/node_modules/estree-walker": {
 			"version": "2.0.2",
@@ -8014,6 +8067,32 @@
 				"rollup": "^1.20.0 || ^2.0.0"
 			}
 		},
+		"node_modules/@rollup/plugin-image/node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-image/node_modules/@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+		},
+		"node_modules/@rollup/plugin-image/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+		},
 		"node_modules/@rollup/plugin-json": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
@@ -8024,6 +8103,32 @@
 			"peerDependencies": {
 				"rollup": "^1.20.0 || ^2.0.0"
 			}
+		},
+		"node_modules/@rollup/plugin-json/node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-json/node_modules/@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+		},
+		"node_modules/@rollup/plugin-json/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
 		},
 		"node_modules/@rollup/plugin-node-resolve": {
 			"version": "13.0.4",
@@ -8044,6 +8149,27 @@
 				"rollup": "^2.42.0"
 			}
 		},
+		"node_modules/@rollup/plugin-node-resolve/node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-node-resolve/node_modules/@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+		},
 		"node_modules/@rollup/plugin-node-resolve/node_modules/builtin-modules": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
@@ -8054,6 +8180,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/@rollup/plugin-node-resolve/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
 		},
 		"node_modules/@rollup/plugin-replace": {
 			"version": "2.4.1",
@@ -8066,6 +8197,32 @@
 			"peerDependencies": {
 				"rollup": "^1.20.0 || ^2.0.0"
 			}
+		},
+		"node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-replace/node_modules/@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+		},
+		"node_modules/@rollup/plugin-replace/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
 		},
 		"node_modules/@rollup/plugin-typescript": {
 			"version": "8.3.0",
@@ -8084,6 +8241,32 @@
 				"typescript": ">=3.7.0"
 			}
 		},
+		"node_modules/@rollup/plugin-typescript/node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-typescript/node_modules/@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+		},
+		"node_modules/@rollup/plugin-typescript/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+		},
 		"node_modules/@rollup/plugin-url": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-url/-/plugin-url-6.1.0.tgz",
@@ -8099,6 +8282,32 @@
 			"peerDependencies": {
 				"rollup": "^1.20.0||^2.0.0"
 			}
+		},
+		"node_modules/@rollup/plugin-url/node_modules/@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dependencies": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0"
+			}
+		},
+		"node_modules/@rollup/plugin-url/node_modules/@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+		},
+		"node_modules/@rollup/plugin-url/node_modules/estree-walker": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
 		},
 		"node_modules/@rollup/plugin-url/node_modules/make-dir": {
 			"version": "3.1.0",
@@ -8123,30 +8332,21 @@
 			}
 		},
 		"node_modules/@rollup/pluginutils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.0.tgz",
+			"integrity": "sha512-2WUyJNRkyH5p487pGnn4tWAsxhEFKN/pT8CMgHshd5H+IXkOnKvKZwsz5ZWz+YCXkleZRAU5kwbfgF8CPfDRqA==",
 			"dependencies": {
-				"@types/estree": "0.0.39",
-				"estree-walker": "^1.0.1",
+				"estree-walker": "^2.0.1",
 				"picomatch": "^2.2.2"
 			},
 			"engines": {
 				"node": ">= 8.0.0"
-			},
-			"peerDependencies": {
-				"rollup": "^1.20.0||^2.0.0"
 			}
 		},
-		"node_modules/@rollup/pluginutils/node_modules/@types/estree": {
-			"version": "0.0.39",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
-		},
 		"node_modules/@rollup/pluginutils/node_modules/estree-walker": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-			"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
 		},
 		"node_modules/@sideway/address": {
 			"version": "4.1.3",
@@ -54111,6 +54311,28 @@
 			"requires": {
 				"@babel/helper-module-imports": "^7.10.4",
 				"@rollup/pluginutils": "^3.1.0"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+					"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+					"requires": {
+						"@types/estree": "0.0.39",
+						"estree-walker": "^1.0.1",
+						"picomatch": "^2.2.2"
+					}
+				},
+				"@types/estree": {
+					"version": "0.0.39",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+				},
+				"estree-walker": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+				}
 			}
 		},
 		"@rollup/plugin-commonjs": {
@@ -54127,6 +54349,28 @@
 				"resolve": "^1.17.0"
 			},
 			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+					"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+					"requires": {
+						"@types/estree": "0.0.39",
+						"estree-walker": "^1.0.1",
+						"picomatch": "^2.2.2"
+					},
+					"dependencies": {
+						"estree-walker": {
+							"version": "1.0.1",
+							"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+							"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+						}
+					}
+				},
+				"@types/estree": {
+					"version": "0.0.39",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+				},
 				"estree-walker": {
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -54141,6 +54385,28 @@
 			"requires": {
 				"@rollup/pluginutils": "^3.1.0",
 				"mini-svg-data-uri": "^1.2.3"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+					"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+					"requires": {
+						"@types/estree": "0.0.39",
+						"estree-walker": "^1.0.1",
+						"picomatch": "^2.2.2"
+					}
+				},
+				"@types/estree": {
+					"version": "0.0.39",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+				},
+				"estree-walker": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+				}
 			}
 		},
 		"@rollup/plugin-json": {
@@ -54149,6 +54415,28 @@
 			"integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
 			"requires": {
 				"@rollup/pluginutils": "^3.0.8"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+					"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+					"requires": {
+						"@types/estree": "0.0.39",
+						"estree-walker": "^1.0.1",
+						"picomatch": "^2.2.2"
+					}
+				},
+				"@types/estree": {
+					"version": "0.0.39",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+				},
+				"estree-walker": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+				}
 			}
 		},
 		"@rollup/plugin-node-resolve": {
@@ -54164,10 +54452,30 @@
 				"resolve": "^1.19.0"
 			},
 			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+					"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+					"requires": {
+						"@types/estree": "0.0.39",
+						"estree-walker": "^1.0.1",
+						"picomatch": "^2.2.2"
+					}
+				},
+				"@types/estree": {
+					"version": "0.0.39",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+				},
 				"builtin-modules": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
 					"integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA=="
+				},
+				"estree-walker": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
 				}
 			}
 		},
@@ -54178,6 +54486,28 @@
 			"requires": {
 				"@rollup/pluginutils": "^3.1.0",
 				"magic-string": "^0.25.7"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+					"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+					"requires": {
+						"@types/estree": "0.0.39",
+						"estree-walker": "^1.0.1",
+						"picomatch": "^2.2.2"
+					}
+				},
+				"@types/estree": {
+					"version": "0.0.39",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+				},
+				"estree-walker": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+				}
 			}
 		},
 		"@rollup/plugin-typescript": {
@@ -54187,6 +54517,28 @@
 			"requires": {
 				"@rollup/pluginutils": "^3.1.0",
 				"resolve": "^1.17.0"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+					"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+					"requires": {
+						"@types/estree": "0.0.39",
+						"estree-walker": "^1.0.1",
+						"picomatch": "^2.2.2"
+					}
+				},
+				"@types/estree": {
+					"version": "0.0.39",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+				},
+				"estree-walker": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+				}
 			}
 		},
 		"@rollup/plugin-url": {
@@ -54199,6 +54551,26 @@
 				"mime": "^2.4.6"
 			},
 			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+					"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+					"requires": {
+						"@types/estree": "0.0.39",
+						"estree-walker": "^1.0.1",
+						"picomatch": "^2.2.2"
+					}
+				},
+				"@types/estree": {
+					"version": "0.0.39",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
+				},
+				"estree-walker": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+				},
 				"make-dir": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -54215,24 +54587,18 @@
 			}
 		},
 		"@rollup/pluginutils": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.0.tgz",
+			"integrity": "sha512-2WUyJNRkyH5p487pGnn4tWAsxhEFKN/pT8CMgHshd5H+IXkOnKvKZwsz5ZWz+YCXkleZRAU5kwbfgF8CPfDRqA==",
 			"requires": {
-				"@types/estree": "0.0.39",
-				"estree-walker": "^1.0.1",
+				"estree-walker": "^2.0.1",
 				"picomatch": "^2.2.2"
 			},
 			"dependencies": {
-				"@types/estree": {
-					"version": "0.0.39",
-					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-					"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
-				},
 				"estree-walker": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+					"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
 				}
 			}
 		},

--- a/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-assets.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup-plugin-assets.js
@@ -1,0 +1,131 @@
+import crypto from "crypto";
+import path from "path";
+import util from "util";
+import fs from "fs";
+
+import makeDir from "make-dir";
+import mime from "mime";
+import { createFilter } from "@rollup/pluginutils";
+
+const fsStatPromise = util.promisify(fs.stat);
+const fsReadFilePromise = util.promisify(fs.readFile);
+const { posix, sep } = path;
+const defaultInclude = ["**/*.svg", "**/*.png", "**/*.jp(e)?g", "**/*.gif", "**/*.webp"];
+
+/**
+ * This is basically an entire copy of the `@rollup/plugin-url` plugin (https://github.com/rollup/plugins/tree/master/packages/url).
+ * The reason we have an exact replication here is because the current version of the plugin (v6.1.0) is still using an older
+ * version of the `@rollup/pluginutils` (v3.1.0) dependency. Between v4.0.0 and v4.2.0, a bug related to pattern globs was fixed
+ * that solves our issues of the plugin not targeting SVGs in other packages, like `@mendix/shared-charts`. Unfortunately,
+ * NPM's `overrides` functionality doesn't work properly with Lerna's hoisting. So for now we run our own until rollup updates
+ * their own plugin. (https://github.com/rollup/plugins/blob/5363f55aa1933b6c650832b08d6a54cb9ea64539/packages/pluginutils/CHANGELOG.md)
+ */
+export default function url(options = {}) {
+    const {
+        limit = 14 * 1024,
+        include = defaultInclude,
+        exclude,
+        publicPath = "",
+        emitFiles = true,
+        fileName = "[hash][extname]"
+    } = options;
+    const filter = createFilter(include, exclude);
+
+    const copies = Object.create(null);
+
+    return {
+        name: "url",
+        load(id) {
+            if (!filter(id)) {
+                return null;
+            }
+            return Promise.all([fsStatPromise(id), fsReadFilePromise(id)]).then(([stats, buffer]) => {
+                let data;
+                if ((limit && stats.size > limit) || limit === 0) {
+                    const hash = crypto.createHash("sha1").update(buffer).digest("hex").substr(0, 16);
+                    const ext = path.extname(id);
+                    const name = path.basename(id, ext);
+                    // Determine the directory name of the file based
+                    // on either the relative path provided in options,
+                    // or the parent directory
+                    const relativeDir = options.sourceDir
+                        ? path.relative(options.sourceDir, path.dirname(id))
+                        : path.dirname(id).split(sep).pop();
+
+                    // Generate the output file name based on some string
+                    // replacement parameters
+                    const outputFileName = fileName
+                        .replace(/\[hash\]/g, hash)
+                        .replace(/\[extname\]/g, ext)
+                        // use `sep` for windows environments
+                        .replace(/\[dirname\]/g, relativeDir === "" ? "" : `${relativeDir}${sep}`)
+                        .replace(/\[name\]/g, name);
+                    // Windows fix - exports must be in unix format
+                    data = `${publicPath}${outputFileName.split(sep).join(posix.sep)}`;
+                    copies[id] = outputFileName;
+                } else {
+                    const mimetype = mime.getType(id);
+                    const isSVG = mimetype === "image/svg+xml";
+                    data = isSVG ? encodeSVG(buffer) : buffer.toString("base64");
+                    const encoding = isSVG ? "" : ";base64";
+                    data = `data:${mimetype}${encoding},${data}`;
+                }
+                return `export default "${data}"`;
+            });
+        },
+        generateBundle: async function write(outputOptions) {
+            // Allow skipping saving files for server side builds.
+            if (!emitFiles) {
+                return;
+            }
+
+            const base = options.destDir || outputOptions.dir || path.dirname(outputOptions.file);
+
+            // await fsMkdirPromise(base, { recursive: true });
+            await makeDir(base);
+
+            await Promise.all(
+                Object.keys(copies).map(async name => {
+                    const output = copies[name];
+                    // Create a nested directory if the fileName pattern contains
+                    // a directory structure
+                    const outputDirectory = path.join(base, path.dirname(output));
+                    // await fsMkdirPromise(outputDirectory, { recursive: true });
+                    await makeDir(outputDirectory);
+                    return copy(name, path.join(base, output));
+                })
+            );
+        }
+    };
+}
+
+function copy(src, dest) {
+    return new Promise((resolve, reject) => {
+        const read = fs.createReadStream(src);
+        read.on("error", reject);
+        const write = fs.createWriteStream(dest);
+        write.on("error", reject);
+        write.on("finish", resolve);
+        read.pipe(write);
+    });
+}
+
+// https://github.com/filamentgroup/directory-encoder/blob/master/lib/svg-uri-encoder.js
+function encodeSVG(buffer) {
+    return (
+        encodeURIComponent(
+            buffer
+                .toString("utf-8")
+                // strip newlines and tabs
+                .replace(/[\n\r]/gim, "")
+                .replace(/\t/gim, " ")
+                // strip comments
+                .replace(/<!--(.*(?=-->))-->/gim, "")
+                // replace
+                .replace(/'/gim, "\\i")
+        )
+            // encode brackets
+            .replace(/\(/g, "%28")
+            .replace(/\)/g, "%29")
+    );
+}

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -7,7 +7,6 @@ import image from "@rollup/plugin-image";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import replace from "rollup-plugin-re";
 import typescript from "@rollup/plugin-typescript";
-import url from "@rollup/plugin-url";
 import { red, yellow, blue } from "ansi-colors";
 import postcssImport from "postcss-import";
 import postcssUrl from "postcss-url";
@@ -32,11 +31,14 @@ import {
     widgetPackage,
     widgetVersion
 } from "./shared";
+import url from "./rollup-plugin-assets";
 
 const outDir = join(sourcePath, "/dist/tmp/widgets/");
-const outWidgetFile = join(widgetPackage.replace(/\./g, "/"), widgetName.toLowerCase(), `${widgetName}`);
+const outWidgetDir = join(widgetPackage.replace(/\./g, "/"), widgetName.toLowerCase());
+const outWidgetFile = join(outWidgetDir, `${widgetName}`);
 const mpkDir = join(sourcePath, "dist", widgetVersion);
 const mpkFile = join(mpkDir, process.env.MPKOUTPUT ? process.env.MPKOUTPUT : `${widgetPackage}.${widgetName}.mpk`);
+const assetsDirName = "assets";
 
 export default async args => {
     const production = Boolean(args.configProduction);
@@ -57,7 +59,12 @@ export default async args => {
             external: webExternal,
             plugins: [
                 ...getClientComponentPlugins(),
-                url({ include: imagesAndFonts, limit: 100000 }),
+                url({
+                    include: imagesAndFonts,
+                    limit: 0,
+                    publicPath: `${join("widgets", outWidgetDir, assetsDirName)}/`, // Prefix for the actual import, relative to Mendix web server root
+                    destDir: join(outDir, outWidgetDir, assetsDirName)
+                }),
                 postcss({
                     extensions: [".css", ".sass", ".scss"],
                     extract: production && outputFormat === "amd",

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -67,8 +67,8 @@ export default async args => {
                 }),
                 postcss({
                     extensions: [".css", ".sass", ".scss"],
-                    extract: production && outputFormat === "amd",
-                    inject: !production,
+                    extract: outputFormat === "amd",
+                    inject: false,
                     minimize: production,
                     plugins: [postcssImport(), postcssUrl({ url: "inline" })],
                     sourceMap: !production ? "inline" : false,

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -48,6 +48,7 @@
     "@rollup/plugin-node-resolve": "^13.0.4",
     "@rollup/plugin-typescript": "^8.3.0",
     "@rollup/plugin-url": "^6.1.0",
+    "@rollup/pluginutils": "^4.2.0",
     "@testing-library/dom": "^8.1.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ❌
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with designs ❌
- Comply with PM's requirements ✅ 

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Comply with CSP by extracting assets from JS files and copying them into the widget's `assets` folder and reference them instead of inlining them.

## What should be covered while testing?
Make sure all widgets (including charts) work properly and don't spawn any CSP errors from JS files.
