### PR TITLE
[WC-1086] Add last visible column check to onClick handler in column selector

### DIFF
--- a/packages/modules/data-widgets/CHANGELOG.md
+++ b/packages/modules/data-widgets/CHANGELOG.md
@@ -5,10 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## [2.2.3] Datagrid
-### Fixed
-- We fixed an issue with column hiding behaviour. Now user can't uncheck last visible column in the datagrid. (Ticket #144500)
-
 ## [2.3.0] Data Widgets - 2022-2-10
 
 

--- a/packages/modules/data-widgets/CHANGELOG.md
+++ b/packages/modules/data-widgets/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [2.2.3] Datagrid
+### Fixed
+- We fixed an issue with column hiding behaviour. Now user can't uncheck last visible column in the datagrid. (Ticket #144500)
+
 ## [2.3.0] Data Widgets - 2022-2-10
 
 

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- We fixed an issue with column hiding behaviour. Now user can't uncheck last visible column in the datagrid. (Ticket #144500)
+
 ## [2.2.2] - 2022-1-19
 
 ### Fixed

--- a/packages/pluggableWidgets/datagrid-web/cypress/integration/DataGrid.spec.js
+++ b/packages/pluggableWidgets/datagrid-web/cypress/integration/DataGrid.spec.js
@@ -81,6 +81,23 @@ describe("datagrid-web", () => {
             cy.wait(1000);
             cy.get(".mx-name-datagrid1 .column-header").first().should("not.be.visible");
         });
+
+        it("do not allow to hide last visible column", () => {
+            cy.get(".mx-name-datagrid1 .column-header").first().should("be.visible");
+            cy.get(".mx-name-datagrid1 .column-selector-button").click();
+            cy.get(".column-selectors input:checked").should("have.length", 3);
+            cy.get(".column-selectors > li").eq(2).click();
+            cy.get(".column-selectors > li").eq(1).click();
+            cy.get(".column-selectors input:checked").should("have.length", 1);
+            cy.get(".column-selectors > li").eq(0).click();
+            cy.get(".column-selectors input:checked").should("have.length", 1);
+            // Trigger Enter keypress
+            cy.get(".column-selectors > li").eq(0).trigger("keydown", { keyCode: 13 });
+            cy.get(".column-selectors input:checked").should("have.length", 1);
+            // Trigger Space keypress
+            cy.get(".column-selectors > li").eq(0).trigger("keydown", { keyCode: 32 });
+            cy.get(".column-selectors input:checked").should("have.length", 1);
+        });
     });
 
     describe("capabilities: onClick action", () => {

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datagrid-web",
   "widgetName": "Datagrid",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/datagrid-web/src/components/ColumnSelector.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/ColumnSelector.tsx
@@ -18,7 +18,7 @@ export function ColumnSelector(props: ColumnSelectorProps): ReactElement {
     const buttonRef = useRef<HTMLButtonElement>(null);
     const position = usePositionObserver(buttonRef.current, show);
     const visibleCount = props.columns.length - props.hiddenColumns.length;
-    const isOnlyOneColumnVisible = visibleCount < 2;
+    const isOnlyOneColumnVisible = visibleCount === 1;
 
     useOnClickOutside([buttonRef, optionsRef], () => setShow(false));
 

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="2.2.2" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="2.2.3" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Datagrid.xml" />
         </widgetFiles>


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

### This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
- Fix column hiding behavior in datagrid 

## Relevant changes
- Added extra check to onClick handler to prevent hiding of last visible column

## What should be covered while testing?
- Column selector