### PR TITLE
Investigate mono-repo build/dev

### DIFF
--- a/packages/tools/pluggable-widgets-tools/bin/mx-scripts.js
+++ b/packages/tools/pluggable-widgets-tools/bin/mx-scripts.js
@@ -1,7 +1,7 @@
 #! /usr/bin/env node
 const { spawnSync } = require("child_process");
 const { existsSync } = require("fs");
-const { delimiter, dirname, join, parse } = require("path");
+const { delimiter, join, parse } = require("path");
 
 const [, , cmd, ...args] = process.argv;
 const nodeRegEx = /node_modules/g;

--- a/packages/tools/pluggable-widgets-tools/bin/mx-scripts.js
+++ b/packages/tools/pluggable-widgets-tools/bin/mx-scripts.js
@@ -3,10 +3,11 @@ const { spawnSync } = require("child_process");
 const { existsSync } = require("fs");
 const { delimiter, dirname, join, parse } = require("path");
 
-const [, currentScriptPath, cmd, ...args] = process.argv;
-const toolsRoot = currentScriptPath.endsWith("pluggable-widgets-tools")
-    ? join(dirname(currentScriptPath), "../@mendix/pluggable-widgets-tools")
-    : join(dirname(currentScriptPath), "..");
+const [, , cmd, ...args] = process.argv;
+const nodeRegEx = /node_modules/g;
+const mainSubDir = __dirname.search(nodeRegEx);
+const basePath = __dirname.substring(0, mainSubDir);
+const toolsRoot = join(basePath, "node_modules/@mendix/pluggable-widgets-tools");
 
 if (args.indexOf("--subprojectPath") > -1) {
     args.splice(args.indexOf("--subprojectPath"), 2);


### PR DESCRIPTION
## Checklist

- Compatible with: MX  9️⃣

#### Web specific

- Compatible with Studio ✅
- Cross-browser compatible ✅


## This PR contains

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?

Makes it possible to use `@mendix/pluggable-widgets-tools` in Mono-repos.

## Relevant changes

Ive been working on refactoring our teams mono-repo where we host our widgets in. With the current implementation   `pluggable-widgets-tools` does not play well if `node_modules` is not in a very specific place, and we are required to use [noHoist](https://classic.yarnpkg.com/blog/2018/02/15/nohoist/) and that makes our `node_modules` very **heavy**.

The error I get when I build a widget seems to be from `mx-scripts.js` where `toolsRoot` is calculated.

Currently `toolsRoot` uses `currentScriptPath` from [process.argv](https://nodejs.org/docs/latest/api/process.html#processargv) to get the path from and that usually resolves to something like this:

```
widget/node_modules/.bin/pluggable-widgets-tools
```

but in a mono-repo it will resolve to something like this:

```
repo/packages/widget/node_modules/.bin/pluggable-widgets-tools
```

but that is not possible as in a mono-repo the dependency will ideally be installed at the root level `repo/node_modules/.bin/pluggable-widgets-tools`.

My changes will assume `@mendix/pluggable-widgets-tools` dependency is installed in the root of the project and will go there to find the scrips.

## What should be covered while testing?

Build environments ?

I've tested it with a simple standalone widget, in a mono-repo and within this repo.

## Extra comments (optional)
are you doing well?