### PR TITLE
[WC-1161] Tooltip widget is not taking full width

### DIFF
--- a/packages/modules/atlas-core/CHANGELOG.md
+++ b/packages/modules/atlas-core/CHANGELOG.md
@@ -1,66 +1,70 @@
 # Changelog
 
-All notable changes to this widget will be documented in this file.
+All notable changes to this module will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [3.2.1] Atlas Core - 2022-4-1
+### Added
+
+-   We added a new design property for Tooltip widget.
+
+## [3.2.1] Atlas Core - 2022-04-01
 
 ### Fixed
 
 -   We fixed this module to be compatible with strict CSP mode.
 
-## [3.2.0] Atlas Core - 2022-2-25
+## [3.2.0] Atlas Core - 2022-02-25
 
 ### Added
 
 -   Added support for setting variables using relative length CSS units.
 
-## [3.1.1] Atlas Core - 2022-2-18
+## [3.1.1] Atlas Core - 2022-02-18
 
 ### Fixed
 
 -   We fixed an issue with logo covering the whole login page when opening in firefox (Ticket 141170).
 
-## [3.1.0] Atlas Core - 2022-2-2
+## [3.1.0] Atlas Core - 2022-02-02
 
 ### Added
 
 -   We added design properties to add shadows in containers. Thanks Ronnie van Doorn.
 
-## [3.0.9] Atlas Core - 2022-1-24
+## [3.0.9] Atlas Core - 2022-01-24
 
 ### Fixed
 
 -   We corrected the border styling for the Floating Action Button native widget when in Dark Mode.
 
-## [3.0.8] Atlas Core - 2021-12-3
+## [3.0.8] Atlas Core - 2021-12-03
 
 ### Added
 
 -   We added a design property to align the content of the image widget.
 
-## [3.0.7] - 2021-09-28
+## [3.0.7] Atlas Core - 2021-09-28
 
 ### Changed
 
 -   We fixed a problem with the styles of groupbox widget not respecting the header mode element size (Ticket #131119).
 
-## [3.0.6] - 2021-08-12
+## [3.0.6] Atlas Core - 2021-08-12
 
 ### Changed
 
 -   We fixed the z-index (priority) of the menu bar.
 
-## [3.0.5] - 2021-07-27
+## [3.0.5] Atlas Core - 2021-07-27
 
 ### Changed
 
 -   We moved resource files from web/resources to public folder.
 
-## [3.0.4] - 2021-07-16
+## [3.0.4] Atlas Core - 2021-07-16
 
 ### Added
 
@@ -76,7 +80,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 -   We removed the restrictions to show the toggle sidebar widget only on phones.
 -   We removed San Francisco font from default font variable.
 
-## [3.0.3] - 2021-06-29
+## [3.0.3] Atlas Core - 2021-06-29
 
 ### Added
 

--- a/packages/modules/atlas-core/package.json
+++ b/packages/modules/atlas-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlas-core",
   "moduleName": "Atlas Core",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/tooltip-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/tooltip-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue with Tooltip widget preventing contained widgets from rendering in full width.
+
 ## [1.1.0] - 2021-12-23
 
 ### Added

--- a/packages/pluggableWidgets/tooltip-web/package.json
+++ b/packages/pluggableWidgets/tooltip-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tooltip-web",
   "widgetName": "Tooltip",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Shows a value inside a colored tooltip or label",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "license": "Apache-2.0",

--- a/packages/pluggableWidgets/tooltip-web/src/package.xml
+++ b/packages/pluggableWidgets/tooltip-web/src/package.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Tooltip" version="1.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Tooltip" version="1.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
-            <widgetFile path="Tooltip.xml"/>
+            <widgetFile path="Tooltip.xml" />
         </widgetFiles>
         <files>
-            <file path="com/mendix/widget/web/tooltip"/>
+            <file path="com/mendix/widget/web/tooltip" />
         </files>
     </clientModule>
 </package>

--- a/packages/pluggableWidgets/tooltip-web/src/ui/Tooltip.scss
+++ b/packages/pluggableWidgets/tooltip-web/src/ui/Tooltip.scss
@@ -1,7 +1,4 @@
 .widget-tooltip {
-    display: flex;
-    flex-grow: 0;
-
     &.widget-tooltip-top {
         &,
         &-end,

--- a/packages/theming/atlas/package.json
+++ b/packages/theming/atlas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/atlas-ui",
-  "version": "3.1.1",
+  "version": "3.2.2",
   "description": "Mendix Atlas UI is the foundation of making beautiful apps with Mendix. For more information about the framework go to https://atlas.mendix.com.",
   "testProject": {
     "githubUrl": "https://github.com/mendix/Atlas-Design-System",

--- a/packages/theming/atlas/src/themesource/atlas_core/web/_exclusion-variables.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/_exclusion-variables.scss
@@ -71,6 +71,7 @@ $exclude-tab-container-helpers: false;
 $exclude-template-grid: false;
 $exclude-template-grid-helpers: false;
 $exclude-timeline: false;
+$exclude-tooltip: false;
 $exclude-typography: false;
 $exclude-typography-helpers: false;
 

--- a/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_tooltip.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/core/widgets/_tooltip.scss
@@ -1,0 +1,19 @@
+//
+// DISCLAIMER:
+// Do not change this file because it is core styling.
+// Customizing core files will make updating Atlas much more difficult in the future.
+// To customize any core styling, copy the part you want to customize to styles/web/sass/app/ so the core styling is overwritten.
+//
+
+@mixin tooltip() {
+    /* ==========================================================================
+       Tooltip
+
+       Widget styles
+    ========================================================================== */
+
+    // Tooltip inline
+    .widget-tooltip-inline {
+        display: inline-block;
+    }
+}

--- a/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
@@ -1181,38 +1181,38 @@
         }
     ],
     "com.mendix.widget.web.image.Image": [
-      {
-        "name": "Align content",
-        "type": "Dropdown",
-        "description": "Align content of this element left, right or center it. Align elements inside the container as a row or as a column.",
-        "options": [
-          {
-            "name": "Left align as a row",
-            "class": "row-left"
-          },
-          {
-            "name": "Center align as a row",
-            "class": "row-center"
-          },
-          {
-            "name": "Right align as a row",
-            "class": "row-right"
-          },
-          {
-            "name": "Left align as a column",
-            "class": "col-left"
-          },
-          {
-            "name": "Center align as a column",
-            "class": "col-center"
-          },
-          {
-            "name": "Right align as a column",
-            "class": "col-right"
-          }
-        ]
-      },
-      {
+        {
+            "name": "Align content",
+            "type": "Dropdown",
+            "description": "Align content of this element left, right or center it. Align elements inside the container as a row or as a column.",
+            "options": [
+                {
+                    "name": "Left align as a row",
+                    "class": "row-left"
+                },
+                {
+                    "name": "Center align as a row",
+                    "class": "row-center"
+                },
+                {
+                    "name": "Right align as a row",
+                    "class": "row-right"
+                },
+                {
+                    "name": "Left align as a column",
+                    "class": "col-left"
+                },
+                {
+                    "name": "Center align as a column",
+                    "class": "col-center"
+                },
+                {
+                    "name": "Right align as a column",
+                    "class": "col-right"
+                }
+            ]
+        },
+        {
             "name": "Image style",
             "type": "Dropdown",
             "description": "Change the image style.",
@@ -1310,6 +1310,14 @@
             ]
         }
     ],
+    "com.mendix.widget.custom.tooltip.Tooltip": [
+        {
+            "name": "Show inline",
+            "type": "Toggle",
+            "description": "Show the widget as an inline element.",
+            "class": "widget-tooltip-inline"
+        }
+    ],
     "com.mendix.widget.custom.RangeSlider.RangeSlider": [
         {
             "name": "Style",
@@ -1335,4 +1343,5 @@
                 }
             ]
         }
-    ]}
+    ]
+}

--- a/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/design-properties.json
@@ -1310,7 +1310,7 @@
             ]
         }
     ],
-    "com.mendix.widget.custom.tooltip.Tooltip": [
+    "com.mendix.widget.web.tooltip.Tooltip": [
         {
             "name": "Show inline",
             "type": "Toggle",

--- a/packages/theming/atlas/src/themesource/atlas_core/web/main.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/main.scss
@@ -324,6 +324,11 @@
     @include timeline();
 }
 
+@import "core/widgets/tooltip";
+@if not $exclude-tooltip {
+    @include tooltip();
+}
+
 @import "core/helpers/helper-classes";
 @if not $exclude-helper-classes {
     @include helper-classes();


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ✅ 
- Contains Atlas changes ✅ 
- Compatible with: MX 7️⃣, 8️⃣, 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 


## This PR contains
- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Make tooltip widget interfere less with children and surrounding. Add a design property to be able to render widget inline.

## What should be covered while testing?
Tooltip is still rendering correctly in different cases. Besides expanding where needed it should not expand to full width when it is unnecessary. If it is the case, this should be considered a breaking change and a major version have to be bumped. The new design property have bring the old inline behavior back.
