### PR TITLE
[WC-1107] Fix issue with slider flex-grow

### DIFF
--- a/packages/pluggableWidgets/slider-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/slider-web/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   We fixed an issue with slider being rendered collapsed when "Show label" was set to "Yes" (Ticket #145543)
 
+### Changed
+
+-   We changed widget properties order to align UX between Studio and Studio Pro
+
 ## [2.0.0] - 2021-12-23
 
 ### Changed

--- a/packages/pluggableWidgets/slider-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/slider-web/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Changelog
+
 All notable changes to this widget will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue with slider being rendered collapsed when "Show label" was set to "Yes" (Ticket #145543)
+
 ## [2.0.0] - 2021-12-23
 
 ### Changed
-- Converted into a pluggable widget.
+
+-   Converted into a pluggable widget.

--- a/packages/pluggableWidgets/slider-web/src/ui/Slider.scss
+++ b/packages/pluggableWidgets/slider-web/src/ui/Slider.scss
@@ -4,6 +4,7 @@
 .widget-slider {
     padding: 4px 8px;
     margin-bottom: 16px;
+    flex-grow: 1;
 
     .rc-slider-disabled {
         background-color: initial;


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
- Fix style issue for Slider

## Relevant changes
- We set root styles for Slider to be `flex-grow: 1` by default

## What should be covered while testing?
- Enable "Show label" property for sldier
- Expected: slider width should be equal to available space
