### PR TITLE
[WTF-1093] Update pluggable-widgets-tools for association property in 9.13

### DIFF
--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+-   We added support for the new association property introduced in Mendix 9.13.
+
+### Changed
+
+-   We updated the Mendix package to version 9.13.43286.
+
 ### Fixed
 
 -   We fixed the way assets are handled inside widgets to comply with strict Content-Security-Policy.

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.11.1",
+  "version": "9.13.0",
   "description": "Mendix Pluggable Widgets Tools",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
@@ -91,7 +91,7 @@
     "jest-junit": "^13.0.0",
     "jest-react-hooks-shallow": "^1.4.1",
     "jest-svg-transformer": "^1.0.0",
-    "mendix": "^9.10.36429",
+    "mendix": "^9.13.43286",
     "metro-react-native-babel-preset": "~0.63.0",
     "node-fetch": "^2.6.1",
     "postcss": "^8.3.11",

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/association.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/association.ts
@@ -11,6 +11,21 @@ export const associationInput = `<?xml version="1.0" encoding="utf-8"?>
                     <associationType name="Reference"/>
                 </associationTypes>
             </property>
+            <property key="referenceSet" type="association" selectableObjects="optionsSource">
+                <caption>Reference Set</caption>
+                <description/>
+                <associationTypes>
+                    <associationType name="ReferenceSet"/>
+                </associationTypes>
+            </property>
+            <property key="referenceOrSet" type="association" selectableObjects="optionsSource">
+                <caption>Reference or Set</caption>
+                <description/>
+                <associationTypes>
+                    <associationType name="Reference"/>
+                    <associationType name="ReferenceSet"/>
+                </associationTypes>
+            </property>
              <property key="optionsSource" type="datasource" isList="true" required="false">
                 <caption>Universe Data source</caption>
                 <description />
@@ -37,6 +52,21 @@ export const associationInputNative = `<?xml version="1.0" encoding="utf-8"?>
                 <description/>
                 <associationTypes>
                     <associationType name="Reference"/>
+                </associationTypes>
+            </property>
+            <property key="referenceSet" type="association" selectableObjects="optionsSource">
+                <caption>Reference Set</caption>
+                <description/>
+                <associationTypes>
+                    <associationType name="ReferenceSet"/>
+                </associationTypes>
+            </property>
+            <property key="referenceOrSet" type="association" selectableObjects="optionsSource">
+                <caption>Reference or Set</caption>
+                <description/>
+                <associationTypes>
+                    <associationType name="Reference"/>
+                    <associationType name="ReferenceSet"/>
                 </associationTypes>
             </property>
              <property key="optionsSource" type="datasource" isList="true" required="false">

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
@@ -4,14 +4,16 @@ export const associationWebOutput = `/**
  * @author Mendix UI Content Team
  */
 import { CSSProperties } from "react";
-import { ListValue, ListAttributeValue, ModifiableValue } from "mendix";
+import { ListValue, ListAttributeValue, ReferenceValue, ReferenceSetValue } from "mendix";
 
 export interface MyWidgetContainerProps {
     name: string;
     class: string;
     style?: CSSProperties;
     tabIndex?: number;
-    reference: ModifiableValue<ObjectItem>;
+    reference: ReferenceValue;
+    referenceSet: ReferenceSetValue;
+    referenceOrSet: ReferenceValue | ReferenceSetValue;
     optionsSource?: ListValue;
     displayValue?: ListAttributeValue<string>;
 }
@@ -22,6 +24,8 @@ export interface MyWidgetPreviewProps {
     styleObject?: CSSProperties;
     readOnly: boolean;
     reference: string;
+    referenceSet: string;
+    referenceOrSet: string;
     optionsSource: {} | { type: string } | null;
     displayValue: string;
 }
@@ -30,7 +34,9 @@ export interface MyWidgetPreviewProps {
 export const associationNativeOutput = `export interface MyWidgetProps<Style> {
     name: string;
     style: Style[];
-    reference: ModifiableValue<ObjectItem>;
+    reference: ReferenceValue;
+    referenceSet: ReferenceSetValue;
+    referenceOrSet: ReferenceValue | ReferenceSetValue;
     optionsSource?: ListValue;
     displayValue?: ListAttributeValue<string>;
 }`;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generate.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generate.ts
@@ -15,7 +15,8 @@ const mxExports = [
     "ListAttributeValue",
     "ListExpressionValue",
     "ListWidgetValue",
-    "ModifiableValue",
+    "ReferenceValue",
+    "ReferenceSetValue",
     "WebIcon",
     "WebImage"
 ];


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Add support for the new association property introduced in Mendix 9.13 to the typings generator of the pluggable-widgets-tools.

## Relevant changes
For properties of `type="association"`, the typings generator will now produce `ReferenceValue`, `ReferenceSetValue` or `ReferenceValue | ReferenceSetValue` depending on the configured `<associationTypes>`. These types, as well as the updated XSD, will be available in the typings for Mendix 9.13, as they will be publicly released in that version.

## What should be covered while testing?
The added unit test coverage should be sufficient.

## Extra comments (optional)
The `package.json` and the release notes still need to be updated to the actual version number of the Mendix typings once they become available (upon the release of 9.13).