### PR TITLE
[NC-548] Add notch area background color to safe area view widget

### DIFF
--- a/packages/pluggableWidgets/safe-area-view-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/safe-area-view-native/CHANGELOG.md
@@ -1,16 +1,23 @@
 # Changelog
+
 All notable changes to this widget will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed the notch area background color.
+
 ## [2.1.0] - 2022-1-24
 
 ### Added
-- Dark theme icons for Tile and List view.
+
+-   Dark theme icons for Tile and List view.
 
 ## [2.0.0] - 2021-9-28
 
 ### Added
- - We added a toolbox category and toolbox tile image for Studio & Studio Pro.
+
+-   We added a toolbox category and toolbox tile image for Studio & Studio Pro.

--- a/packages/pluggableWidgets/safe-area-view-native/package.json
+++ b/packages/pluggableWidgets/safe-area-view-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "safe-area-view-native",
   "widgetName": "SafeAreaView",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/pluggableWidgets/safe-area-view-native/src/SafeAreaView.tsx
+++ b/packages/pluggableWidgets/safe-area-view-native/src/SafeAreaView.tsx
@@ -9,7 +9,11 @@ export const SafeAreaView = (props: SafeAreaViewProps<SafeAreaViewStyle>): JSX.E
     const styles = flattenStyles(defaultSafeAreaViewStyle, props.style);
 
     return (
-        <ReactSaveAreaView style={{ flex: 1 }} pointerEvents={"box-none"} testID={props.name}>
+        <ReactSaveAreaView
+            style={{ flex: 1, ...{ backgroundColor: styles.container.backgroundColor } }}
+            pointerEvents={"box-none"}
+            testID={props.name}
+        >
             <View style={styles.container} pointerEvents={"box-none"}>
                 {props.content}
             </View>

--- a/packages/pluggableWidgets/safe-area-view-native/src/__tests__/__snapshots__/SafeAreaView.spec.tsx.snap
+++ b/packages/pluggableWidgets/safe-area-view-native/src/__tests__/__snapshots__/SafeAreaView.spec.tsx.snap
@@ -6,6 +6,7 @@ exports[`Safe area view renders with content 1`] = `
   pointerEvents="box-none"
   style={
     Object {
+      "backgroundColor": undefined,
       "flex": 1,
     }
   }
@@ -32,6 +33,7 @@ exports[`Safe area view renders with custom styling 1`] = `
   pointerEvents="box-none"
   style={
     Object {
+      "backgroundColor": "green",
       "flex": 1,
     }
   }
@@ -59,6 +61,7 @@ exports[`Safe area view renders without content 1`] = `
   pointerEvents="box-none"
   style={
     Object {
+      "backgroundColor": undefined,
       "flex": 1,
     }
   }

--- a/packages/pluggableWidgets/safe-area-view-native/src/package.xml
+++ b/packages/pluggableWidgets/safe-area-view-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="SafeAreaView" version="2.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="SafeAreaView" version="2.1.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="SafeAreaView.xml" />
         </widgetFiles>


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Native specific
- Works in Android ✅ 
- Works in iOS ✅ 
- Works in Tablet ✅ 

## This PR contains
- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
To fix [this](https://mendix.atlassian.net/jira/software/c/projects/NC/boards/419?modal=detail&selectedIssue=NC-548) issue.

## What should be covered while testing?
Setting the `Safe Area View` background color should also change the notch area background color.
