### PR TITLE
[WC-1113] chore: move props utils to pwt

### DIFF
--- a/packages/pluggableWidgets/accessibility-helper-web/src/AccessibilityHelper.editorConfig.ts
+++ b/packages/pluggableWidgets/accessibility-helper-web/src/AccessibilityHelper.editorConfig.ts
@@ -1,12 +1,5 @@
-import {
-    hidePropertyIn,
-    Properties,
-    Problem,
-    StructurePreviewProps,
-    DropZoneProps,
-    RowLayoutProps,
-    TextProps
-} from "@mendix/piw-utils-internal";
+import { StructurePreviewProps, DropZoneProps, RowLayoutProps, TextProps } from "@mendix/piw-utils-internal";
+import { hidePropertyIn, Properties, Problem } from "@mendix/pluggable-widgets-tools";
 import { AttributesListPreviewType, AccessibilityHelperPreviewProps } from "../typings/AccessibilityHelperProps";
 
 const PROHIBITED_ATTRIBUTES = ["class", "style", "widgetid", "data-mendix-id"];

--- a/packages/pluggableWidgets/accordion-native/src/Accordion.editorConfig.ts
+++ b/packages/pluggableWidgets/accordion-native/src/Accordion.editorConfig.ts
@@ -1,11 +1,5 @@
-import {
-    StructurePreviewProps,
-    changePropertyIn,
-    hidePropertyIn,
-    Properties,
-    Problem,
-    ContainerProps
-} from "@mendix/piw-utils-internal";
+import { StructurePreviewProps, ContainerProps } from "@mendix/piw-utils-internal";
+import { changePropertyIn, hidePropertyIn, Properties, Problem } from "@mendix/pluggable-widgets-tools";
 
 import { AccordionPreviewProps, GroupsPreviewType } from "../typings/AccordionProps";
 

--- a/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
+++ b/packages/pluggableWidgets/accordion-web/src/Accordion.editorConfig.ts
@@ -1,14 +1,12 @@
+import { ContainerProps, RowLayoutProps, StructurePreviewProps } from "@mendix/piw-utils-internal";
 import {
-    ContainerProps,
     hideNestedPropertiesIn,
     hidePropertiesIn,
     hidePropertyIn,
     Problem,
     Properties,
-    RowLayoutProps,
-    StructurePreviewProps,
     transformGroupsIntoTabs
-} from "@mendix/piw-utils-internal";
+} from "@mendix/pluggable-widgets-tools";
 
 import { AccordionPreviewProps, GroupsPreviewType } from "../typings/AccordionProps";
 

--- a/packages/pluggableWidgets/area-chart-web/src/AreaChart.editorConfig.ts
+++ b/packages/pluggableWidgets/area-chart-web/src/AreaChart.editorConfig.ts
@@ -1,14 +1,13 @@
+import { ContainerProps, ImageProps, StructurePreviewProps } from "@mendix/piw-utils-internal";
 import {
-    ContainerProps,
     hideNestedPropertiesIn,
     hidePropertiesIn,
     hidePropertyIn,
-    ImageProps,
     Problem,
     Properties,
-    StructurePreviewProps,
     transformGroupsIntoTabs
-} from "@mendix/piw-utils-internal";
+} from "@mendix/pluggable-widgets-tools";
+
 import { AreaChartPreviewProps } from "../typings/AreaChartProps";
 
 import AreaChartLightSvg from "./assets/AreaChart.light.svg";

--- a/packages/pluggableWidgets/background-gradient-native/src/BackgroundGradient.editorConfig.ts
+++ b/packages/pluggableWidgets/background-gradient-native/src/BackgroundGradient.editorConfig.ts
@@ -1,5 +1,6 @@
-import { StructurePreviewProps, Problem } from "@mendix/piw-utils-internal";
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
 import { BackgroundGradientPreviewProps } from "../typings/BackgroundGradientProps";
+import { Problem } from "@mendix/pluggable-widgets-tools";
 
 export const getPreview = (values: BackgroundGradientPreviewProps, isDarkMode: boolean): StructurePreviewProps => ({
     type: "Container",

--- a/packages/pluggableWidgets/bar-chart-native/src/BarChart.editorConfig.ts
+++ b/packages/pluggableWidgets/bar-chart-native/src/BarChart.editorConfig.ts
@@ -1,4 +1,5 @@
-import { StructurePreviewProps, hideNestedPropertiesIn, Problem, Properties } from "@mendix/piw-utils-internal";
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { hideNestedPropertiesIn, Problem, Properties } from "@mendix/pluggable-widgets-tools";
 
 import barChartGroupedSvgDark from "./assets/BarChart.Grouped.dark.svg";
 import barChartGroupedSvgLight from "./assets/BarChart.Grouped.light.svg";

--- a/packages/pluggableWidgets/bar-chart-web/src/BarChart.editorConfig.ts
+++ b/packages/pluggableWidgets/bar-chart-web/src/BarChart.editorConfig.ts
@@ -1,15 +1,13 @@
 import { BarChartPreviewProps, BarmodeEnum } from "../typings/BarChartProps";
+import { StructurePreviewProps, ContainerProps, ImageProps } from "@mendix/piw-utils-internal";
 import {
     hideNestedPropertiesIn,
     hidePropertiesIn,
     hidePropertyIn,
     Problem,
     Properties,
-    StructurePreviewProps,
-    transformGroupsIntoTabs,
-    ContainerProps,
-    ImageProps
-} from "@mendix/piw-utils-internal";
+    transformGroupsIntoTabs
+} from "@mendix/pluggable-widgets-tools";
 
 import BarChartGroupedDark from "./assets/BarChart-grouped.dark.svg";
 import BarChartGroupedLight from "./assets/BarChart-grouped.light.svg";

--- a/packages/pluggableWidgets/barcode-scanner-web/src/BarcodeScanner.editorConfig.ts
+++ b/packages/pluggableWidgets/barcode-scanner-web/src/BarcodeScanner.editorConfig.ts
@@ -1,4 +1,6 @@
-import { Properties, StructurePreviewProps, transformGroupsIntoTabs } from "@mendix/piw-utils-internal";
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { Properties, transformGroupsIntoTabs } from "@mendix/pluggable-widgets-tools";
+
 import { BarcodeScannerContainerProps } from "../typings/BarcodeScannerProps";
 import BarcodeScannerSvg from "./assets/barcodescanner.svg";
 import BarcodeScannerSvgDark from "./assets/barcodescanner-dark.svg";

--- a/packages/pluggableWidgets/bottom-sheet-native/src/BottomSheet.editorConfig.ts
+++ b/packages/pluggableWidgets/bottom-sheet-native/src/BottomSheet.editorConfig.ts
@@ -1,11 +1,11 @@
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
 import {
-    StructurePreviewProps,
     changePropertyIn,
     hidePropertiesIn,
     hidePropertyIn,
     Problem,
     Properties
-} from "@mendix/piw-utils-internal";
+} from "@mendix/pluggable-widgets-tools";
 
 import { BottomSheetPreviewProps } from "../typings/BottomSheetProps";
 

--- a/packages/pluggableWidgets/bubble-chart-web/src/BubbleChart.editorConfig.ts
+++ b/packages/pluggableWidgets/bubble-chart-web/src/BubbleChart.editorConfig.ts
@@ -1,14 +1,13 @@
+import { ContainerProps, ImageProps, StructurePreviewProps } from "@mendix/piw-utils-internal";
 import {
-    ContainerProps,
     hideNestedPropertiesIn,
     hidePropertiesIn,
     hidePropertyIn,
-    ImageProps,
     Problem,
     Properties,
-    StructurePreviewProps,
     transformGroupsIntoTabs
-} from "@mendix/piw-utils-internal";
+} from "@mendix/pluggable-widgets-tools";
+
 import { BubbleChartPreviewProps } from "../typings/BubbleChartProps";
 
 import BubbleChartLightSvg from "./assets/BubbleChart.light.svg";

--- a/packages/pluggableWidgets/carousel-web/src/Carousel.editorConfig.ts
+++ b/packages/pluggableWidgets/carousel-web/src/Carousel.editorConfig.ts
@@ -1,7 +1,4 @@
 import {
-    Properties,
-    transformGroupsIntoTabs,
-    hidePropertiesIn,
     StructurePreviewProps,
     TextProps,
     DropZoneProps,
@@ -9,6 +6,8 @@ import {
     RowLayoutProps,
     ImageProps
 } from "@mendix/piw-utils-internal";
+import { Properties, transformGroupsIntoTabs, hidePropertiesIn } from "@mendix/pluggable-widgets-tools";
+
 import { CarouselPreviewProps } from "../typings/CarouselProps";
 import DotBlue from "./ui/dot_blue.svg";
 import DotGrey from "./ui/dot_grey.svg";

--- a/packages/pluggableWidgets/color-picker-web/src/ColorPicker.editorConfig.ts
+++ b/packages/pluggableWidgets/color-picker-web/src/ColorPicker.editorConfig.ts
@@ -1,14 +1,12 @@
 import {
     ContainerProps,
     ImageProps,
-    Properties,
     RowLayoutProps,
     StructurePreviewProps,
-    TextProps,
-    transformGroupsIntoTabs,
-    hidePropertiesIn,
-    hidePropertyIn
+    TextProps
 } from "@mendix/piw-utils-internal";
+import { Properties, transformGroupsIntoTabs, hidePropertiesIn, hidePropertyIn } from "@mendix/pluggable-widgets-tools";
+
 import { ColorPickerPreviewProps } from "../typings/ColorPickerProps";
 import StructurePreviewSvg from "./assets/structure-preview.svg";
 import StructurePreviewSvgDark from "./assets/structure-preview-dark.svg";

--- a/packages/pluggableWidgets/column-chart-native/src/ColumnChart.editorConfig.ts
+++ b/packages/pluggableWidgets/column-chart-native/src/ColumnChart.editorConfig.ts
@@ -1,4 +1,5 @@
-import { hideNestedPropertiesIn, Problem, Properties, StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { hideNestedPropertiesIn, Problem, Properties } from "@mendix/pluggable-widgets-tools";
 
 import { ColumnChartPreviewProps } from "../typings/ColumnChartProps";
 import columnChartGroupedSvgDark from "./assets/ColumnChart.Grouped.dark.svg";

--- a/packages/pluggableWidgets/column-chart-web/src/ColumnChart.editorConfig.ts
+++ b/packages/pluggableWidgets/column-chart-web/src/ColumnChart.editorConfig.ts
@@ -1,15 +1,13 @@
 import { ColumnChartPreviewProps, BarmodeEnum } from "../typings/ColumnChartProps";
+import { StructurePreviewProps, ImageProps, ContainerProps } from "@mendix/piw-utils-internal";
 import {
     hideNestedPropertiesIn,
     hidePropertiesIn,
     hidePropertyIn,
     Problem,
     Properties,
-    StructurePreviewProps,
-    transformGroupsIntoTabs,
-    ImageProps,
-    ContainerProps
-} from "@mendix/piw-utils-internal";
+    transformGroupsIntoTabs
+} from "@mendix/pluggable-widgets-tools";
 
 import ColumnChartGroupedDark from "./assets/ColumnChart-grouped.dark.svg";
 import ColumnChartGroupedLight from "./assets/ColumnChart-grouped.light.svg";

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/DatagridDateFilter.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/DatagridDateFilter.editorConfig.ts
@@ -12,14 +12,11 @@ import {
     greaterThanEqualIconDark,
     greaterThanIcon,
     greaterThanIconDark,
-    hidePropertiesIn,
-    hidePropertyIn,
     ImageProps,
     notEmptyIcon,
     notEmptyIconDark,
     notEqualIcon,
     notEqualIconDark,
-    Properties,
     smallerThanEqualIcon,
     smallerThanEqualIconDark,
     smallerThanIcon,
@@ -27,6 +24,8 @@ import {
     StructurePreviewProps,
     TextProps
 } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, hidePropertyIn, Properties } from "@mendix/pluggable-widgets-tools";
+
 import { DatagridDateFilterPreviewProps, DefaultFilterEnum } from "../typings/DatagridDateFilterProps";
 
 export function getProperties(

--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/DatagridDropdownFilter.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/DatagridDropdownFilter.editorConfig.ts
@@ -3,13 +3,11 @@ import {
     chevronDownIcon,
     chevronDownIconDark,
     ContainerProps,
-    hidePropertiesIn,
-    hidePropertyIn,
     ImageProps,
-    Properties,
     StructurePreviewProps,
     TextProps
 } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, hidePropertyIn, Properties } from "@mendix/pluggable-widgets-tools";
 
 export function getProperties(
     values: DatagridDropdownFilterPreviewProps,

--- a/packages/pluggableWidgets/datagrid-number-filter-web/src/DatagridNumberFilter.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/src/DatagridNumberFilter.editorConfig.ts
@@ -8,14 +8,11 @@ import {
     greaterThanEqualIconDark,
     greaterThanIcon,
     greaterThanIconDark,
-    hidePropertiesIn,
-    hidePropertyIn,
     ImageProps,
     notEmptyIcon,
     notEmptyIconDark,
     notEqualIcon,
     notEqualIconDark,
-    Properties,
     smallerThanEqualIcon,
     smallerThanEqualIconDark,
     smallerThanIcon,
@@ -23,6 +20,8 @@ import {
     StructurePreviewProps,
     TextProps
 } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, hidePropertyIn, Properties } from "@mendix/pluggable-widgets-tools";
+
 import { DatagridNumberFilterPreviewProps, DefaultFilterEnum } from "../typings/DatagridNumberFilterProps";
 
 export function getProperties(

--- a/packages/pluggableWidgets/datagrid-text-filter-web/src/DatagridTextFilter.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/src/DatagridTextFilter.editorConfig.ts
@@ -12,14 +12,11 @@ import {
     greaterThanEqualIconDark,
     greaterThanIcon,
     greaterThanIconDark,
-    hidePropertiesIn,
-    hidePropertyIn,
     ImageProps,
     notEmptyIcon,
     notEmptyIconDark,
     notEqualIcon,
     notEqualIconDark,
-    Properties,
     smallerThanEqualIcon,
     smallerThanEqualIconDark,
     smallerThanIcon,
@@ -29,6 +26,8 @@ import {
     StructurePreviewProps,
     TextProps
 } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, hidePropertyIn, Properties } from "@mendix/pluggable-widgets-tools";
+
 import { DatagridTextFilterPreviewProps, DefaultFilterEnum } from "../typings/DatagridTextFilterProps";
 
 export function getProperties(

--- a/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/Datagrid.editorConfig.ts
@@ -1,16 +1,14 @@
+import { ContainerProps, DropZoneProps, RowLayoutProps, StructurePreviewProps } from "@mendix/piw-utils-internal";
 import {
     changePropertyIn,
-    ContainerProps,
-    DropZoneProps,
     hideNestedPropertiesIn,
     hidePropertiesIn,
     hidePropertyIn,
     Problem,
     Properties,
-    RowLayoutProps,
-    StructurePreviewProps,
     transformGroupsIntoTabs
-} from "@mendix/piw-utils-internal";
+} from "@mendix/pluggable-widgets-tools";
+
 import { ColumnsPreviewType, DatagridPreviewProps } from "../typings/DatagridProps";
 
 export function getProperties(

--- a/packages/pluggableWidgets/document-viewer-web/src/DocumentViewer.editorConfig.ts
+++ b/packages/pluggableWidgets/document-viewer-web/src/DocumentViewer.editorConfig.ts
@@ -1,5 +1,6 @@
 import { DocumentViewerPreviewProps } from "../typings/DocumentViewerProps";
-import { hidePropertyIn, Problem, Properties, StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { hidePropertyIn, Problem, Properties } from "@mendix/pluggable-widgets-tools";
 
 import DocumentViewerURLPreviewSVGDark from "./assets/document-viewer-url-preview.dark.svg";
 import DocumentViewerURLPreviewSVGLight from "./assets/document-viewer-url-preview.light.svg";

--- a/packages/pluggableWidgets/gallery-web/src/Gallery.editorConfig.ts
+++ b/packages/pluggableWidgets/gallery-web/src/Gallery.editorConfig.ts
@@ -1,14 +1,11 @@
+import { ContainerProps, DropZoneProps, RowLayoutProps, StructurePreviewProps } from "@mendix/piw-utils-internal";
 import {
-    ContainerProps,
-    DropZoneProps,
     hidePropertiesIn,
     hidePropertyIn,
     Problem,
     Properties,
-    RowLayoutProps,
-    StructurePreviewProps,
     transformGroupsIntoTabs
-} from "@mendix/piw-utils-internal";
+} from "@mendix/pluggable-widgets-tools";
 import { GalleryPreviewProps } from "../typings/GalleryProps";
 
 export function getProperties(

--- a/packages/pluggableWidgets/heatmap-chart-web/src/HeatMap.editorConfig.ts
+++ b/packages/pluggableWidgets/heatmap-chart-web/src/HeatMap.editorConfig.ts
@@ -1,12 +1,6 @@
-import {
-    hidePropertiesIn,
-    Properties,
-    StructurePreviewProps,
-    transformGroupsIntoTabs,
-    ImageProps,
-    ContainerProps,
-    moveProperty
-} from "@mendix/piw-utils-internal";
+import { StructurePreviewProps, ImageProps, ContainerProps } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, moveProperty, Properties, transformGroupsIntoTabs } from "@mendix/pluggable-widgets-tools";
+
 import { HeatMapPreviewProps } from "../typings/HeatMapProps";
 
 import HeatMapDark from "./assets/HeatMap.dark.svg";

--- a/packages/pluggableWidgets/image-native/src/Image.editorConfig.ts
+++ b/packages/pluggableWidgets/image-native/src/Image.editorConfig.ts
@@ -1,12 +1,6 @@
-import {
-    DropZoneProps,
-    hidePropertiesIn,
-    hidePropertyIn,
-    Problem,
-    Properties,
-    RowLayoutProps,
-    StructurePreviewProps
-} from "@mendix/piw-utils-internal";
+import { DropZoneProps, RowLayoutProps, StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, hidePropertyIn, Problem, Properties } from "@mendix/pluggable-widgets-tools";
+
 import { DatasourceEnum, ImagePreviewProps } from "../typings/ImageProps";
 import StructurePreviewImageSvg from "./assets/placeholder.svg";
 import StructurePreviewImageDarkSvg from "./assets/placeholderDark.svg";

--- a/packages/pluggableWidgets/image-web/src/Image.editorConfig.ts
+++ b/packages/pluggableWidgets/image-web/src/Image.editorConfig.ts
@@ -1,14 +1,13 @@
+import { DropZoneProps, RowLayoutProps, StructurePreviewProps } from "@mendix/piw-utils-internal";
 import {
-    DropZoneProps,
     hidePropertiesIn,
     hidePropertyIn,
     moveProperty,
     Problem,
     Properties,
-    RowLayoutProps,
-    StructurePreviewProps,
     transformGroupsIntoTabs
-} from "@mendix/piw-utils-internal";
+} from "@mendix/pluggable-widgets-tools";
+
 import { DatasourceEnum, ImagePreviewProps } from "../typings/ImageProps";
 import StructurePreviewImageSvg from "./assets/placeholder.svg";
 import StructurePreviewImageSvgDark from "./assets/placeholder-dark.svg";

--- a/packages/pluggableWidgets/line-chart-native/src/LineChart.editorConfig.ts
+++ b/packages/pluggableWidgets/line-chart-native/src/LineChart.editorConfig.ts
@@ -1,4 +1,5 @@
-import { StructurePreviewProps, hideNestedPropertiesIn, Problem, Properties } from "@mendix/piw-utils-internal";
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { hideNestedPropertiesIn, Problem, Properties } from "@mendix/pluggable-widgets-tools";
 
 import lineChartSvgDark from "./assets/LineChart.dark.svg";
 import lineChartSvgLight from "./assets/LineChart.light.svg";

--- a/packages/pluggableWidgets/line-chart-web/src/LineChart.editorConfig.ts
+++ b/packages/pluggableWidgets/line-chart-web/src/LineChart.editorConfig.ts
@@ -1,14 +1,13 @@
+import { StructurePreviewProps, ImageProps, ContainerProps } from "@mendix/piw-utils-internal";
 import {
     hideNestedPropertiesIn,
     hidePropertiesIn,
     hidePropertyIn,
     Problem,
     Properties,
-    StructurePreviewProps,
-    transformGroupsIntoTabs,
-    ImageProps,
-    ContainerProps
-} from "@mendix/piw-utils-internal";
+    transformGroupsIntoTabs
+} from "@mendix/pluggable-widgets-tools";
+
 import { LineChartPreviewProps } from "../typings/LineChartProps";
 
 import LineChartDark from "./assets/LineChart.dark.svg";

--- a/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
+++ b/packages/pluggableWidgets/maps-native/src/Maps.editorConfig.ts
@@ -1,11 +1,12 @@
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
 import {
     changePropertyIn,
     hidePropertiesIn,
     hidePropertyIn,
     Problem,
-    Properties,
-    StructurePreviewProps
-} from "@mendix/piw-utils-internal";
+    Properties
+} from "@mendix/pluggable-widgets-tools";
+
 import { MapsPreviewProps } from "../typings/MapsProps";
 import StructurePreviewMapsSVG from "./assets/StructurePreviewMaps.svg";
 

--- a/packages/pluggableWidgets/maps-web/src/Maps.editorConfig.ts
+++ b/packages/pluggableWidgets/maps-web/src/Maps.editorConfig.ts
@@ -1,10 +1,6 @@
-import {
-    hidePropertiesIn,
-    hidePropertyIn,
-    Problem,
-    Properties,
-    StructurePreviewProps
-} from "@mendix/piw-utils-internal";
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, hidePropertyIn, Problem, Properties } from "@mendix/pluggable-widgets-tools";
+
 import { MapsPreviewProps } from "../typings/MapsProps";
 
 import GoogleMapsSVG from "./assets/GoogleMaps.svg";

--- a/packages/pluggableWidgets/pie-doughnut-chart-web/src/PieChart.editorConfig.ts
+++ b/packages/pluggableWidgets/pie-doughnut-chart-web/src/PieChart.editorConfig.ts
@@ -1,13 +1,12 @@
+import { StructurePreviewProps, ImageProps, ContainerProps } from "@mendix/piw-utils-internal";
 import {
     hidePropertiesIn,
     hidePropertyIn,
     Problem,
     Properties,
-    StructurePreviewProps,
-    transformGroupsIntoTabs,
-    ImageProps,
-    ContainerProps
-} from "@mendix/piw-utils-internal";
+    transformGroupsIntoTabs
+} from "@mendix/pluggable-widgets-tools";
+
 import { PieChartPreviewProps } from "../typings/PieChartProps";
 
 import PieChartDark from "./assets/PieChart.dark.svg";

--- a/packages/pluggableWidgets/popup-menu-native/src/PopupMenu.editorConfig.ts
+++ b/packages/pluggableWidgets/popup-menu-native/src/PopupMenu.editorConfig.ts
@@ -1,11 +1,6 @@
-import {
-    StructurePreviewProps,
-    hidePropertyIn,
-    Properties,
-    DropZoneProps,
-    ContainerProps,
-    RowLayoutProps
-} from "@mendix/piw-utils-internal";
+import { StructurePreviewProps, DropZoneProps, ContainerProps, RowLayoutProps } from "@mendix/piw-utils-internal";
+import { hidePropertyIn, Properties } from "@mendix/pluggable-widgets-tools";
+
 import { BasicItemsPreviewType, PopupMenuPreviewProps } from "../typings/PopupMenuProps";
 
 export function getPreview(values: PopupMenuPreviewProps, isDarkMode: boolean): StructurePreviewProps {

--- a/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.editorConfig.ts
+++ b/packages/pluggableWidgets/popup-menu-web/src/PopupMenu.editorConfig.ts
@@ -1,16 +1,19 @@
 import {
-    changePropertyIn,
     ContainerProps,
     DropZoneProps,
-    hidePropertyIn,
-    Problem,
-    Properties,
     RowLayoutProps,
     SelectableProps,
     StructurePreviewProps,
-    TextProps,
-    transformGroupsIntoTabs
+    TextProps
 } from "@mendix/piw-utils-internal";
+import {
+    changePropertyIn,
+    hidePropertyIn,
+    Problem,
+    Properties,
+    transformGroupsIntoTabs
+} from "@mendix/pluggable-widgets-tools";
+
 import { BasicItemsPreviewType, PopupMenuPreviewProps } from "../typings/PopupMenuProps";
 
 export function getProperties(

--- a/packages/pluggableWidgets/progress-bar-web/src/ProgressBar.editorConfig.ts
+++ b/packages/pluggableWidgets/progress-bar-web/src/ProgressBar.editorConfig.ts
@@ -1,10 +1,6 @@
-import {
-    hidePropertiesIn,
-    hidePropertyIn,
-    Problem,
-    Properties,
-    StructurePreviewProps
-} from "@mendix/piw-utils-internal";
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, hidePropertyIn, Problem, Properties } from "@mendix/pluggable-widgets-tools";
+
 import { ProgressBarPreviewProps, TypeEnum } from "../typings/ProgressBarProps";
 import StructurePreviewSvg from "./assets/structure-preview.svg";
 import StructurePreviewSvgDark from "./assets/structure-preview-dark.svg";

--- a/packages/pluggableWidgets/progress-circle-web/src/ProgressCircle.editorConfig.ts
+++ b/packages/pluggableWidgets/progress-circle-web/src/ProgressCircle.editorConfig.ts
@@ -1,10 +1,6 @@
-import {
-    hidePropertiesIn,
-    hidePropertyIn,
-    Problem,
-    Properties,
-    StructurePreviewProps
-} from "@mendix/piw-utils-internal";
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, hidePropertyIn, Problem, Properties } from "@mendix/pluggable-widgets-tools";
+
 import { ProgressCirclePreviewProps, TypeEnum } from "../typings/ProgressCircleProps";
 import StructurePreviewSvg from "./assets/structure-preview.svg";
 import StructurePreviewSvgDark from "./assets/structure-preview-dark.svg";

--- a/packages/pluggableWidgets/radio-buttons-native/src/RadioButtons.editorConfig.ts
+++ b/packages/pluggableWidgets/radio-buttons-native/src/RadioButtons.editorConfig.ts
@@ -1,4 +1,6 @@
-import { StructurePreviewProps, Properties, hidePropertiesIn } from "@mendix/piw-utils-internal";
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { Properties, hidePropertiesIn } from "@mendix/pluggable-widgets-tools";
+
 import { RadioButtonsPreviewProps } from "../typings/RadioButtonsProps";
 import darkRadioIcon from "./assets/radioButton_dark.svg";
 import lightRadioIcon from "./assets/radioButton_light.svg";

--- a/packages/pluggableWidgets/range-slider-web/src/RangeSlider.editorConfig.ts
+++ b/packages/pluggableWidgets/range-slider-web/src/RangeSlider.editorConfig.ts
@@ -1,10 +1,6 @@
-import {
-    hidePropertiesIn,
-    hidePropertyIn,
-    Properties,
-    StructurePreviewProps,
-    transformGroupsIntoTabs
-} from "@mendix/piw-utils-internal";
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, hidePropertyIn, Properties, transformGroupsIntoTabs } from "@mendix/pluggable-widgets-tools";
+
 import {
     MaxValueTypeEnum,
     MinValueTypeEnum,

--- a/packages/pluggableWidgets/rating-web/src/StarRating.editorConfig.ts
+++ b/packages/pluggableWidgets/rating-web/src/StarRating.editorConfig.ts
@@ -1,4 +1,6 @@
-import { ImageProps, Problem, RowLayoutProps } from "@mendix/piw-utils-internal";
+import { ImageProps, RowLayoutProps } from "@mendix/piw-utils-internal";
+import { Problem } from "@mendix/pluggable-widgets-tools";
+
 import StructurePreviewRatingFilledSVG from "./assets/StructurePreviewRatingFilled.svg";
 import StructurePreviewRatingFilledSVGDark from "./assets/StructurePreviewRatingFilled-dark.svg";
 import StructurePreviewRatingEmptySVG from "./assets/StructurePreviewRatingEmpty.svg";

--- a/packages/pluggableWidgets/rich-text-web/src/RichText.editorConfig.ts
+++ b/packages/pluggableWidgets/rich-text-web/src/RichText.editorConfig.ts
@@ -1,10 +1,6 @@
-import {
-    Properties,
-    hidePropertiesIn,
-    transformGroupsIntoTabs,
-    hidePropertyIn,
-    StructurePreviewProps
-} from "@mendix/piw-utils-internal";
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { Properties, hidePropertiesIn, transformGroupsIntoTabs, hidePropertyIn } from "@mendix/pluggable-widgets-tools";
+
 import { RichTextPreviewProps } from "../typings/RichTextProps";
 import RichTextPreviewSVGDark from "./assets/rich-text-preview-dark.svg";
 import RichTextPreviewSVGLight from "./assets/rich-text-preview-light.svg";

--- a/packages/pluggableWidgets/scroll-container-web/src/ScrollContainer.editorConfig.ts
+++ b/packages/pluggableWidgets/scroll-container-web/src/ScrollContainer.editorConfig.ts
@@ -1,4 +1,4 @@
-import { hidePropertiesIn, Properties, transformGroupsIntoTabs } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, Properties, transformGroupsIntoTabs } from "@mendix/pluggable-widgets-tools";
 import { ScrollContainerContainerProps } from "../typings/ScrollContainerProps";
 
 export function getProperties(

--- a/packages/pluggableWidgets/sidebar-toggle-web/src/SidebarToggle.editorConfig.ts
+++ b/packages/pluggableWidgets/sidebar-toggle-web/src/SidebarToggle.editorConfig.ts
@@ -1,12 +1,7 @@
 import { SidebarTogglePreviewProps } from "../typings/SidebarToggleProps";
-import {
-    hidePropertyIn,
-    ImageProps,
-    Properties,
-    StructurePreviewProps,
-    TextProps,
-    transformGroupsIntoTabs
-} from "@mendix/piw-utils-internal";
+import { ImageProps, StructurePreviewProps, TextProps } from "@mendix/piw-utils-internal";
+import { hidePropertyIn, Properties, transformGroupsIntoTabs } from "@mendix/pluggable-widgets-tools";
+
 import HamburgerIcon from "./assets/hamburger.svg";
 
 export function getProperties(

--- a/packages/pluggableWidgets/sidebar-web/src/Sidebar.editorConfig.ts
+++ b/packages/pluggableWidgets/sidebar-web/src/Sidebar.editorConfig.ts
@@ -1,11 +1,5 @@
-import {
-    DropZoneProps,
-    hidePropertiesIn,
-    Properties,
-    RowLayoutProps,
-    StructurePreviewProps,
-    transformGroupsIntoTabs
-} from "@mendix/piw-utils-internal";
+import { DropZoneProps, RowLayoutProps, StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, Properties, transformGroupsIntoTabs } from "@mendix/pluggable-widgets-tools";
 
 import { SidebarPreviewProps } from "../typings/SidebarProps";
 

--- a/packages/pluggableWidgets/slider-web/src/Slider.editorConfig.ts
+++ b/packages/pluggableWidgets/slider-web/src/Slider.editorConfig.ts
@@ -1,11 +1,12 @@
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
 import {
     hidePropertiesIn,
     hidePropertyIn,
     Problem,
     Properties,
-    StructurePreviewProps,
     transformGroupsIntoTabs
-} from "@mendix/piw-utils-internal";
+} from "@mendix/pluggable-widgets-tools";
+
 import { MaxValueTypeEnum, MinValueTypeEnum, SliderPreviewProps, StepSizeTypeEnum } from "../typings/SliderProps";
 import StructurePreviewSvg from "./assets/structure-preview.svg";
 import StructurePreviewSvgDark from "./assets/structure-preview-dark.svg";

--- a/packages/pluggableWidgets/switch-native/src/Switch.editorConfig.ts
+++ b/packages/pluggableWidgets/switch-native/src/Switch.editorConfig.ts
@@ -1,4 +1,6 @@
-import { hidePropertiesIn, Properties, StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, Properties } from "@mendix/pluggable-widgets-tools";
+
 import { SwitchPreviewProps } from "../typings/SwitchProps";
 import StructurePreviewSwitchSVG from "./assets/checked.svg";
 import StructurePreviewSwitchDarkSVG from "./assets/checked-dark.svg";

--- a/packages/pluggableWidgets/time-series-chart-web/src/TimeSeries.editorConfig.ts
+++ b/packages/pluggableWidgets/time-series-chart-web/src/TimeSeries.editorConfig.ts
@@ -1,14 +1,13 @@
+import { StructurePreviewProps, ImageProps, ContainerProps } from "@mendix/piw-utils-internal";
 import {
     hideNestedPropertiesIn,
     hidePropertiesIn,
     hidePropertyIn,
     Problem,
     Properties,
-    transformGroupsIntoTabs,
-    StructurePreviewProps,
-    ImageProps,
-    ContainerProps
-} from "@mendix/piw-utils-internal";
+    transformGroupsIntoTabs
+} from "@mendix/pluggable-widgets-tools";
+
 import { TimeSeriesPreviewProps } from "../typings/TimeSeriesProps";
 
 import TimeSeriesDark from "./assets/TimeSeries.dark.svg";

--- a/packages/pluggableWidgets/time-series-chart-web/typings/TimeSeriesProps.d.ts
+++ b/packages/pluggableWidgets/time-series-chart-web/typings/TimeSeriesProps.d.ts
@@ -87,10 +87,10 @@ export interface TimeSeriesContainerProps {
     style?: CSSProperties;
     tabIndex?: number;
     lines: LinesType[];
-    xAxisLabel?: DynamicValue<string>;
-    yAxisLabel?: DynamicValue<string>;
     enableAdvancedOptions: boolean;
     enableDeveloperMode: boolean;
+    xAxisLabel?: DynamicValue<string>;
+    yAxisLabel?: DynamicValue<string>;
     showLegend: boolean;
     showRangeSlider: boolean;
     gridLines: GridLinesEnum;
@@ -110,10 +110,10 @@ export interface TimeSeriesPreviewProps {
     styleObject?: CSSProperties;
     readOnly: boolean;
     lines: LinesPreviewType[];
-    xAxisLabel: string;
-    yAxisLabel: string;
     enableAdvancedOptions: boolean;
     enableDeveloperMode: boolean;
+    xAxisLabel: string;
+    yAxisLabel: string;
     showLegend: boolean;
     showRangeSlider: boolean;
     gridLines: GridLinesEnum;

--- a/packages/pluggableWidgets/timeline-web/src/Timeline.editorConfig.ts
+++ b/packages/pluggableWidgets/timeline-web/src/Timeline.editorConfig.ts
@@ -1,10 +1,6 @@
-import {
-    hidePropertiesIn,
-    hidePropertyIn,
-    Problem,
-    Properties,
-    StructurePreviewProps
-} from "@mendix/piw-utils-internal";
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, hidePropertyIn, Problem, Properties } from "@mendix/pluggable-widgets-tools";
+
 import { TimelinePreviewProps } from "../typings/TimelineProps";
 import lineAndDotSVG from "./assets/lineAndDot.svg";
 import lineAndDotSVGDark from "./assets/lineAndDot-dark.svg";

--- a/packages/pluggableWidgets/tooltip-web/src/Tooltip.editorConfig.ts
+++ b/packages/pluggableWidgets/tooltip-web/src/Tooltip.editorConfig.ts
@@ -1,14 +1,12 @@
 import { TooltipPreviewProps } from "../typings/TooltipProps";
 import {
-    hidePropertiesIn,
-    Problem,
-    Properties,
     StructurePreviewProps,
     DropZoneProps,
     RowLayoutProps,
     ContainerProps,
     TextProps
 } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, Problem, Properties } from "@mendix/pluggable-widgets-tools";
 
 export function getProperties(values: TooltipPreviewProps, defaultValues: Properties): Properties {
     if (values.renderMethod === "text") {

--- a/packages/pluggableWidgets/tree-node-web/src/TreeNode.editorConfig.ts
+++ b/packages/pluggableWidgets/tree-node-web/src/TreeNode.editorConfig.ts
@@ -1,14 +1,12 @@
 import {
     ContainerProps,
     DropZoneProps,
-    hidePropertiesIn,
-    hidePropertyIn,
-    Properties,
     RowLayoutProps,
     StructurePreviewProps,
-    TextProps,
-    transformGroupsIntoTabs
+    TextProps
 } from "@mendix/piw-utils-internal";
+import { hidePropertiesIn, hidePropertyIn, Properties, transformGroupsIntoTabs } from "@mendix/pluggable-widgets-tools";
+
 import { HeaderTypeEnum, TreeNodePreviewProps } from "../typings/TreeNodeProps";
 
 import ChevronSVG from "./assets/ChevronStructurePreview.svg";

--- a/packages/pluggableWidgets/video-player-web/src/VideoPlayer.editorConfig.ts
+++ b/packages/pluggableWidgets/video-player-web/src/VideoPlayer.editorConfig.ts
@@ -1,11 +1,11 @@
+import { StructurePreviewProps } from "@mendix/piw-utils-internal";
 import {
     hidePropertiesIn,
     hidePropertyIn,
     Problem,
     Properties,
-    StructurePreviewProps,
     transformGroupsIntoTabs
-} from "@mendix/piw-utils-internal";
+} from "@mendix/pluggable-widgets-tools";
 
 import { VideoPlayerContainerProps, VideoPlayerPreviewProps } from "../typings/VideoPlayerProps";
 

--- a/packages/tools/piw-utils-internal/src/typings/PageEditor.ts
+++ b/packages/tools/piw-utils-internal/src/typings/PageEditor.ts
@@ -1,34 +1,3 @@
-export type Properties = PropertyGroup[];
-
-export type PropertyGroup = {
-    caption: string;
-    propertyGroups?: PropertyGroup[];
-    properties?: Property[];
-};
-
-export type Property = {
-    key: string;
-    caption: string;
-    description?: string;
-    objectHeaders?: string[]; // used for customizing object grids
-    objects?: ObjectProperties[];
-    properties?: Properties[]; // Property needs to remain here for compatibility with Studio Pro < 8.12
-};
-
-export type Problem = {
-    property?: string; // key of the property, at which the problem exists
-    severity?: "error" | "warning" | "deprecation"; // default = "error"
-    message: string; // description of the problem
-    studioMessage?: string; // studio-specific message, defaults to message
-    url?: string; // link with more information about the problem
-    studioUrl?: string; // studio-specific link
-};
-
-export type ObjectProperties = {
-    properties: PropertyGroup[];
-    captions?: string[]; // used for customizing object grids
-};
-
 /**
  * Structure preview typings
  */

--- a/packages/tools/piw-utils-internal/src/utils/index.ts
+++ b/packages/tools/piw-utils-internal/src/utils/index.ts
@@ -1,4 +1,3 @@
-export * from "./PageEditorUtils";
 export * from "./StylingPropertyUtils";
 export { useScheduleUpdateOnce } from "./ReactLifecycleUtils";
 export * from "./AttributeValueUtils";

--- a/packages/tools/pluggable-widgets-tools/jest.config.js
+++ b/packages/tools/pluggable-widgets-tools/jest.config.js
@@ -4,7 +4,11 @@ const nativeBaseConfig = require("./test-config/jest.native.config.js");
 const webConfig = {
     ...webBaseConfig,
     rootDir: ".",
-    testMatch: ["<rootDir>/src/@(web|typings-generator)/**/*.spec.{ts,tsx}"]
+    testMatch: [
+        "<rootDir>/src/web/**/*.spec.{ts,tsx}",
+        "<rootDir>/src/typings-generator/**/*.spec.{ts,tsx}",
+        "<rootDir>/src/utils/**/*.spec.{ts,tsx}"
+    ]
 };
 
 const nativeConfig = {

--- a/packages/tools/pluggable-widgets-tools/src/index.ts
+++ b/packages/tools/pluggable-widgets-tools/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./common";
 export * from "./native/common";
 export * from "./web/common";
+export * from "./utils/typings";
+export * from "./utils";

--- a/packages/tools/pluggable-widgets-tools/src/utils/PageEditorUtils.ts
+++ b/packages/tools/pluggable-widgets-tools/src/utils/PageEditorUtils.ts
@@ -1,6 +1,3 @@
-/**
- * TODO: Include tests for methods
- */
 import { Properties, Property, PropertyGroup } from "./typings";
 
 declare type Option<T> = T | undefined;
@@ -108,18 +105,13 @@ function modifyProperty(
 }
 
 export function moveProperty(fromIndex: number, toIndex: number, properties: Properties): void {
-    if (fromIndex >= 0 && toIndex >= 0 && fromIndex < properties.length && toIndex < properties.length) {
-        const elementToMove = properties[fromIndex];
-
-        const isMoveForward = toIndex - fromIndex >= 0;
-        const maxIndexStep = isMoveForward ? toIndex - fromIndex : fromIndex - toIndex;
-        const getNextIndex = (currentIndex: number): number => currentIndex + (isMoveForward ? +1 : -1);
-        const getCurrentIndex = (indexStep: number): number => fromIndex + (isMoveForward ? +indexStep : -indexStep);
-
-        for (let indexStep = 0; indexStep <= maxIndexStep; indexStep++) {
-            const currentIndex = getCurrentIndex(indexStep);
-            const newElement = currentIndex === toIndex ? elementToMove : properties[getNextIndex(currentIndex)];
-            properties[currentIndex] = newElement;
-        }
+    if (
+        fromIndex >= 0 &&
+        toIndex >= 0 &&
+        fromIndex < properties.length &&
+        toIndex < properties.length &&
+        fromIndex !== toIndex
+    ) {
+        properties.splice(toIndex, 0, ...properties.splice(fromIndex, 1));
     }
 }

--- a/packages/tools/pluggable-widgets-tools/src/utils/PageEditorUtils.ts
+++ b/packages/tools/pluggable-widgets-tools/src/utils/PageEditorUtils.ts
@@ -1,8 +1,7 @@
-/* eslint-disable */
 /**
  * TODO: Include tests for methods
  */
-import { Properties, Property, PropertyGroup } from "../typings";
+import { Properties, Property, PropertyGroup } from "./typings";
 
 declare type Option<T> = T | undefined;
 

--- a/packages/tools/pluggable-widgets-tools/src/utils/__tests__/PageEditorUtils.spec.ts
+++ b/packages/tools/pluggable-widgets-tools/src/utils/__tests__/PageEditorUtils.spec.ts
@@ -1,8 +1,8 @@
 import { Properties } from "../typings";
-import { moveProperty } from "../PageEditorUtils";
+import { hideNestedPropertiesIn, hidePropertiesIn, hidePropertyIn, moveProperty } from "../PageEditorUtils";
 
 describe("The PageEditorUtils", () => {
-    describe("the moveProperty function", () => {
+    describe("moveProperty", () => {
         let properties: Properties;
         const originalProperties = [
             { caption: "General" },
@@ -28,7 +28,7 @@ describe("The PageEditorUtils", () => {
             ]);
         });
 
-        it("moves a property backwars in the array", () => {
+        it("moves a property backward in the array", () => {
             moveProperty(5, 2, properties);
             expect(properties).toEqual([
                 { caption: "General" },
@@ -62,4 +62,229 @@ describe("The PageEditorUtils", () => {
             expect(properties).toEqual(originalProperties);
         });
     });
+
+    describe("hiding properties", () => {
+        let values: SamplePreviewProps;
+        let properties: Properties;
+        beforeEach(() => {
+            values = {
+                title: "Hi there",
+                readOnly: false,
+                collapsible: true,
+                icon: "right",
+                list: []
+            };
+
+            properties = [
+                {
+                    caption: "General",
+                    properties: [
+                        { key: "title", caption: "Title" },
+                        { key: "readOnly", caption: "Readonly" },
+                        {
+                            key: "list",
+                            caption: "List",
+                            objects: [
+                                {
+                                    properties: [
+                                        {
+                                            caption: "name",
+                                            properties: [
+                                                { key: "name", caption: "Name" },
+                                                { key: "isOpen", caption: "Is Open" }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            objectHeaders: ["one"]
+                        }
+                    ]
+                },
+                {
+                    caption: "Design",
+                    properties: [
+                        { key: "collapsible", caption: "Collapsible" },
+                        { key: "icon", caption: "Icon style" }
+                    ]
+                }
+            ];
+        });
+
+        describe("hidePropertyIn", () => {
+            it("hides a property correctly", () => {
+                hidePropertyIn(properties, values, "icon");
+
+                // check properties
+                expect(properties).toEqual([
+                    {
+                        caption: "General",
+                        properties: [
+                            { key: "title", caption: "Title" },
+                            { key: "readOnly", caption: "Readonly" },
+                            {
+                                key: "list",
+                                caption: "List",
+                                objects: [
+                                    {
+                                        properties: [
+                                            {
+                                                caption: "name",
+                                                properties: [
+                                                    { key: "name", caption: "Name" },
+                                                    { key: "isOpen", caption: "Is Open" }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ],
+                                objectHeaders: ["one"]
+                            }
+                        ]
+                    },
+                    {
+                        caption: "Design",
+                        properties: [
+                            { key: "collapsible", caption: "Collapsible" }
+                            // here was a prop with key "icon", but it is hidden
+                        ]
+                    }
+                ]);
+            });
+
+            it("hides a nested property correctly", () => {
+                hidePropertyIn(properties, values, "list", 0, "name");
+
+                // check properties
+                expect(properties).toEqual([
+                    {
+                        caption: "General",
+                        properties: [
+                            { key: "title", caption: "Title" },
+                            { key: "readOnly", caption: "Readonly" },
+                            {
+                                key: "list",
+                                caption: "List",
+                                objects: [
+                                    {
+                                        properties: [
+                                            {
+                                                caption: "name",
+                                                properties: [
+                                                    // here was a nested prop with key "name", but it is hidden
+                                                    { key: "isOpen", caption: "Is Open" }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ],
+                                objectHeaders: ["one"]
+                            }
+                        ]
+                    },
+                    {
+                        caption: "Design",
+                        properties: [
+                            { key: "collapsible", caption: "Collapsible" },
+                            { key: "icon", caption: "Icon style" }
+                        ]
+                    }
+                ]);
+            });
+        });
+
+        describe("hidePropertiesIn", () => {
+            it("hides multiple properties", () => {
+                hidePropertiesIn(properties, values, ["title", "collapsible"]);
+
+                expect(properties).toEqual([
+                    {
+                        caption: "General",
+                        properties: [
+                            // here was a prop with key "title", but it is hidden
+                            { key: "readOnly", caption: "Readonly" },
+                            {
+                                key: "list",
+                                caption: "List",
+                                objects: [
+                                    {
+                                        properties: [
+                                            {
+                                                caption: "name",
+                                                properties: [
+                                                    { key: "name", caption: "Name" },
+                                                    { key: "isOpen", caption: "Is Open" }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ],
+                                objectHeaders: ["one"]
+                            }
+                        ]
+                    },
+                    {
+                        caption: "Design",
+                        properties: [
+                            // here was a prop with key "collapsed", but it is hidden
+                            { key: "icon", caption: "Icon style" }
+                        ]
+                    }
+                ]);
+            });
+        });
+
+        describe("hideNestedPropertiesIn", () => {
+            it("hides multiple properties", () => {
+                hideNestedPropertiesIn(properties, values, "list", 0, ["name", "isOpen"]);
+
+                expect(properties).toEqual([
+                    {
+                        caption: "General",
+                        properties: [
+                            { key: "title", caption: "Title" },
+                            { key: "readOnly", caption: "Readonly" },
+                            {
+                                key: "list",
+                                caption: "List",
+                                objects: [
+                                    {
+                                        properties: [
+                                            {
+                                                caption: "name",
+                                                properties: [
+                                                    // here were a props with keys "name" and isOpen, but they were hidden
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ],
+                                objectHeaders: ["one"]
+                            }
+                        ]
+                    },
+                    {
+                        caption: "Design",
+                        properties: [
+                            { key: "collapsible", caption: "Collapsible" },
+                            { key: "icon", caption: "Icon style" }
+                        ]
+                    }
+                ]);
+            });
+        });
+    });
 });
+
+interface ListProps {
+    name: string;
+    isOpen: boolean;
+}
+
+interface SamplePreviewProps {
+    title: string;
+    readOnly: boolean;
+    collapsible: boolean;
+    list: ListProps[];
+    icon: "right" | "left" | "no";
+}

--- a/packages/tools/pluggable-widgets-tools/src/utils/__tests__/PageEditorUtils.spec.ts
+++ b/packages/tools/pluggable-widgets-tools/src/utils/__tests__/PageEditorUtils.spec.ts
@@ -1,4 +1,4 @@
-import { Properties } from "../../typings/PageEditor";
+import { Properties } from "../typings";
 import { moveProperty } from "../PageEditorUtils";
 
 describe("The PageEditorUtils", () => {

--- a/packages/tools/pluggable-widgets-tools/src/utils/index.ts
+++ b/packages/tools/pluggable-widgets-tools/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./PageEditorUtils";

--- a/packages/tools/pluggable-widgets-tools/src/utils/typings/PageEditor.ts
+++ b/packages/tools/pluggable-widgets-tools/src/utils/typings/PageEditor.ts
@@ -1,0 +1,30 @@
+export type Properties = PropertyGroup[];
+
+export type PropertyGroup = {
+    caption: string;
+    propertyGroups?: PropertyGroup[];
+    properties?: Property[];
+};
+
+export type Property = {
+    key: string;
+    caption: string;
+    description?: string;
+    objectHeaders?: string[]; // used for customizing object grids
+    objects?: ObjectProperties[];
+    properties?: Properties[]; // Property needs to remain here for compatibility with Studio Pro < 8.12
+};
+
+export type ObjectProperties = {
+    properties: PropertyGroup[];
+    captions?: string[]; // used for customizing object grids
+};
+
+export type Problem = {
+    property?: string; // key of the property, at which the problem exists
+    severity?: "error" | "warning" | "deprecation"; // default = "error"
+    message: string; // description of the problem
+    studioMessage?: string; // studio-specific message, defaults to message
+    url?: string; // link with more information about the problem
+    studioUrl?: string; // studio-specific link
+};

--- a/packages/tools/pluggable-widgets-tools/src/utils/typings/index.ts
+++ b/packages/tools/pluggable-widgets-tools/src/utils/typings/index.ts
@@ -1,0 +1,1 @@
+export * from "./PageEditor";


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅ 
- Contains breaking changes  ❌
- Contains Atlas changes ❌
- Compatible with: MX  9️⃣

## This PR contains
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Other (describe)

## What is the purpose of this PR?
Move property visibility utils for editor config to the publicly available package of `pluggable-widgets-tools`.
