### PR TITLE
use legacy peer deps in npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+legacy-peer-deps=true

--- a/packages/tools/pluggable-widgets-tools/tests/commands.js
+++ b/packages/tools/pluggable-widgets-tools/tests/commands.js
@@ -181,7 +181,7 @@ async function main() {
 
             await writeJson(join(workDir, "package.json"), widgetPackageJson);
 
-            await execAsync("npm install --legacy-peer-deps --loglevel=error", workDir);
+            await execAsync("npm install --loglevel=error", workDir);
         }
 
         async function testLint() {


### PR DESCRIPTION
- add legacy peer deps to npmrc 
- remove explicit usage in scripts' tests

fixes CI issue: https://github.com/mendix/widgets-resources/runs/7037695181?check_suite_focus=true