### PR TITLE
Override react peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72864,11 +72864,12 @@
             "resolved": "https://registry.npmjs.org/jest-react-hooks-shallow/-/jest-react-hooks-shallow-1.4.2.tgz",
             "integrity": "sha512-Xpn/RjedUEhLpsly1SoNbHYc1RbuG5II1HzrRAXDdRmHmiyOz+28i/VUmDXMRoJooe1ohSKYzkLxhE8E50T6QA==",
             "requires": {
-                "react": "17.0.1"
+                "react": "^16.8.0"
             },
             "dependencies": {
                 "react": {
-                    "version": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+                    "version": "16.14.0",
+                    "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
                     "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
                     "requires": {
                         "loose-envify": "^1.1.0",
@@ -81327,7 +81328,7 @@
                 "scheduler": "^0.20.1",
                 "shelljs": "^0.8.4",
                 "stacktrace-parser": "^0.1.3",
-                "use-subscription": "^1.0.0",
+                "use-subscription": "1.5.1",
                 "whatwg-fetch": "^3.0.0",
                 "ws": "^6.1.4"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -72864,12 +72864,11 @@
             "resolved": "https://registry.npmjs.org/jest-react-hooks-shallow/-/jest-react-hooks-shallow-1.4.2.tgz",
             "integrity": "sha512-Xpn/RjedUEhLpsly1SoNbHYc1RbuG5II1HzrRAXDdRmHmiyOz+28i/VUmDXMRoJooe1ohSKYzkLxhE8E50T6QA==",
             "requires": {
-                "react": "^16.8.0"
+                "react": "17.0.1"
             },
             "dependencies": {
                 "react": {
-                    "version": "16.14.0",
-                    "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+                    "version": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
                     "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
                     "requires": {
                         "loose-envify": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -94,9 +94,11 @@
     "node": ">=14"
   },
   "overrides": {
-    "react": "17.0.1"
-  },
-  "resolutions": {
-    "react": "17.0.1"
+    "@testing-library/react-native": {
+      "react-test-renderer": "17.0.2"
+    },
+    "react-native": {
+      "use-subscription": "1.5.1"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -92,5 +92,11 @@
   },
   "engines": {
     "node": ">=14"
+  },
+  "overrides": {
+    "react": "17.0.1"
+  },
+  "resolutions": {
+    "react": "17.0.1"
   }
 }


### PR DESCRIPTION
## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Since react was updated to version 18, react-native testing library peer dependency is asking for the newer version and then breaking the npm install.

## Relevant changes
Overrides the react version to 17.

## What should be covered while testing?
Automation should pass.
