### PR TITLE
[WC-1177] Gallery widget filters container

### DIFF
--- a/packages/pluggableWidgets/gallery-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/gallery-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We removed "widget-gallery-filter" element from DOM if no filters has been provided.
+
 ## [1.1.0] - 2021-12-23
 
 ### Added

--- a/packages/pluggableWidgets/gallery-web/package.json
+++ b/packages/pluggableWidgets/gallery-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gallery-web",
   "widgetName": "Gallery",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A flexible gallery widget that renders columns, rows and layouts.",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "license": "Apache-2.0",

--- a/packages/pluggableWidgets/gallery-web/src/Gallery.editorPreview.tsx
+++ b/packages/pluggableWidgets/gallery-web/src/Gallery.editorPreview.tsx
@@ -35,6 +35,7 @@ export function preview(props: GalleryPreviewProps): ReactElement {
                     </props.filtersPlaceholder.renderer>
                 ) : null
             }
+            hasFilters={!!props.filterList.length}
             hasMoreItems={false}
             items={items}
             itemRenderer={useCallback(

--- a/packages/pluggableWidgets/gallery-web/src/Gallery.tsx
+++ b/packages/pluggableWidgets/gallery-web/src/Gallery.tsx
@@ -157,6 +157,7 @@ export function Gallery(props: GalleryContainerProps): ReactElement {
                 ]
             )}
             filtersTitle={props.filterSectionTitle?.value}
+            hasFilters={!!props.filterList.length}
             hasMoreItems={props.datasource.hasMoreItems ?? false}
             items={props.datasource.items ?? []}
             itemRenderer={useCallback(

--- a/packages/pluggableWidgets/gallery-web/src/components/Gallery.tsx
+++ b/packages/pluggableWidgets/gallery-web/src/components/Gallery.tsx
@@ -10,6 +10,7 @@ export interface GalleryProps<T extends ObjectItem> {
     emptyMessageTitle?: string;
     filters?: ReactNode;
     filtersTitle?: string;
+    hasFilters: boolean;
     hasMoreItems: boolean;
     items: T[];
     itemRenderer: (
@@ -47,9 +48,11 @@ export function Gallery<T extends ObjectItem>(props: GalleryProps<T>): ReactElem
     return (
         <div className={classNames("widget-gallery", props.className)} data-focusindex={props.tabIndex || 0}>
             {props.paginationPosition === "above" && pagination}
-            <div className="widget-gallery-filter" role="section" aria-label={props.filtersTitle}>
-                {props.filters}
-            </div>
+            {props.hasFilters ? (
+                <div className="widget-gallery-filter" role="section" aria-label={props.filtersTitle}>
+                    {props.filters}
+                </div>
+            ) : null}
 
             {props.items.length > 0 && props.itemRenderer && (
                 <InfiniteBody

--- a/packages/pluggableWidgets/gallery-web/src/components/__tests__/Gallery.spec.tsx
+++ b/packages/pluggableWidgets/gallery-web/src/components/__tests__/Gallery.spec.tsx
@@ -24,7 +24,9 @@ const defaultProps: GalleryProps<ObjectItem> = {
     desktopItems: 4,
     className: "",
     items: [{ id: "11" as GUID }, { id: "22" as GUID }, { id: "33" as GUID }],
-    itemRenderer: itemWrapperFunction({})
+    itemRenderer: itemWrapperFunction({}),
+    hasFilters: true,
+    filters: <input />
 };
 
 describe("Gallery", () => {
@@ -175,6 +177,15 @@ describe("Gallery", () => {
                     emptyPlaceholderRenderer={renderWrapper => renderWrapper(<span>No items found</span>)}
                 />
             );
+
+            expect(gallery).toMatchSnapshot();
+        });
+    });
+
+    describe("without filters", () => {
+        it("renders structure without filters container", () => {
+            const filters = { ...defaultProps, hasFilters: false, filters: undefined };
+            const gallery = render(<Gallery {...filters} />);
 
             expect(gallery).toMatchSnapshot();
         });

--- a/packages/pluggableWidgets/gallery-web/src/components/__tests__/__snapshots__/Gallery.spec.tsx.snap
+++ b/packages/pluggableWidgets/gallery-web/src/components/__tests__/__snapshots__/Gallery.spec.tsx.snap
@@ -8,7 +8,9 @@ exports[`Gallery DOM Structure renders correctly 1`] = `
   <div
     class="widget-gallery-filter"
     role="section"
-  />
+  >
+    <input />
+  </div>
   <div
     class="widget-gallery-items widget-gallery-lg-4 widget-gallery-md-3 widget-gallery-sm-2 infinite-loading"
     role="list"
@@ -43,7 +45,9 @@ exports[`Gallery DOM Structure renders correctly with onclick event 1`] = `
   <div
     class="widget-gallery-filter"
     role="section"
-  />
+  >
+    <input />
+  </div>
   <div
     class="widget-gallery-items widget-gallery-lg-4 widget-gallery-md-3 widget-gallery-sm-2 infinite-loading"
     role="list"
@@ -82,7 +86,9 @@ exports[`Gallery with accessibility properties renders correctly 1`] = `
     aria-label="filter title"
     class="widget-gallery-filter"
     role="section"
-  />
+  >
+    <input />
+  </div>
   <div
     aria-label="empty message"
     class="widget-gallery-empty"
@@ -107,7 +113,9 @@ exports[`Gallery with empty option renders correctly 1`] = `
   <div
     class="widget-gallery-filter"
     role="section"
-  />
+  >
+    <input />
+  </div>
   <div
     class="widget-gallery-empty"
     role="section"
@@ -190,9 +198,42 @@ exports[`Gallery with pagination renders correctly 1`] = `
   <div
     class="widget-gallery-filter"
     role="section"
-  />
+  >
+    <input />
+  </div>
   <div
     class="widget-gallery-items widget-gallery-lg-4 widget-gallery-md-3 widget-gallery-sm-2"
+    role="list"
+  >
+    <div
+      class="widget-gallery-item"
+      role="listitem"
+    >
+      11
+    </div>
+    <div
+      class="widget-gallery-item"
+      role="listitem"
+    >
+      22
+    </div>
+    <div
+      class="widget-gallery-item"
+      role="listitem"
+    >
+      33
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Gallery without filters renders structure without filters container 1`] = `
+<div
+  class="widget-gallery"
+  data-focusindex="0"
+>
+  <div
+    class="widget-gallery-items widget-gallery-lg-4 widget-gallery-md-3 widget-gallery-sm-2 infinite-loading"
     role="list"
   >
     <div

--- a/packages/pluggableWidgets/gallery-web/src/package.xml
+++ b/packages/pluggableWidgets/gallery-web/src/package.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Gallery" version="1.1.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Gallery" version="1.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
-            <widgetFile path="Gallery.xml"/>
+            <widgetFile path="Gallery.xml" />
         </widgetFiles>
         <files>
-            <file path="com/mendix/widget/web/gallery/"/>
+            <file path="com/mendix/widget/web/gallery/" />
         </files>
     </clientModule>
 </package>

--- a/packages/pluggableWidgets/gallery-web/tsconfig.json
+++ b/packages/pluggableWidgets/gallery-web/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "extends": "@mendix/pluggable-widgets-tools/configs/tsconfig.base",
-    "baseUrl": "./",
+    "compilerOptions": {
+        "baseUrl": "./"
+    },
     "include": ["./src"]
 }


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX  9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅ 

#### Feature specific
- Comply with designs ✅ 
- Comply with PM's requirements ✅ 

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Purpose is to remove `widget-gallery-filter` element from dom if there is no filters.

## Relevant changes
Added filters count variable to make it simple to understand whether is there a filter or not.

## What should be covered while testing?
If element exist on DOM or not.

## Extra comments (optional)
Need to add e2e tests as well.