### PR TITLE
[WC-1163] Prevent PWT from assuming that `react-dom/server` is an external dependency

### DIFF
--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue with some packages were wrongly assumed to be externally available.
+
 ## [9.13.0] - 2022-05-04
 
 ### Added

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -311,11 +311,25 @@ const imagesAndFonts = [
     "**/*.eot"
 ];
 
-const webExternal = [/^mendix($|\/)/, /^react($|\/)/, /^react-dom($|\/)/, /^big.js$/];
+const commonExternalLibs = [
+    // "mendix" and internals under "mendix/"
+    /^mendix($|\/)/,
 
-const editorPreviewExternal = [/^mendix($|\/)/, /^react($|\/)/, /^react-dom($|\/)/];
+    // "react"
+    /^react$/,
 
-const editorConfigExternal = [/^mendix($|\/)/, /^react($|\/)/, /^react-dom($|\/)/];
+    // "react/jsx-runtime"
+    /^react\/jsx-runtime$/,
+
+    // "react-dom"
+    /^react-dom$/
+];
+
+const webExternal = commonExternalLibs.concat(/^big.js$/);
+
+const editorPreviewExternal = commonExternalLibs;
+
+const editorConfigExternal = commonExternalLibs;
 
 export function postCssPlugin(outputFormat, production, postcssPlugins = []) {
     return postcss({

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.native.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.native.js
@@ -244,7 +244,19 @@ export default async args => {
 
 const extensions = [".js", ".jsx", ".tsx", ".ts"];
 
-const editorConfigExternal = [/^mendix($|\/)/, /^react($|\/)/, /^react-dom($|\/)/];
+const editorConfigExternal = [
+    // "mendix" and internals under "mendix/"
+    /^mendix($|\/)/,
+
+    // "react"
+    /^react$/,
+
+    // "react/jsx-runtime"
+    /^react\/jsx-runtime$/,
+
+    // "react-dom"
+    /^react-dom$/
+];
 
 const nativeExternal = [
     /^mendix($|\/)/,

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.13.0",
+  "version": "9.13.1",
   "description": "Mendix Pluggable Widgets Tools",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX  9️⃣



## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
There is a limited set of external packages provided in Mendix client, state those explicitly instead of assuming that the whole namespace is available.

