### PR TITLE
Apply formatting onto json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "postinstall": "lerna bootstrap --hoist --strict",
     "reinstall": "git clean -dfx && npx lerna clean --yes && npm i",
     "prettier": "prettier --config \"./prettier.config.js\" --write \"**/{src,script,typings,test}/**/*.{js,jsx,ts,tsx,scss,html,xml}\"",
-    "format": "pretty-quick --staged --config \"./prettier.config.js\" --pattern \"**/{src,script,typings,test}/**/*.{js,jsx,ts,tsx,scss,html,xml,md}\"",
+    "format": "pretty-quick --staged --config \"./prettier.config.js\" --pattern \"**/{src,script,typings,test,**}/**/*.{js,jsx,ts,tsx,scss,html,xml,md,json}\"",
     "clean-all-screenshots-mac": "find . -name 'screenshot-baseline' -type d -prune -exec rm -rf '{}' +",
     "information:githubrelease": "lerna run information:githubrelease",
     "lint": "npm run lint:src && lerna run lint --stream",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -11,9 +11,16 @@ module.exports = {
             }
         },
         {
-            files: ["package.json", "package.json"],
+            files: "package.json",
             options: {
                 tabWidth: 2
+            }
+        },
+        {
+            files: "package-lock.json",
+            options: {
+                tabWidth: 4,
+                useTabs: false
             }
         },
         {


### PR DESCRIPTION
Like `package.json` and `package-lock.json` file, the latter suffers from some lerna issue causing ~180K changed lines: https://github.com/lerna/lerna/issues/2845 

Edit: I only applied this to the `format` script and not the `prettier` one because the latter also doens't include `md` files, so I assumed there are some differences.

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)
