### PR TITLE
fix: automation/web-modules: add missing widgetsFolders arg to updateChangelogs fn

### DIFF
--- a/scripts/release/createWebModules.js
+++ b/scripts/release/createWebModules.js
@@ -164,9 +164,9 @@ async function createWebActionsModule() {
 async function commonActions(moduleInfo, widgets = [], exportWithSnippet = true, changeLogScope = "MODULE") {
     const tmpFolder = join(repoRootPath, "tmp", moduleFolderNameInRepo);
     await githubAuthentication(moduleInfo);
-    const moduleChangelogs = await (changeLogScope === "WIDGETS" ? updateChangelogs : updateModuleChangelogs)(
-        moduleInfo
-    );
+    const moduleChangelogs = await (changeLogScope === "WIDGETS"
+        ? updateChangelogs(widgets, moduleInfo)
+        : updateModuleChangelogs(moduleInfo));
     if (!moduleChangelogs) {
         throw new Error(
             `No unreleased changes found in the CHANGELOG.md for ${moduleInfo.nameWithSpace} ${moduleInfo.version}.`


### PR DESCRIPTION
## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (describe) automation fix

## What is the purpose of this PR?
- Fix modules automation script

## Relevant changes
- The updateChangelogs function was missing argument