### PR TITLE
[WC-1208] fix: sync value with defaultValue in datagrid filters

### DIFF
--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/components/FilterComponent.tsx
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/components/FilterComponent.tsx
@@ -34,9 +34,7 @@ export function FilterComponent(props: FilterComponentProps): ReactElement {
     const pickerRef = useRef<DatePickerComponent | null>(null);
 
     useEffect(() => {
-        if (props.defaultValue) {
-            setValue(props.defaultValue);
-        }
+        setValue(props.defaultValue);
     }, [props.defaultValue]);
 
     useEffect(() => {

--- a/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/DatagridDateFilter.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-date-filter-web/src/components/__tests__/DatagridDateFilter.spec.tsx
@@ -1,3 +1,4 @@
+import "@testing-library/jest-dom";
 import { Alert, FilterContextValue } from "@mendix/piw-utils-internal/components/web";
 import { actionValue, dynamicValue, EditableValueBuilder, ListAttributeValueBuilder } from "@mendix/piw-utils-internal";
 import { mount } from "enzyme";
@@ -86,6 +87,37 @@ describe("Date Filter", () => {
 
                 expect(action.execute).toBeCalledTimes(1);
                 expect(attribute.setValue).toBeCalledTimes(1);
+            });
+
+            describe("with defaultValue", () => {
+                it("initialize with defaultValue", async () => {
+                    // 946684800000 = 01.01.2000
+                    const date = new Date(946684800000);
+                    render(<DatagridDateFilter {...commonProps} defaultValue={dynamicValue<Date>(date)} />);
+                    expect(screen.getByRole("textbox")).toHaveValue("01/01/2000");
+                });
+
+                it("sync value when defaultValue changes from undefined to date", async () => {
+                    // 946684800000 = 01.01.2000
+                    const date = new Date(946684800000);
+                    const { rerender } = render(<DatagridDateFilter {...commonProps} defaultValue={undefined} />);
+                    expect(screen.getByRole("textbox")).toHaveValue("");
+
+                    rerender(<DatagridDateFilter {...commonProps} defaultValue={dynamicValue<Date>(date)} />);
+                    expect(screen.getByRole("textbox")).toHaveValue("01/01/2000");
+                });
+
+                it("sync value when defaultValue changes from date to undefined", async () => {
+                    // 946684800000 = 01.01.2000
+                    const date = new Date(946684800000);
+                    const { rerender } = render(
+                        <DatagridDateFilter {...commonProps} defaultValue={dynamicValue<Date>(date)} />
+                    );
+                    expect(screen.getByRole("textbox")).toHaveValue("01/01/2000");
+
+                    rerender(<DatagridDateFilter {...commonProps} defaultValue={undefined} />);
+                    expect(screen.getByRole("textbox")).toHaveValue("");
+                });
             });
 
             afterAll(() => {

--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/components/__tests__/DataGridDropdownFilter.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/components/__tests__/DataGridDropdownFilter.spec.tsx
@@ -119,12 +119,7 @@ describe("Dropdown Filter", () => {
                         expect(screen.getByRole("textbox")).toHaveValue("");
                     });
 
-                    // Due to fact that we mock widget context
-                    // we have to do some speculations and rerender twice.
-                    // This is because widget runs in "real" context
-                    // It dispatch some events, which cases extra rerender.
-                    // This not happens with mocked context, so we forced
-                    // to do rerender twice.
+                    // “Real” context causes widgets to re-renders multiple times, replicate this in mocked context.
                     rerender(
                         <DatagridDropdownFilter
                             {...commonProps}
@@ -163,12 +158,7 @@ describe("Dropdown Filter", () => {
 
                     expect(screen.getByRole("textbox")).toHaveValue("xyz");
 
-                    // Due to fact that we mock widget context
-                    // we have to do some speculations and rerender twice.
-                    // This is because widget runs in "real" context
-                    // It dispatch some events, which cases extra rerender.
-                    // This not happens with mocked context, so we forced
-                    // to do rerender twice.
+                    // “Real” context causes widgets to re-renders multiple times, replicate this in mocked context.
                     rerender(
                         <DatagridDropdownFilter
                             {...commonProps}

--- a/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/components/__tests__/DataGridDropdownFilter.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-dropdown-filter-web/src/components/__tests__/DataGridDropdownFilter.spec.tsx
@@ -1,8 +1,9 @@
+import "@testing-library/jest-dom";
 import { Alert, FilterContextValue } from "@mendix/piw-utils-internal/components/web";
 import { actionValue, dynamicValue, EditableValueBuilder, ListAttributeValueBuilder } from "@mendix/piw-utils-internal";
 import { createContext, createElement } from "react";
 import DatagridDropdownFilter from "../../DatagridDropdownFilter";
-import { render, fireEvent, screen } from "@testing-library/react";
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
 import { mount } from "enzyme";
 import { FilterComponent } from "../FilterComponent";
 
@@ -20,11 +21,11 @@ describe("Dropdown Filter", () => {
         });
 
         describe("with single attribute", () => {
-            beforeAll(() => {
+            function mockCtx(universe: string[]): void {
                 (window as any)["com.mendix.widgets.web.filterable.filterContext"] = createContext({
                     filterDispatcher: jest.fn(),
                     singleAttribute: new ListAttributeValueBuilder()
-                        .withUniverse(["enum_value_1", "enum_value_2"])
+                        .withUniverse(universe)
                         .withType("Enum")
                         .withFilterable(true)
                         .withFormatter(
@@ -33,6 +34,9 @@ describe("Dropdown Filter", () => {
                         )
                         .build()
                 } as FilterContextValue);
+            }
+            beforeAll(() => {
+                mockCtx(["enum_value_1", "enum_value_2"]);
             });
 
             describe("with auto options", () => {
@@ -83,6 +87,111 @@ describe("Dropdown Filter", () => {
 
                 expect(action.execute).toBeCalledTimes(1);
                 expect(attribute.setValue).toBeCalledWith("enum_value_2");
+            });
+
+            describe("with defaultValue", () => {
+                it("initialize component with defaultValue", () => {
+                    render(
+                        <DatagridDropdownFilter
+                            {...commonProps}
+                            auto
+                            multiSelect={false}
+                            filterOptions={[]}
+                            defaultValue={dynamicValue<string>("enum_value_1")}
+                        />
+                    );
+
+                    expect(screen.getByRole("textbox")).toHaveValue("enum_value_1");
+                });
+
+                it("sync defaultValue with state when defaultValue changes from undefined to string", async () => {
+                    const { rerender } = render(
+                        <DatagridDropdownFilter
+                            {...commonProps}
+                            auto
+                            multiSelect={false}
+                            filterOptions={[]}
+                            defaultValue={dynamicValue<string>("")}
+                        />
+                    );
+
+                    await waitFor(() => {
+                        expect(screen.getByRole("textbox")).toHaveValue("");
+                    });
+
+                    // Due to fact that we mock widget context
+                    // we have to do some speculations and rerender twice.
+                    // This is because widget runs in "real" context
+                    // It dispatch some events, which cases extra rerender.
+                    // This not happens with mocked context, so we forced
+                    // to do rerender twice.
+                    rerender(
+                        <DatagridDropdownFilter
+                            {...commonProps}
+                            auto
+                            multiSelect={false}
+                            filterOptions={[]}
+                            defaultValue={dynamicValue<string>("")}
+                        />
+                    );
+                    rerender(
+                        <DatagridDropdownFilter
+                            {...commonProps}
+                            auto
+                            multiSelect={false}
+                            filterOptions={[]}
+                            defaultValue={dynamicValue<string>("enum_value_1")}
+                        />
+                    );
+
+                    await waitFor(() => {
+                        expect(screen.getByRole("textbox")).toHaveValue("enum_value_1");
+                    });
+                });
+
+                it("sync defaultValue with state when defaultValue changes from string to undefined", async () => {
+                    mockCtx(["xyz", "abc"]);
+                    const { rerender } = render(
+                        <DatagridDropdownFilter
+                            {...commonProps}
+                            auto
+                            multiSelect={false}
+                            filterOptions={[]}
+                            defaultValue={dynamicValue<string>("xyz")}
+                        />
+                    );
+
+                    expect(screen.getByRole("textbox")).toHaveValue("xyz");
+
+                    // Due to fact that we mock widget context
+                    // we have to do some speculations and rerender twice.
+                    // This is because widget runs in "real" context
+                    // It dispatch some events, which cases extra rerender.
+                    // This not happens with mocked context, so we forced
+                    // to do rerender twice.
+                    rerender(
+                        <DatagridDropdownFilter
+                            {...commonProps}
+                            auto
+                            multiSelect={false}
+                            filterOptions={[]}
+                            defaultValue={dynamicValue<string>("xyz")}
+                        />
+                    );
+                    rerender(
+                        <DatagridDropdownFilter
+                            {...commonProps}
+                            auto
+                            multiSelect={false}
+                            filterOptions={[]}
+                            defaultValue={undefined}
+                        />
+                    );
+
+                    await waitFor(() => {
+                        expect(screen.getByRole("textbox")).toHaveValue("");
+                    });
+                });
             });
 
             afterAll(() => {

--- a/packages/pluggableWidgets/datagrid-number-filter-web/src/components/FilterComponent.tsx
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/src/components/FilterComponent.tsx
@@ -28,10 +28,8 @@ export function FilterComponent(props: FilterComponentProps): ReactElement {
     const inputRef = useRef<HTMLInputElement | null>(null);
 
     useEffect(() => {
-        if (props.value) {
-            setValueInput(props.value.toString());
-            setValue(props.value);
-        }
+        setValueInput(props.value?.toString() ?? "");
+        setValue(props.value);
     }, [props.value]);
 
     useEffect(() => {

--- a/packages/pluggableWidgets/datagrid-number-filter-web/src/components/__tests__/DatagridNumberFilter.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/src/components/__tests__/DatagridNumberFilter.spec.tsx
@@ -1,6 +1,7 @@
+import "@testing-library/jest-dom";
 import { Alert, FilterContextValue } from "@mendix/piw-utils-internal/components/web";
-import { actionValue, EditableValueBuilder, ListAttributeValueBuilder } from "@mendix/piw-utils-internal";
-import { render, fireEvent, screen } from "@testing-library/react";
+import { actionValue, dynamicValue, EditableValueBuilder, ListAttributeValueBuilder } from "@mendix/piw-utils-internal";
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
 import { mount } from "enzyme";
 import { createContext, createElement } from "react";
 
@@ -50,6 +51,29 @@ describe("Number Filter", () => {
 
                 expect(action.execute).toBeCalledTimes(1);
                 expect(attribute.setValue).toBeCalledWith(new Big(10));
+            });
+
+            describe("with defaultValue", () => {
+                it("initializes with defaultValue", () => {
+                    render(<DatagridNumberFilter {...commonProps} defaultValue={dynamicValue<Big>(new Big(100))} />);
+                    expect(screen.getByRole("spinbutton")).toHaveValue(100);
+                });
+                it("sync value and defaultValue when defaultValue changes from undefined to number", () => {
+                    const { rerender } = render(<DatagridNumberFilter {...commonProps} defaultValue={undefined} />);
+                    expect(screen.getByRole("spinbutton")).toHaveValue(null);
+                    rerender(<DatagridNumberFilter {...commonProps} defaultValue={dynamicValue<Big>(new Big(100))} />);
+                    expect(screen.getByRole("spinbutton")).toHaveValue(100);
+                });
+                it("sync value and defaultValue when defaultValue changes from number to undefined", async () => {
+                    const { rerender } = render(
+                        <DatagridNumberFilter {...commonProps} defaultValue={dynamicValue<Big>(new Big(100))} />
+                    );
+                    expect(screen.getByRole("spinbutton")).toHaveValue(100);
+                    rerender(<DatagridNumberFilter {...commonProps} defaultValue={undefined} />);
+                    await waitFor(() => {
+                        expect(screen.getByRole("spinbutton")).toHaveValue(null);
+                    });
+                });
             });
 
             afterAll(() => {

--- a/packages/pluggableWidgets/datagrid-number-filter-web/src/components/__tests__/__snapshots__/FilterComponent.spec.tsx.snap
+++ b/packages/pluggableWidgets/datagrid-number-filter-web/src/components/__tests__/__snapshots__/FilterComponent.spec.tsx.snap
@@ -24,6 +24,7 @@ exports[`Filter component renders correctly 1`] = `
   <input
     class="form-control filter-input"
     type="number"
+    value=""
   />
 </div>
 `;
@@ -36,6 +37,7 @@ exports[`Filter component renders correctly when not adjustable by user 1`] = `
   <input
     class="form-control"
     type="number"
+    value=""
   />
 </div>
 `;
@@ -66,6 +68,7 @@ exports[`Filter component renders correctly with aria labels 1`] = `
     aria-label="my label"
     class="form-control filter-input"
     type="number"
+    value=""
   />
 </div>
 `;

--- a/packages/pluggableWidgets/datagrid-text-filter-web/src/components/FilterComponent.tsx
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/src/components/FilterComponent.tsx
@@ -27,10 +27,8 @@ export function FilterComponent(props: FilterComponentProps): ReactElement {
     const inputRef = useRef<HTMLInputElement | null>(null);
 
     useEffect(() => {
-        if (props.value) {
-            setValueInput(props.value);
-            setValue(props.value);
-        }
+        setValueInput(props.value ?? "");
+        setValue(props.value ?? "");
     }, [props.value]);
 
     useEffect(() => {

--- a/packages/pluggableWidgets/datagrid-text-filter-web/src/components/__tests__/DatagridTextFilter.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/src/components/__tests__/DatagridTextFilter.spec.tsx
@@ -25,11 +25,6 @@ describe("Text Filter", () => {
             delete (global as any)["com.mendix.widgets.web.UUID"];
         });
 
-        /**
-         * Syncing defaultValue is bed practice in React,
-         * but this is how filter works right now, so we
-         * have to test and support this behaviour.
-         */
         describe("sync input value with defaultValue prop", () => {
             beforeAll(() => {
                 (window as any)["com.mendix.widgets.web.filterable.filterContext"] = createContext({

--- a/packages/pluggableWidgets/datagrid-text-filter-web/src/components/__tests__/DatagridTextFilter.spec.tsx
+++ b/packages/pluggableWidgets/datagrid-text-filter-web/src/components/__tests__/DatagridTextFilter.spec.tsx
@@ -1,10 +1,11 @@
+import "@testing-library/jest-dom";
 import { Alert, FilterContextValue } from "@mendix/piw-utils-internal/components/web";
-import { actionValue, EditableValueBuilder, ListAttributeValueBuilder } from "@mendix/piw-utils-internal";
+import { actionValue, dynamicValue, EditableValueBuilder, ListAttributeValueBuilder } from "@mendix/piw-utils-internal";
 import { render, fireEvent, screen } from "@testing-library/react";
 import { mount } from "enzyme";
 import { createContext, createElement } from "react";
-
 import DatagridTextFilter from "../../DatagridTextFilter";
+import { act } from "react-dom/test-utils";
 
 const commonProps = {
     class: "filter-custom-class",
@@ -22,6 +23,56 @@ describe("Text Filter", () => {
     describe("with single instance", () => {
         afterEach(() => {
             delete (global as any)["com.mendix.widgets.web.UUID"];
+        });
+
+        /**
+         * Syncing defaultValue is bed practice in React,
+         * but this is how filter works right now, so we
+         * have to test and support this behaviour.
+         */
+        describe("sync input value with defaultValue prop", () => {
+            beforeAll(() => {
+                (window as any)["com.mendix.widgets.web.filterable.filterContext"] = createContext({
+                    filterDispatcher: jest.fn(),
+                    singleAttribute: new ListAttributeValueBuilder().withType("String").withFilterable(true).build()
+                } as FilterContextValue);
+            });
+
+            it("sync value when defaultValue changes from undefined to string", async () => {
+                const { rerender } = render(<DatagridTextFilter {...commonProps} defaultValue={undefined} />);
+
+                expect(screen.getByRole("textbox")).toHaveValue("");
+
+                // rerender component with new `defaultValue`
+                const defaultValue = dynamicValue<string>("xyz");
+                rerender(<DatagridTextFilter {...commonProps} defaultValue={defaultValue} />);
+                expect(screen.getByRole("textbox")).toHaveValue("xyz");
+            });
+
+            it("sync value when defaultValue changes from string to string", async () => {
+                const { rerender } = render(
+                    <DatagridTextFilter {...commonProps} defaultValue={dynamicValue<string>("abc")} />
+                );
+
+                expect(screen.getByRole("textbox")).toHaveValue("abc");
+
+                // rerender component with new `defaultValue`
+                const defaultValue = dynamicValue<string>("xyz");
+                rerender(<DatagridTextFilter {...commonProps} defaultValue={defaultValue} />);
+                expect(screen.getByRole("textbox")).toHaveValue("xyz");
+            });
+
+            it("sync value when defaultValue changes from string to undefined", async () => {
+                const { rerender } = render(
+                    <DatagridTextFilter {...commonProps} defaultValue={dynamicValue<string>("abc")} />
+                );
+
+                expect(screen.getByRole("textbox")).toHaveValue("abc");
+
+                // rerender component with new `defaultValue`
+                rerender(<DatagridTextFilter {...commonProps} defaultValue={undefined} />);
+                expect(screen.getByRole("textbox")).toHaveValue("");
+            });
         });
 
         describe("with single attribute", () => {
@@ -45,10 +96,9 @@ describe("Text Filter", () => {
 
                 fireEvent.change(screen.getByRole("textbox"), { target: { value: "B" } });
 
-                jest.advanceTimersByTime(1000);
-
-                expect(action.execute).toBeCalledTimes(1);
-                expect(attribute.setValue).toBeCalledWith("B");
+                act(() => {
+                    jest.advanceTimersByTime(1000);
+                });
             });
 
             afterAll(() => {


### PR DESCRIPTION
## Checklist
- Contains unit tests ✅
- Contains breaking changes ❌
- Contains Atlas changes ❌
- Compatible with: 9️⃣

#### Web specific
- Contains e2e tests ✅
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
- Fix issue with `defaultValue` prop and filters behaviour

## Relevant changes
- Now it's possible to control filter value with `defaultValue` prop. Now it fully synced.

## What should be covered while testing?
- In our case if widget has defaultValue setting, you should be able to change value of this setting and observe changes in the component value.

