### PR TITLE
[WC-1083] Fix glyphicon issue on dg2

### DIFF
--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/datagrid-filters.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/datagrid-filters.scss
@@ -66,6 +66,7 @@ $arrow: "resources/dropdown-arrow.svg";
             list-style-type: none;
             box-shadow: 0 2px 20px 1px rgba(5, 15, 129, 0.05), 0 2px 16px 0 rgba(33, 43, 54, 0.08);
             overflow: hidden;
+            z-index: 1;
 
             li {
                 display: flex;

--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/datagrid-filters.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/datagrid-filters.scss
@@ -66,7 +66,7 @@ $arrow: "resources/dropdown-arrow.svg";
             list-style-type: none;
             box-shadow: 0 2px 20px 1px rgba(5, 15, 129, 0.05), 0 2px 16px 0 rgba(33, 43, 54, 0.08);
             overflow: hidden;
-            z-index: 1;
+            z-index: 102;
 
             li {
                 display: flex;

--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/datagrid.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/datagrid.scss
@@ -46,6 +46,7 @@ $brand-primary: #264ae5 !default;
         position: -webkit-sticky; /* Safari */
         position: sticky;
         top: 0;
+        z-index: 1;
 
         /* Clickable column header (Sortable) */
         .clickable {


### PR DESCRIPTION
… on top of it

## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Compatible with Studio ✅
- Cross-browser compatible ✅

#### Feature specific
- Comply with designs ✅
- Comply with PM's requirements ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fix the issue with icons appearing on top of headers in dg2.

## Relevant changes
The issue was about icons having different positioning than table div itselfs, so the reasonable change to prevent all kind of cases was to add minimal z-index value for table headers.

## What should be covered while testing?
Check whether it works for icons, texts and other items(buttons, dropdowns,etc.)
In a worst case this can be configured by user itself, if for example dropdown appears on top of header he/she can simply change z-index in his css configuration.

## Extra comments (optional)
Please let me know if I need to update change-logs or versions