### PR TITLE
Update MR template with point on external documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,41 +1,51 @@
 ## Checklist
-- Contains unit tests ✅ ❌
-- Contains breaking changes ✅ ❌
-- Contains Atlas changes ✅ ❌
-- Compatible with: MX 7️⃣, 8️⃣, 9️⃣
+
+-   Contains unit tests ✅ ❌
+-   Contains breaking changes ✅ ❌
+-   Contains Atlas changes ✅ ❌
+-   Compatible with: MX 7️⃣, 8️⃣, 9️⃣
+-   Has external documentation (link to `github.com/mendix/docs` MRs) ✅ ❌
 
 #### Web specific
-- Contains e2e tests ✅ ❌
-- Is accessible ✅ ❌
-- Compatible with Studio ✅ ❌
-- Cross-browser compatible ✅ ❌
+
+-   Contains e2e tests ✅ ❌
+-   Is accessible ✅ ❌
+-   Compatible with Studio ✅ ❌
+-   Cross-browser compatible ✅ ❌
 
 #### Native specific
-- Works in Android ✅ ❌
-- Works in iOS ✅ ❌
-- Works in Tablet ✅ ❌
+
+-   Works in Android ✅ ❌
+-   Works in iOS ✅ ❌
+-   Works in Tablet ✅ ❌
 
 #### Feature specific
-- Comply with designs ✅ ❌
-- Comply with PM's requirements ✅ ❌
+
+-   Comply with designs ✅ ❌
+-   Comply with PM's requirements ✅ ❌
 
 **_Please remove unnecessary emojis and sections and this comment before proceeding_**
 
 ## This PR contains
-- [ ] Bug fix
-- [ ] Feature
-- [ ] Refactor
-- [ ] Documentation
-- [ ] Other (describe)
+
+-   [ ] Bug fix
+-   [ ] Feature
+-   [ ] Refactor
+-   [ ] Documentation
+-   [ ] Other (describe)
 
 ## What is the purpose of this PR?
+
 _..._
 
 ## Relevant changes
+
 _Please add a high level explanation of what was changed and how the initial problem was solved_
 
 ## What should be covered while testing?
+
 _..._
 
 ## Extra comments (optional)
+
 _Please add extra comments or delete the section if not required_


### PR DESCRIPTION
Update template to include a checklist item for external documentation (on docs.mendix.com)

This should serve as a trigger to developers and reviewers, for documentation creation and also reviewing.

# suggestion
toggle whitespace off in review