### PR TITLE
fix(datagrid-web): fix filter widgets layout

### DIFF
--- a/packages/modules/data-widgets/package.json
+++ b/packages/modules/data-widgets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "data-widgets",
   "moduleName": "Data Widgets",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "repository": {

--- a/packages/modules/data-widgets/src/themesource/datawidgets/web/datagrid.scss
+++ b/packages/modules/data-widgets/src/themesource/datawidgets/web/datagrid.scss
@@ -76,6 +76,8 @@ $brand-primary: #264ae5 !default;
 
         /* Content of the column header */
         .column-container {
+            display: flex;
+            flex-direction: column;
             flex-grow: 1;
             align-self: stretch;
             min-width: 0;

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed the issue with filtering widgets rendered outside of header cells.
+
 ## [2.4.0] - 2022-6-29
 
 ### Fixed

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datagrid-web",
   "widgetName": "Datagrid",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="2.4.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="2.4.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Datagrid.xml" />
         </widgetFiles>


### PR DESCRIPTION
## Checklist
- Contains unit tests  ❌
- Contains breaking changes  ❌
- Contains Atlas changes ❌
- Compatible with: MX  9️⃣

#### Web specific
- Contains e2e tests ✅ ❌
- Is accessible ✅ 
- Compatible with Studio ✅ 
- Cross-browser compatible ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

Fix filter widgets overflowing header cells.
