### PR TITLE
[WC-1084] Remount video player on url change to not break history

### DIFF
--- a/packages/pluggableWidgets/video-player-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/video-player-web/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- We fixed the issue when after changing URL property of Video Player, app navigation is get broken. (Ticket #143982)
+
 ## [3.1.0] - 2021-12-23
 
 ### Added

--- a/packages/pluggableWidgets/video-player-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/video-player-web/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- We fixed the issue when after changing URL property of Video Player, app navigation is get broken. (Ticket #143982)
+- We fixed the issue that when changing the URL property of the Video Player, app navigation is get broken. (Ticket #143982)
 
 ## [3.1.0] - 2021-12-23
 

--- a/packages/pluggableWidgets/video-player-web/package.json
+++ b/packages/pluggableWidgets/video-player-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "video-player-web",
   "widgetName": "VideoPlayer",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Player for YouTube, Dailymotion, Vimeo and Mp4 videos",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.tsx
@@ -12,7 +12,7 @@ export default class VideoPlayer extends Component<VideoPlayerContainerProps> {
         const useExpressionForLinks = this.props.type === "expression";
         const url = useExpressionForLinks ? this.props.urlExpression?.value : this.props.videoUrl?.value;
         const poster = useExpressionForLinks ? this.props.posterExpression?.value : this.props.posterUrl?.value;
-        const key = poster ? `${url}-${poster}` : `${url}`;
+        const key = poster ? `${url}-${poster}` : url;
 
         return (
             <SizeContainer

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.tsx
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.tsx
@@ -12,6 +12,8 @@ export default class VideoPlayer extends Component<VideoPlayerContainerProps> {
         const useExpressionForLinks = this.props.type === "expression";
         const url = useExpressionForLinks ? this.props.urlExpression?.value : this.props.videoUrl?.value;
         const poster = useExpressionForLinks ? this.props.posterExpression?.value : this.props.posterUrl?.value;
+        const key = poster ? `${url}-${poster}` : `${url}`;
+
         return (
             <SizeContainer
                 className={classNames("widget-video-player widget-video-player-container", this.props.class)}
@@ -24,6 +26,7 @@ export default class VideoPlayer extends Component<VideoPlayerContainerProps> {
                 tabIndex={this.props.tabIndex}
             >
                 <Video
+                    key={key}
                     url={url}
                     poster={poster}
                     autoStart={this.props.autoStart}

--- a/packages/pluggableWidgets/video-player-web/src/package.xml
+++ b/packages/pluggableWidgets/video-player-web/src/package.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="VideoPlayer" version="3.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="VideoPlayer" version="3.1.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
-            <widgetFile path="VideoPlayer.xml"/>
+            <widgetFile path="VideoPlayer.xml" />
         </widgetFiles>
         <files>
-            <file path="com/mendix/widget/web/videoplayer"/>
+            <file path="com/mendix/widget/web/videoplayer" />
         </files>
     </clientModule>
 </package>


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with:  9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
 - Fix Video Player issue with browser history being broken after updating player URL

## Relevant changes
- the `key` prop was added to the player to prevent unexpected history changes 

## What should be covered while testing?
- Check attached slack video
