### PR TITLE
fix: properly detect e2e tests (detox & cypress)

### DIFF
--- a/data/content.json
+++ b/data/content.json
@@ -20,7 +20,7 @@
                     "icons": {},
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -45,7 +45,7 @@
                     "icons": {},
                     "tests": {
                         "hasUnitTests": false,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -90,7 +90,7 @@
                     },
                     "tests": {
                         "hasUnitTests": false,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -133,7 +133,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -178,7 +178,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -221,7 +221,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -386,7 +386,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -431,7 +431,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -474,7 +474,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -519,7 +519,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -562,7 +562,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -695,7 +695,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -869,7 +869,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": true
+                        "hasE2ETests": false
                     }
                 }
             ]
@@ -912,7 +912,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -956,7 +956,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": true
+                        "hasE2ETests": false
                     }
                 }
             ]
@@ -1091,7 +1091,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -1136,7 +1136,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -1181,7 +1181,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -1226,7 +1226,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -1341,7 +1341,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -1386,7 +1386,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -1429,7 +1429,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -1474,7 +1474,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -1553,7 +1553,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -1598,7 +1598,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -1684,7 +1684,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -1728,7 +1728,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -1859,7 +1859,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -1945,7 +1945,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2032,7 +2032,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2077,7 +2077,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2120,7 +2120,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2165,7 +2165,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2208,7 +2208,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2253,7 +2253,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2296,7 +2296,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2339,7 +2339,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2382,7 +2382,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2426,7 +2426,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2469,7 +2469,7 @@
                     },
                     "tests": {
                         "hasUnitTests": false,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2514,7 +2514,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2557,7 +2557,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2601,7 +2601,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": true
+                        "hasE2ETests": false
                     }
                 }
             ]
@@ -2752,7 +2752,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2836,7 +2836,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2880,7 +2880,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2923,7 +2923,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -2968,7 +2968,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -3050,7 +3050,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -3138,7 +3138,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -3183,7 +3183,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -3271,7 +3271,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]
@@ -3314,7 +3314,7 @@
                     },
                     "tests": {
                         "hasUnitTests": true,
-                        "hasE2ETests": false
+                        "hasE2ETests": true
                     }
                 }
             ]

--- a/scripts/data/generator/model/widget.ts
+++ b/scripts/data/generator/model/widget.ts
@@ -115,7 +115,7 @@ export class Widget {
             matches => matches.length > 0
         );
         const hasE2ETests = await withGlob(
-            `${packagePath}/tests/**/*.spec.{js,jsx,ts,tsx}`,
+            `${packagePath}/{e2e,cypress}/**/*.spec.{js,jsx,ts,tsx}`,
             matches => matches.length > 0
         );
 


### PR DESCRIPTION
## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
E2E tests weren't properly detected in the content data generator