### PR TITLE
[WTF-1194] Update PW tools to generate typings for linked association property

### DIFF
--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+-   We added support for association properties linked to a data source, introduced in Mendix 9.17.
+
 ## [9.13.4] - 2022-08-26
 
 ### Changed

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -91,7 +91,7 @@
     "jest-junit": "^13.0.0",
     "jest-react-hooks-shallow": "^1.4.1",
     "jest-svg-transformer": "^1.0.0",
-    "mendix": "^9.13.43286",
+    "mendix": "^9.16.49269",
     "metro-react-native-babel-preset": "~0.63.0",
     "node-fetch": "^2.6.1",
     "postcss": "^8.3.11",

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -91,7 +91,7 @@
     "jest-junit": "^13.0.0",
     "jest-react-hooks-shallow": "^1.4.1",
     "jest-svg-transformer": "^1.0.0",
-    "mendix": "^9.16.49269",
+    "mendix": "^9.17.51380",
     "metro-react-native-babel-preset": "~0.63.0",
     "node-fetch": "^2.6.1",
     "postcss": "^8.3.11",

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
@@ -1,6 +1,8 @@
 import { parseString } from "xml2js";
 import { listActionInput, listActionInputNative } from "./inputs/list-action";
 import { listActionNativeOutput, listActionWebOutput } from "./outputs/list-action";
+import { listAssociationWebInput, listAssociationNativeInput } from "./inputs/list-association";
+import { listAssociationNativeOutput, listAssociationWebOutput } from "./outputs/list-association";
 import { listImageInput, listImageInputNative } from "./inputs/list-image";
 import { listImageNativeOutput, listImageWebOutput } from "./outputs/list-image";
 import { iconInput, iconInputNative } from "./inputs/icon";
@@ -133,6 +135,16 @@ describe("Generating tests", () => {
     it("Generates a parsed typing from XML for native using association", () => {
         const newContent = generateNativeTypesFor(associationInputNative);
         expect(newContent).toBe(associationNativeOutput);
+    });
+
+    it("Generates a parsed typing from XML for web using linked association", () => {
+        const newContent = generateFullTypesFor(listAssociationWebInput);
+        expect(newContent).toBe(listAssociationWebOutput);
+    });
+
+    it("Generates a parsed typing from XML for native using linked association", () => {
+        const newContent = generateNativeTypesFor(listAssociationNativeInput);
+        expect(newContent).toBe(listAssociationNativeOutput);
     });
 });
 

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/list-association.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/list-association.ts
@@ -1,0 +1,93 @@
+export const listAssociationWebInput = `<?xml version="1.0" encoding="utf-8"?>
+<widget id="mendix.mywidget.MyWidget" needsEntityContext="true" offlineCapable="true" pluginWidget="true"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../xsd/widget.xsd">
+    <properties>
+        <propertyGroup caption="General">
+             <property key="dataSource" type="datasource" isList="true" required="false">
+                <caption>Data source</caption>
+                <description />
+            </property>
+            <property key="reference" type="association" dataSource="dataSource" selectableObjects="optionsSource">
+                <caption>Reference</caption>
+                <description/>
+                <associationTypes>
+                    <associationType name="Reference"/>
+                </associationTypes>
+            </property>
+            <property key="referenceSet" type="association" dataSource="dataSource"  selectableObjects="optionsSource">
+                <caption>Reference Set</caption>
+                <description/>
+                <associationTypes>
+                    <associationType name="ReferenceSet"/>
+                </associationTypes>
+            </property>
+            <property key="referenceOrSet" type="association" dataSource="dataSource"  selectableObjects="optionsSource">
+                <caption>Reference or Set</caption>
+                <description/>
+                <associationTypes>
+                    <associationType name="Reference"/>
+                    <associationType name="ReferenceSet"/>
+                </associationTypes>
+            </property>
+             <property key="optionsSource" type="datasource" isList="true" required="false">
+                <caption>Universe Data source</caption>
+                <description />
+            </property>
+            <property key="displayValue" dataSource="optionsSource" type="attribute">
+                <caption>Display value</caption>
+                <description>Display value</description>
+                <attributeTypes>
+                    <attributeType name="String"/>
+                </attributeTypes>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>`;
+
+export const listAssociationNativeInput = `<?xml version="1.0" encoding="utf-8"?>
+<widget id="mendix.mywidget.MyWidget" needsEntityContext="true" offlineCapable="true" pluginWidget="true" supportedPlatform="Native"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../xsd/widget.xsd">
+    <properties>
+        <propertyGroup caption="General">
+             <property key="dataSource" type="datasource" isList="true" required="false">
+                <caption>Data source</caption>
+                <description />
+            </property>
+            <property key="reference" type="association" dataSource="dataSource" selectableObjects="optionsSource">
+                <caption>Reference</caption>
+                <description/>
+                <associationTypes>
+                    <associationType name="Reference"/>
+                </associationTypes>
+            </property>
+            <property key="referenceSet" type="association" dataSource="dataSource" selectableObjects="optionsSource">
+                <caption>Reference Set</caption>
+                <description/>
+                <associationTypes>
+                    <associationType name="ReferenceSet"/>
+                </associationTypes>
+            </property>
+            <property key="referenceOrSet" type="association" dataSource="dataSource" selectableObjects="optionsSource">
+                <caption>Reference or Set</caption>
+                <description/>
+                <associationTypes>
+                    <associationType name="Reference"/>
+                    <associationType name="ReferenceSet"/>
+                </associationTypes>
+            </property>
+             <property key="optionsSource" type="datasource" isList="true" required="false">
+                <caption>Universe Data source</caption>
+                <description />
+            </property>
+            <property key="displayValue" dataSource="optionsSource" type="attribute">
+                <caption>Display value</caption>
+                <description>Display value</description>
+                <attributeTypes>
+                    <attributeType name="String"/>
+                </attributeTypes>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>`;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-association.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-association.ts
@@ -1,0 +1,45 @@
+export const listAssociationWebOutput = `/**
+ * This file was generated from MyWidget.xml
+ * WARNING: All changes made to this file will be overwritten
+ * @author Mendix UI Content Team
+ */
+import { CSSProperties } from "react";
+import { ListValue, ListAttributeValue, ListReferenceValue, ListReferenceSetValue } from "mendix";
+
+export interface MyWidgetContainerProps {
+    name: string;
+    class: string;
+    style?: CSSProperties;
+    tabIndex?: number;
+    dataSource?: ListValue;
+    reference?: ListReferenceValue;
+    referenceSet?: ListReferenceSetValue;
+    referenceOrSet?: ListReferenceValue | ListReferenceSetValue;
+    optionsSource?: ListValue;
+    displayValue?: ListAttributeValue<string>;
+}
+
+export interface MyWidgetPreviewProps {
+    className: string;
+    style: string;
+    styleObject?: CSSProperties;
+    readOnly: boolean;
+    dataSource: {} | { type: string } | null;
+    reference: string;
+    referenceSet: string;
+    referenceOrSet: string;
+    optionsSource: {} | { type: string } | null;
+    displayValue: string;
+}
+`;
+
+export const listAssociationNativeOutput = `export interface MyWidgetProps<Style> {
+    name: string;
+    style: Style[];
+    dataSource?: ListValue;
+    reference?: ListReferenceValue;
+    referenceSet?: ListReferenceSetValue;
+    referenceOrSet?: ListReferenceValue | ListReferenceSetValue;
+    optionsSource?: ListValue;
+    displayValue?: ListAttributeValue<string>;
+}`;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generate.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generate.ts
@@ -14,6 +14,8 @@ const mxExports = [
     "ListActionValue",
     "ListAttributeValue",
     "ListExpressionValue",
+    "ListReferenceValue",
+    "ListReferenceSetValue",
     "ListWidgetValue",
     "ReferenceValue",
     "ReferenceSetValue",

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
@@ -130,7 +130,7 @@ function toClientPropType(
             const types = prop.associationTypes
                 .map(ats => ats.associationType)
                 .reduce((a, i) => a.concat(i), [])
-                .map(at => toAssociationOutputType(at.$.name));
+                .map(at => toAssociationOutputType(at.$.name, !!prop.$.dataSource));
             const uniqueTypes = Array.from(new Set(types));
             return uniqueTypes.join(" | ");
         }
@@ -195,12 +195,12 @@ export function toAttributeClientType(xmlType: string): string {
     }
 }
 
-export function toAssociationOutputType(xmlType: string) {
+export function toAssociationOutputType(xmlType: string, linkedToDataSource: boolean) {
     switch (xmlType) {
         case "Reference":
-            return "ReferenceValue";
+            return linkedToDataSource ? "ListReferenceValue" : "ReferenceValue";
         case "ReferenceSet":
-            return "ReferenceSetValue";
+            return linkedToDataSource ? "ListReferenceSetValue" : "ReferenceSetValue";
         default:
             return "any";
     }


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: MX 9️⃣

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
Add support for association properties linked to a data source, introduced in Mendix 9.17.

## Relevant changes
When an association property is linked to a data source (using the `dataSource` attribute, not the `selectableObjects` attribute), the typings generator will now output `ListReferenceValue`, `ListReferenceSetValue` or `ListReferenceValue | ListReferenceSetValue`, depending on the configured association type(s). This requires the `mendix` typings to be bumped to the already released 9.16 version (even though the feature is officially available in 9.17+ only).

## What should be covered while testing?
Full unit test coverage, no manual testing required.