### PR TITLE
[NC-759] fix native test runner ios

### DIFF
--- a/detox/README.md
+++ b/detox/README.md
@@ -16,6 +16,8 @@ To prepare your environment for running the e2e tests (or when you changed the d
 
 To be able to use Detox, it is required to build an app that contains the Detox instrumentation. It is important that both the app under test with the instrumentation and the tests use a similar (preferably same) version of Detox. They need to talk to each other using the same dialect. Once they differ too much, instead of telling you these versions are not compatible, certain commands will stop working.
 
+Note: The below setup is only required whenever we change the detox version in package.json in `widgets-resources`.
+
 Steps:
 
 1. In the `appdev` repo, go to the `developerapp` folder. Install the version of Detox that you want to use with the `npm i -D detox@<version>` command.

--- a/detox/README.md
+++ b/detox/README.md
@@ -1,18 +1,36 @@
 # Running local detox tests
 
-### Required software
+## Required software
 
 -   Android studio
 -   Xcode
 -   Node 14
 -   Java 8
 
-### Setup emulators
+## Setup emulators
 
 The devices that will be run on are defined in the top of the `detox/detox.config.js` file.
 To prepare your environment for running the e2e tests (or when you changed the devices in the config file), first run `npm run setup-mobile` from the root of this package.
 
-### Run or debug the tests:
+## Setup developerapp
+
+To be able to use Detox, it is required to build an app that contains the Detox instrumentation. It is important that both the app under test with the instrumentation and the tests use a similar (preferably same) version of Detox. They need to talk to each other using the same dialect. Once they differ too much, instead of telling you these versions are not compatible, certain commands will stop working.
+
+Steps:
+
+1. In the `appdev` repo, go to the `developerapp` folder. Install the version of Detox that you want to use with the `npm i -D detox@<version>` command.
+2. Run `npm run ios:clean-pod-install` in the `developerapp` dir
+    1. if this fails with “CDN: trunk URL couldn't be downloaded…”,
+    2. then `cd ios` & `pod repo remove trunk`
+    3. then run `pod install`
+3. Go to the `appdev/automated/frontend/native` folder. Run `npm run build`
+4. Android files `app-detox-debug.apk` and `app-detox-debug-androidTest.apk` should be in the `appdev/developerapp/artifacts` folder.
+5. iOS file `DeveloperApp.app` should be at the `appdev/developerapp/ios/build/detox/output/Build/Products/Debug-iphonesimulator/DeveloperApp.app` folder. Zip the `DeveloperApp.app` file
+6. Upload the 3 files generated above at `https://www.dropbox.com/home/RnD/NativeContent/detox-apps/19.7.1`. Ensure to give rights of `Anyone with this link can view` to all the 3 files.
+7. Update the scripts with new URLs at `widgets-resources/detox/scripts`
+8. In `widgets-resources` root, run `npm run setup-mobile` to download the latest `developerapp` files.
+
+## Run or debug the tests:
 
 To run all the specs(from the root directory of the repository or particular native-widget): `npm run test:e2e:local:PLATFORM_NAME`
 
@@ -22,7 +40,7 @@ Debugging(from the root directory of the particular native-widget): `npm run deb
 
 PLATFORM_NAME = `android` or `ios`
 
-# Troubleshooting
+## Troubleshooting
 
 `Failed to connect to websocket`
 

--- a/detox/detox.config.js
+++ b/detox/detox.config.js
@@ -17,8 +17,8 @@ module.exports = {
         },
         "android.developerapp": {
             type: "android.apk",
-            binaryPath: `${__dirname}/apps/app-debug.apk`,
-            testBinaryPath: `${__dirname}/apps/app-debug-androidTest.apk`
+            binaryPath: `${__dirname}/apps/app-detox-debug.apk`,
+            testBinaryPath: `${__dirname}/apps/app-detox-debug-androidTest.apk`
         }
     },
     devices: {

--- a/detox/detox.config.js
+++ b/detox/detox.config.js
@@ -1,6 +1,6 @@
 const ANDROID_SDK_VERSION = "30"; // Set to 30 because: https://github.com/wix/Detox/issues/3071
 const ANDROID_DEVICE_TYPE = "pixel";
-const IOS_SDK_VERSION = "15.4";
+const IOS_SDK_VERSION = "15.5";
 const IOS_DEVICE_TYPE = "iPhone 13";
 
 module.exports = {

--- a/detox/scripts/setup-android.js
+++ b/detox/scripts/setup-android.js
@@ -9,8 +9,8 @@ main().catch(e => {
 async function main() {
     console.log("Downloading Android apps...");
     await Promise.all([
-        downloadFile("https://www.dropbox.com/s/3m4i4tiflncvriw/app-debug-androidTest.apk?dl=1"),
-        downloadFile("https://www.dropbox.com/s/wrhcm3ff316itip/app-debug.apk?dl=1")
+        downloadFile("https://www.dropbox.com/s/4hel4yki6vl1et5/app-debug-androidTest.apk?dl=1"),
+        downloadFile("https://www.dropbox.com/s/qu4z1kpy8abnyr3/app-debug.apk?dl=1")
     ]);
 
     console.log(`Installing Android SDK version ${ANDROID_SDK_VERSION}...`);

--- a/detox/scripts/setup-android.js
+++ b/detox/scripts/setup-android.js
@@ -9,8 +9,8 @@ main().catch(e => {
 async function main() {
     console.log("Downloading Android apps...");
     await Promise.all([
-        downloadFile("https://www.dropbox.com/s/4hel4yki6vl1et5/app-debug-androidTest.apk?dl=1"),
-        downloadFile("https://www.dropbox.com/s/qu4z1kpy8abnyr3/app-debug.apk?dl=1")
+        downloadFile("https://www.dropbox.com/s/4hel4yki6vl1et5/app-detox-debug-androidTest.apk?dl=1"),
+        downloadFile("https://www.dropbox.com/s/qu4z1kpy8abnyr3/app-detox-debug.apk?dl=1")
     ]);
 
     console.log(`Installing Android SDK version ${ANDROID_SDK_VERSION}...`);

--- a/detox/scripts/setup-ios.js
+++ b/detox/scripts/setup-ios.js
@@ -18,7 +18,7 @@ async function main() {
     console.log("Downloading iOS app...");
     const outputPath = join(__dirname, "..", "apps");
     rmSync(join(outputPath, "DeveloperApp.app"), { recursive: true, force: true });
-    const downloadPath = await downloadFile("https://www.dropbox.com/s/g4hctr2joetqn8k/DeveloperApp.zip?dl=1");
+    const downloadPath = await downloadFile("https://www.dropbox.com/s/u7k5ho1krbkn46y/DeveloperApp.zip?dl=1");
 
     console.log("Unzipping iOS app...");
     await promisify(exec)(`unzip -o ${downloadPath} -d ${outputPath}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -304,7 +304,7 @@
                 "@types/xml2js": "^0.4.5",
                 "cross-env": "^7.0.2",
                 "deepmerge": "^4.2.2",
-                "detox": "^19.5.7",
+                "detox": "^19.7.1",
                 "husky": "^7.0.0",
                 "identity-obj-proxy": "^3.0.0",
                 "image-js": "^0.33.0",
@@ -18594,9 +18594,9 @@
             "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
         },
         "node_modules/detox": {
-            "version": "19.5.7",
-            "resolved": "https://registry.npmjs.org/detox/-/detox-19.5.7.tgz",
-            "integrity": "sha512-vLd5eySM/zjaWLJGgbtx4g7qA3JZLCZHVz4n/AphNFFW3T3qiyh7HfIYeoBoZanjjyC1k3iuw2UshpBRlHZuGA==",
+            "version": "19.7.1",
+            "resolved": "https://registry.npmjs.org/detox/-/detox-19.7.1.tgz",
+            "integrity": "sha512-V0XwiaFX1LvIjLl+G4tzMZ0M4YqenQXAdTsw9kO2dVo6NC9RuYqOIsmT9M3CRN9PF22TKJ8pFdA6onYhH/zkiQ==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -18624,6 +18624,7 @@
                 "which": "^1.3.1",
                 "ws": "^7.0.0",
                 "yargs": "^16.0.3",
+                "yargs-parser": "^20.2.2",
                 "yargs-unparser": "^2.0.0"
             },
             "bin": {
@@ -18633,9 +18634,16 @@
                 "node": ">=8.3.0"
             },
             "peerDependencies": {
-                "jest-circus": "26.0.x - 26.4.x || >=26.5.2",
-                "jest-environment-node": ">=25.0.0",
+                "jest": "26.0.x - 26.4.x || ^26.5.2 || 27.x.x || 28.x.x",
                 "mocha": ">=6.0.0"
+            },
+            "peerDependenciesMeta": {
+                "jest": {
+                    "optional": true
+                },
+                "mocha": {
+                    "optional": true
+                }
             }
         },
         "node_modules/detox/node_modules/ajv": {
@@ -62739,9 +62747,9 @@
             "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
         },
         "detox": {
-            "version": "19.5.7",
-            "resolved": "https://registry.npmjs.org/detox/-/detox-19.5.7.tgz",
-            "integrity": "sha512-vLd5eySM/zjaWLJGgbtx4g7qA3JZLCZHVz4n/AphNFFW3T3qiyh7HfIYeoBoZanjjyC1k3iuw2UshpBRlHZuGA==",
+            "version": "19.7.1",
+            "resolved": "https://registry.npmjs.org/detox/-/detox-19.7.1.tgz",
+            "integrity": "sha512-V0XwiaFX1LvIjLl+G4tzMZ0M4YqenQXAdTsw9kO2dVo6NC9RuYqOIsmT9M3CRN9PF22TKJ8pFdA6onYhH/zkiQ==",
             "dev": true,
             "requires": {
                 "ajv": "^8.6.3",
@@ -62768,6 +62776,7 @@
                 "which": "^1.3.1",
                 "ws": "^7.0.0",
                 "yargs": "^16.0.3",
+                "yargs-parser": "^20.2.2",
                 "yargs-unparser": "^2.0.0"
             },
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/xml2js": "^0.4.5",
     "cross-env": "^7.0.2",
     "deepmerge": "^4.2.2",
-    "detox": "^19.5.7",
+    "detox": "^19.7.1",
     "husky": "^7.0.0",
     "identity-obj-proxy": "^3.0.0",
     "image-js": "^0.33.0",

--- a/packages/pluggableWidgets/accordion-native/package.json
+++ b/packages/pluggableWidgets/accordion-native/package.json
@@ -30,6 +30,6 @@
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
-    "detox": "^19.5.7"
+    "detox": "^19.7.1"
   }
 }

--- a/packages/pluggableWidgets/activity-indicator-native/package.json
+++ b/packages/pluggableWidgets/activity-indicator-native/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
-    "detox": "^19.5.7",
+    "detox": "^19.7.1",
     "eslint": "^7.20.0"
   }
 }

--- a/packages/pluggableWidgets/app-events-native/package.json
+++ b/packages/pluggableWidgets/app-events-native/package.json
@@ -30,6 +30,6 @@
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "@mendix/piw-utils-internal": "^1.0.0",
     "eslint": "^7.20.0",
-    "detox": "^19.5.7"
+    "detox": "^19.7.1"
   }
 }

--- a/packages/pluggableWidgets/background-gradient-native/package.json
+++ b/packages/pluggableWidgets/background-gradient-native/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": "^9.0.0",
     "eslint": "^7.20.0",
-    "detox": "^19.5.7"
+    "detox": "^19.7.1"
   },
   "dependencies": {
     "react-native-linear-gradient": "2.5.6",

--- a/packages/pluggableWidgets/background-image-native/package.json
+++ b/packages/pluggableWidgets/background-image-native/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@mendix/piw-utils-internal": "1.0.0",
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
-    "detox": "^19.5.7",
+    "detox": "^19.7.1",
     "eslint": "^7.20.0"
   }
 }

--- a/packages/pluggableWidgets/badge-native/package.json
+++ b/packages/pluggableWidgets/badge-native/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
-    "detox": "^19.5.7",
+    "detox": "^19.7.1",
     "eslint": "^7.20.0"
   }
 }

--- a/packages/pluggableWidgets/bar-chart-native/package.json
+++ b/packages/pluggableWidgets/bar-chart-native/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
-    "detox": "^19.5.7",
+    "detox": "^19.7.1",
     "eslint": "^7.20.0"
   }
 }

--- a/packages/pluggableWidgets/carousel-native/package.json
+++ b/packages/pluggableWidgets/carousel-native/package.json
@@ -33,6 +33,6 @@
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "@types/react-native-snap-carousel": "^3.7.4",
     "eslint": "^7.20.0",
-    "detox": "^19.5.7"
+    "detox": "^19.7.1"
   }
 }

--- a/packages/pluggableWidgets/color-picker-native/package.json
+++ b/packages/pluggableWidgets/color-picker-native/package.json
@@ -35,6 +35,6 @@
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "@types/tinycolor2": "^1.4.1",
     "eslint": "^7.20.0",
-    "detox": "^19.5.7"
+    "detox": "^19.7.1"
   }
 }

--- a/packages/pluggableWidgets/column-chart-native/package.json
+++ b/packages/pluggableWidgets/column-chart-native/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
-    "detox": "^19.5.7",
+    "detox": "^19.7.1",
     "eslint": "^7.20.0"
   }
 }

--- a/packages/pluggableWidgets/feedback-native/package.json
+++ b/packages/pluggableWidgets/feedback-native/package.json
@@ -36,6 +36,6 @@
     "@types/querystringify": "^2.0.0",
     "@types/react-native-dialog": "^5.5.0",
     "eslint": "^7.20.0",
-    "detox": "^19.5.7"
+    "detox": "^19.7.1"
   }
 }

--- a/packages/pluggableWidgets/floating-action-button-native/package.json
+++ b/packages/pluggableWidgets/floating-action-button-native/package.json
@@ -32,6 +32,6 @@
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "eslint": "^7.20.0",
-    "detox": "^19.5.7"
+    "detox": "^19.7.1"
   }
 }

--- a/packages/pluggableWidgets/image-native/package.json
+++ b/packages/pluggableWidgets/image-native/package.json
@@ -37,6 +37,6 @@
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "eslint": "^7.20.0",
-    "detox": "^19.5.7"
+    "detox": "^19.7.1"
   }
 }

--- a/packages/pluggableWidgets/intro-screen-native/package.json
+++ b/packages/pluggableWidgets/intro-screen-native/package.json
@@ -33,6 +33,6 @@
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "eslint": "^7.20.0",
-    "detox": "^19.5.7"
+    "detox": "^19.7.1"
   }
 }

--- a/packages/pluggableWidgets/line-chart-native/package.json
+++ b/packages/pluggableWidgets/line-chart-native/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
-    "detox": "^19.5.7",
+    "detox": "^19.7.1",
     "eslint": "^7.20.0"
   }
 }

--- a/packages/pluggableWidgets/maps-native/package.json
+++ b/packages/pluggableWidgets/maps-native/package.json
@@ -34,6 +34,6 @@
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "eslint": "^7.20.0",
-    "detox": "^19.5.7"
+    "detox": "^19.7.1"
   }
 }

--- a/packages/pluggableWidgets/pie-doughnut-chart-native/package.json
+++ b/packages/pluggableWidgets/pie-doughnut-chart-native/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
-    "detox": "^19.5.7",
+    "detox": "^19.7.1",
     "eslint": "^7.20.0"
   }
 }

--- a/packages/pluggableWidgets/popup-menu-native/package.json
+++ b/packages/pluggableWidgets/popup-menu-native/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "@types/react-native-material-menu": "^1.0.0",
-    "detox": "^19.5.7",
+    "detox": "^19.7.1",
     "eslint": "^7.20.0"
   }
 }

--- a/packages/pluggableWidgets/progress-bar-native/package.json
+++ b/packages/pluggableWidgets/progress-bar-native/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
-    "detox": "^19.5.7",
+    "detox": "^19.7.1",
     "eslint": "^7.20.0"
   }
 }

--- a/packages/pluggableWidgets/progress-circle-native/package.json
+++ b/packages/pluggableWidgets/progress-circle-native/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "@mendix/piw-utils-internal": "^1.0.0",
-    "detox": "^19.5.7",
+    "detox": "^19.7.1",
     "eslint": "^7.20.0"
   }
 }

--- a/packages/pluggableWidgets/qr-code-native/package.json
+++ b/packages/pluggableWidgets/qr-code-native/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@mendix/piw-utils-internal": "1.0.0",
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
-    "detox": "^19.5.7",
+    "detox": "^19.7.1",
     "eslint": "^7.20.0"
   }
 }

--- a/packages/pluggableWidgets/radio-buttons-native/package.json
+++ b/packages/pluggableWidgets/radio-buttons-native/package.json
@@ -31,6 +31,6 @@
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "eslint": "^7.20.0",
-    "detox": "^19.5.7"
+    "detox": "^19.7.1"
   }
 }

--- a/packages/pluggableWidgets/range-slider-native/package.json
+++ b/packages/pluggableWidgets/range-slider-native/package.json
@@ -34,6 +34,6 @@
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "@types/ptomasroos__react-native-multi-slider": "^0.0.1",
     "eslint": "^7.20.0",
-    "detox": "^19.5.7"
+    "detox": "^19.7.1"
   }
 }

--- a/packages/pluggableWidgets/rating-native/package.json
+++ b/packages/pluggableWidgets/rating-native/package.json
@@ -35,7 +35,7 @@
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "@types/react-native-button": "^3.0.1",
     "@types/react-native-star-rating": "^1.1.2",
-    "detox": "^19.5.7",
+    "detox": "^19.7.1",
     "eslint": "^7.20.0"
   }
 }

--- a/packages/pluggableWidgets/repeater-native/package.json
+++ b/packages/pluggableWidgets/repeater-native/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
-    "detox": "^19.5.7",
+    "detox": "^19.7.1",
     "eslint": "^7.20.0"
   }
 }

--- a/packages/pluggableWidgets/signature-native/package.json
+++ b/packages/pluggableWidgets/signature-native/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
-    "detox": "^19.5.7",
+    "detox": "^19.7.1",
     "eslint": "^7.20.0"
   }
 }

--- a/packages/pluggableWidgets/slider-native/package.json
+++ b/packages/pluggableWidgets/slider-native/package.json
@@ -33,6 +33,6 @@
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "@types/ptomasroos__react-native-multi-slider": "^0.0.1",
     "eslint": "^7.20.0",
-    "detox": "^19.5.7"
+    "detox": "^19.7.1"
   }
 }

--- a/packages/pluggableWidgets/switch-native/package.json
+++ b/packages/pluggableWidgets/switch-native/package.json
@@ -31,6 +31,6 @@
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "eslint": "^7.20.0",
-    "detox": "^19.5.7"
+    "detox": "^19.7.1"
   }
 }

--- a/packages/pluggableWidgets/toggle-buttons-native/package.json
+++ b/packages/pluggableWidgets/toggle-buttons-native/package.json
@@ -33,6 +33,6 @@
     "@babel/plugin-transform-flow-strip-types": "^7.4.4",
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "eslint": "^7.20.0",
-    "detox": "^19.5.7"
+    "detox": "^19.7.1"
   }
 }

--- a/packages/pluggableWidgets/web-view-native/package.json
+++ b/packages/pluggableWidgets/web-view-native/package.json
@@ -32,6 +32,6 @@
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "eslint": "^7.20.0",
-    "detox": "^19.5.7"
+    "detox": "^19.7.1"
   }
 }


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

#### Native specific
- Works in Android ✅
- Works in iOS ✅
- Works in Tablet ❌

## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [X] Other (describe)

## What is the purpose of this PR?
Update detox version of applicable native widgets to `19.17.1` and iOS SDK version to `15.5`.

## Relevant changes
This fixes the iOS test runner as described in this [PR](https://github.com/wix/Detox/pull/3420).

## What should be covered while testing?
Run the e2e iOS tests locally successfully.

