### PR TITLE
[WC-1139] Add e2e test for dropdown-sort-web

### DIFF
--- a/packages/pluggableWidgets/dropdown-sort-web/cypress/integration/DropDownSort.spec.js
+++ b/packages/pluggableWidgets/dropdown-sort-web/cypress/integration/DropDownSort.spec.js
@@ -1,0 +1,20 @@
+describe("dropdown-sort-web", () => {
+    beforeEach(() => {
+        cy.visit("/");
+    });
+    it("shows the descending order", () => {
+        cy.get(".mx-name-drop_downSort1").click();
+        cy.get(".dropdown-list > li:nth-child(2)").click();
+        cy.get(".mx-name-drop_downSort1").find(".btn").first().click();
+        cy.wait(1000);
+        cy.get(".mx-name-gallery1").find(".widget-gallery-item").first().should("have.text", "test3");
+    });
+
+    it("shows the ascending order", () => {
+        cy.get(".mx-name-drop_downSort1").click();
+        cy.get(".dropdown-list > li:nth-child(2)").click();
+        cy.get(".mx-name-drop_downSort1").find(".btn").first().click();
+        cy.get(".mx-name-drop_downSort1").find(".btn").first().click();
+        cy.get(".mx-name-gallery1").find(".widget-gallery-item").first().should("have.text", "test");
+    });
+});

--- a/packages/pluggableWidgets/dropdown-sort-web/cypress/plugins/index.js
+++ b/packages/pluggableWidgets/dropdown-sort-web/cypress/plugins/index.js
@@ -1,0 +1,1 @@
+module.exports = require("../../../../../configs/e2e/cypress/plugins");

--- a/packages/pluggableWidgets/dropdown-sort-web/cypress/support/index.js
+++ b/packages/pluggableWidgets/dropdown-sort-web/cypress/support/index.js
@@ -1,0 +1,1 @@
+import "../../../../../configs/e2e/cypress/support/command";

--- a/packages/pluggableWidgets/dropdown-sort-web/package.json
+++ b/packages/pluggableWidgets/dropdown-sort-web/package.json
@@ -28,9 +28,9 @@
     "format": "pluggable-widgets-tools format",
     "lint": "eslint --config ../../../.eslintrc.js --ext .jsx,.js,.ts,.tsx src/",
     "test": "pluggable-widgets-tools test:unit:web",
-    "pretest:e2e": "echo 'Skipped'",
-    "test:e2e": "echo 'Skipped'",
-    "test:e2e:dev": "echo 'Skipped'",
+    "pretest:e2e": "npm run release && node ../../../scripts/test/updateAtlas.js --latest-atlas",
+    "test:e2e": "pluggable-widgets-tools test:e2e:web:cypress --remove-atlas-files",
+    "test:e2e:local": "npx cypress open --browser chrome --config-file ../../../configs/e2e/cypress/cypress.json",
     "release": "pluggable-widgets-tools release:ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Checklist
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅ 
- Cross-browser compatible ✅ 

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (describe)

## What is the purpose of this PR?
Add e2e test for dropdown-sort-web.

## Relevant changes
Added specs using Cypress.

## What should be covered while testing?
Automation should pass.
