### PR TITLE
fix: make sure to publish to aws on merge to master

### DIFF
--- a/.github/workflows/UpdateContentOverview.yml
+++ b/.github/workflows/UpdateContentOverview.yml
@@ -59,14 +59,18 @@ jobs:
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           merge-method: merge
       - name: "Setting AWS credentials"
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: >-
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+          (github.event_name == 'push' && github.ref == 'refs/heads/master')
         uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2 # v1.6.1
         with:
           aws-access-key-id: ${{ secrets.AWS_CONTENT_DATA_ID }}
           aws-secret-access-key: ${{ secrets.AWS_CONTENT_DATA_SECRET }}
           aws-region: eu-central-1
       - name: "Uploading to S3"
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        if: >-
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+          (github.event_name == 'push' && github.ref == 'refs/heads/master')
         run: |
           aws s3 sync scripts/data/out s3://widgetresources-data/$GITHUB_REF_NAME/
           echo https://widgetresources-data.s3.eu-central-1.amazonaws.com/$GITHUB_REF_NAME/index.html


### PR DESCRIPTION
## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
The content overview was not published to S3 on merge to master, only on PRs. This MR should fix that.

## Relevant changes
Add additional condition under which the AWS S3 upload steps for the content overview are executed

## What should be covered while testing?
- Ensure that the content overview is still uploaded as part of the MR
- After merge: verify that the content overview is uploaded from master. Pay attention to the url.