### PR TITLE
[WC-1156] fixed issue with slide over content configuration for sidebar

### DIFF
--- a/packages/modules/atlas-core/CHANGELOG.md
+++ b/packages/modules/atlas-core/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed the issue with sidebar "Slide over content" configuration.
+
 ## [3.4.0] Atlas Core - 2022-7-11
 
 ### Fixed

--- a/packages/theming/atlas/src/themesource/atlas_core/web/layouts/_layout-atlas-responsive.scss
+++ b/packages/theming/atlas/src/themesource/atlas_core/web/layouts/_layout-atlas-responsive.scss
@@ -76,7 +76,7 @@
             }
 
             &.mx-scrollcontainer-open > .region-sidebar {
-                width: $navsidebar-width-open !important;
+                width: $navsidebar-width-closed !important;
 
                 & > .mx-scrollcontainer-wrapper {
                     position: relative;
@@ -85,7 +85,7 @@
 
             .region-sidebar > .mx-scrollcontainer-wrapper {
                 z-index: 2;
-                left: 0 !important;
+                left: -$navsidebar-width-closed;
                 background-color: inherit;
             }
         }


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ✅
- Contains Atlas changes ✅
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Compatible with Studio ✅
- Cross-browser compatible ✅

#### Feature specific
- Comply with designs ✅
- Comply with PM's requirements ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
This issue was a request from customer who was saying that "Slide over content" configuration for sidebar works same as "Push content aside". So we had to do a fix on atlas core to make it work as it suppose to work.
## Relevant changes
Brought back idea of slide over content from Atlas 2, instead of changing width of element, now we change it's position from left.
## What should be covered while testing?
Everything related to sidebar position, if it's possible also please test in different test projects. cuz this might be a breaking change if one customer for example already fixed it on their side.