### PR TITLE
Fix dropdown sort e2e test failing

### DIFF
--- a/packages/pluggableWidgets/dropdown-sort-web/cypress/integration/DropDownSort.spec.js
+++ b/packages/pluggableWidgets/dropdown-sort-web/cypress/integration/DropDownSort.spec.js
@@ -15,6 +15,7 @@ describe("dropdown-sort-web", () => {
         cy.get(".dropdown-list > li:nth-child(2)").click();
         cy.get(".mx-name-drop_downSort1").find(".btn").first().click();
         cy.get(".mx-name-drop_downSort1").find(".btn").first().click();
+        cy.wait(1000);
         cy.get(".mx-name-gallery1").find(".widget-gallery-item").first().should("have.text", "test");
     });
 });


### PR DESCRIPTION
## Checklist
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ✅ 


## This PR contains
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (test)

## What is the purpose of this PR?
Fix a test with the dropdown sort, failing on CI only.

## Relevant changes
Added a new wait to get the correct values in the expect.

## What should be covered while testing?
Automation should pass.
