### PR TITLE
[WC-829] fix(datagrid-web): fix cell size for custom content

### DIFF
--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/datagrid.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/datagrid.scss
@@ -207,6 +207,10 @@ $brand-primary: #264ae5 !default;
             word-break: break-all;
         }
 
+        > .td-custom-content {
+            flex-grow: 1;
+        }
+
         > .empty-placeholder {
             width: 100%;
         }

--- a/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/useCellRenderer.spec.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/__tests__/useCellRenderer.spec.ts
@@ -108,6 +108,8 @@ describe("Datagrid useCellRenderer hook", () => {
         const renderWrapper = jest.fn(x => x);
         const output = result.current(renderWrapper, { id: "333" as GUID }, 0);
         expect(renderWrapper).toBeCalled();
-        expect(output).toEqual("custom content");
+        expect(output.type).toBe("div");
+        expect(output.props.className).toEqual("td-custom-content");
+        expect(output.props.children).toEqual("custom content");
     });
 });

--- a/packages/pluggableWidgets/datagrid-web/src/utils/useCellRenderer.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/useCellRenderer.tsx
@@ -29,7 +29,7 @@ export function useCellRenderer({ onClick, columns }: CellRendererHookProps): Ce
                 </span>
             );
         } else {
-            content = column.content?.get(value);
+            content = <div className="td-custom-content">{column.content?.get(value)}</div>;
         }
 
         return renderWrapper(


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes  ❌
- Contains Atlas changes ✅
- Compatible with: MX 7️⃣, 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Fix alignment of elements of custom content placed in datagrid cells.

## What should be covered while testing?
Widgets rendered as custom content correctly taking whole space of a cell.
