### PR TITLE
Force react resolution to avoid conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
   },
   "overrides": {
     "@testing-library/react-native": {
-      "react-test-renderer": "17.0.2"
+      "react-test-renderer": "17.0.2",
+      "react-native": "0.68.2"
     },
     "react-native": {
       "use-subscription": "1.5.1"

--- a/packages/tools/pluggable-widgets-tools/tests/commands.js
+++ b/packages/tools/pluggable-widgets-tools/tests/commands.js
@@ -181,7 +181,7 @@ async function main() {
 
             await writeJson(join(workDir, "package.json"), widgetPackageJson);
 
-            await execAsync("npm install --loglevel=error", workDir);
+            await execAsync("npm install --legacy-peer-deps --loglevel=error", workDir);
         }
 
         async function testLint() {


### PR DESCRIPTION
react-native 0.69 released yesterday has a peerDep on react v18. this causes a conflict with other dependencies. 

force resolution to the previous rn version, 0.68.2 which has a deepDep for react v17

& use `--legacy-peer-deps` in `npm install` for scripts' tests