### PR TITLE
[WC-1182]: Fix issue with DG2 and Gallery container height

### DIFF
--- a/packages/modules/data-widgets/package.json
+++ b/packages/modules/data-widgets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "data-widgets",
   "moduleName": "Data Widgets",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/datagrid-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed the issue with grid container having incorrect height when infinite scroll is enabled and number of rows exceed page size (Ticket #149371)
+
 ## [2.4.1] - 2022-7-5
 
 ### Fixed

--- a/packages/pluggableWidgets/datagrid-web/package.json
+++ b/packages/pluggableWidgets/datagrid-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "datagrid-web",
   "widgetName": "Datagrid",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "repository": {

--- a/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
+++ b/packages/pluggableWidgets/datagrid-web/src/components/Table.tsx
@@ -16,7 +16,9 @@ import classNames from "classnames";
 import { EditableValue, ObjectItem } from "mendix";
 import { SortingRule, useSettings } from "../utils/settings";
 import { ColumnResizer } from "./ColumnResizer";
+import { useCalcPageHeight } from "@mendix/piw-utils-internal";
 import { InfiniteBody, Pagination } from "@mendix/piw-utils-internal/components/web";
+import { calcGridHeight } from "../utils/calcGridHeight";
 
 export type TableColumn = Omit<
     ColumnsPreviewType,
@@ -107,6 +109,8 @@ export function Table<T extends ObjectItem>(props: TableProps<T>): ReactElement 
         columnsWidth,
         setColumnsWidth
     );
+
+    const getPageHeight = useCalcPageHeight(props.data.length, props.pageSize, calcGridHeight);
 
     useEffect(() => updateSettings(), [columnOrder, hiddenColumns, sortBy]);
 
@@ -247,6 +251,7 @@ export function Table<T extends ObjectItem>(props: TableProps<T>): ReactElement 
                     role="rowgroup"
                     setPage={props.setPage}
                     style={cssGridStyles}
+                    getContainerHeight={getPageHeight}
                 >
                     <div className="tr" role="row">
                         {visibleColumns.map(column =>

--- a/packages/pluggableWidgets/datagrid-web/src/package.xml
+++ b/packages/pluggableWidgets/datagrid-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Datagrid" version="2.4.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Datagrid" version="2.4.2" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Datagrid.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/datagrid-web/src/utils/calcGridHeight.ts
+++ b/packages/pluggableWidgets/datagrid-web/src/utils/calcGridHeight.ts
@@ -1,0 +1,12 @@
+import type { CalcHeightFn } from "@mendix/piw-utils-internal";
+
+export const calcGridHeight: CalcHeightFn = (container, _numberOfItems, pageSize) => {
+    const elements = container.querySelectorAll<HTMLElement>(".th:first-child, .td:first-child");
+    const pageSizeWithHeader = pageSize + 1;
+
+    const pageHeight = Array.from(elements)
+        .slice(0, pageSizeWithHeader)
+        .reduce((acc, elt) => acc + elt.offsetHeight, 0);
+
+    return pageHeight - 30;
+};

--- a/packages/pluggableWidgets/gallery-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/gallery-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed the issue with gallery container having incorrect height when infinite scroll is enabled and number of rows exceed page size (Ticket #149371)
+
 ## [1.2.0] - 2022-6-13
 
 ### Fixed

--- a/packages/pluggableWidgets/gallery-web/package.json
+++ b/packages/pluggableWidgets/gallery-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gallery-web",
   "widgetName": "Gallery",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A flexible gallery widget that renders columns, rows and layouts.",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "license": "Apache-2.0",

--- a/packages/pluggableWidgets/gallery-web/src/components/Gallery.tsx
+++ b/packages/pluggableWidgets/gallery-web/src/components/Gallery.tsx
@@ -3,7 +3,7 @@ import { InfiniteBody, Pagination } from "@mendix/piw-utils-internal/components/
 import { ObjectItem } from "mendix";
 import classNames from "classnames";
 import { useCalcPageHeight } from "@mendix/piw-utils-internal";
-import { calcGalleryHeight } from "src/utils/calcGalleryHeight";
+import { calcGalleryHeight } from "../utils/calcGalleryHeight";
 
 export interface GalleryProps<T extends ObjectItem> {
     className?: string;

--- a/packages/pluggableWidgets/gallery-web/src/components/Gallery.tsx
+++ b/packages/pluggableWidgets/gallery-web/src/components/Gallery.tsx
@@ -2,6 +2,8 @@ import { createElement, ReactElement, ReactNode } from "react";
 import { InfiniteBody, Pagination } from "@mendix/piw-utils-internal/components/web";
 import { ObjectItem } from "mendix";
 import classNames from "classnames";
+import { useCalcPageHeight } from "@mendix/piw-utils-internal";
+import { calcGalleryHeight } from "src/utils/calcGalleryHeight";
 
 export interface GalleryProps<T extends ObjectItem> {
     className?: string;
@@ -45,6 +47,8 @@ export function Gallery<T extends ObjectItem>(props: GalleryProps<T>): ReactElem
         </div>
     ) : null;
 
+    const getPageHeight = useCalcPageHeight(props.items.length, props.pageSize, calcGalleryHeight);
+
     return (
         <div className={classNames("widget-gallery", props.className)} data-focusindex={props.tabIndex || 0}>
             {props.paginationPosition === "above" && pagination}
@@ -66,6 +70,7 @@ export function Gallery<T extends ObjectItem>(props: GalleryProps<T>): ReactElem
                     setPage={props.setPage}
                     isInfinite={!props.paging}
                     role="list"
+                    getContainerHeight={getPageHeight}
                 >
                     {props.items.map(item =>
                         props.itemRenderer((children, className, onClick) => {

--- a/packages/pluggableWidgets/gallery-web/src/package.xml
+++ b/packages/pluggableWidgets/gallery-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Gallery" version="1.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Gallery" version="1.2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Gallery.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/gallery-web/src/utils/calcGalleryHeight.ts
+++ b/packages/pluggableWidgets/gallery-web/src/utils/calcGalleryHeight.ts
@@ -1,0 +1,18 @@
+import { CalcHeightFn } from "@mendix/piw-utils-internal";
+
+export const calcGalleryHeight: CalcHeightFn = (container, _numberOfItems, pageSize) => {
+    const elements = Array.from(container.querySelectorAll<HTMLElement>(".widget-gallery-item")).slice(0, pageSize);
+    const [firstColumnElements] = elements.reduce(
+        ([items, visitedRows], elt) => {
+            if (!visitedRows.has(elt.offsetTop)) {
+                items.push(elt);
+                visitedRows.add(elt.offsetTop);
+            }
+
+            return [items, visitedRows];
+        },
+        [[] as HTMLElement[], new Set<number>()] as const
+    );
+    const pageHeight = firstColumnElements.reduce((acc, elt) => acc + elt.offsetHeight, 0);
+    return pageHeight - 30;
+};

--- a/packages/tools/piw-utils-internal/src/hooks/useCalcPageHeight.ts
+++ b/packages/tools/piw-utils-internal/src/hooks/useCalcPageHeight.ts
@@ -1,0 +1,26 @@
+import { useRef } from "react";
+import { useEventCallback } from "./useEventCallback";
+
+export type CalcHeightFn = (container: HTMLElement, numberOfItems: number, pageSize: number) => number;
+export type GetHeightFn = (container: HTMLElement) => number;
+
+export function useCalcPageHeight(numberOfItems: number, pageSize: number, calc: CalcHeightFn): GetHeightFn {
+    const cachedValueRef = useRef<null | number>(null);
+
+    const getPageHeight: GetHeightFn = container => {
+        // Do nothing if not enough items
+        if (numberOfItems < pageSize) {
+            return 0;
+        }
+
+        if (cachedValueRef.current !== null) {
+            return cachedValueRef.current;
+        }
+
+        cachedValueRef.current = calc(container, numberOfItems, pageSize);
+
+        return cachedValueRef.current;
+    };
+
+    return useEventCallback(getPageHeight);
+}

--- a/packages/tools/piw-utils-internal/src/hooks/useEventCallback.ts
+++ b/packages/tools/piw-utils-internal/src/hooks/useEventCallback.ts
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback } from "react";
+import { useRef, useCallback } from "react";
 
 /**
  * Utility hook for wrapping arbitrary function to produce stable version of it.
@@ -10,9 +10,7 @@ export function useEventCallback<T extends (...args: any[]) => any>(fn?: T): T {
     const ref: any = useRef(fn);
 
     // we copy a ref to the callback scoped to the current state/props on each render
-    useEffect(() => {
-        ref.current = fn;
-    });
+    ref.current = fn;
 
     return useCallback((...args: any[]) => ref.current && ref.current.apply(undefined, args), []) as T;
 }

--- a/packages/tools/piw-utils-internal/src/index.ts
+++ b/packages/tools/piw-utils-internal/src/index.ts
@@ -4,3 +4,4 @@ export * from "./builders";
 export * from "./utils";
 export * from "./typings";
 export * from "./hooks/useEventCallback";
+export * from "./hooks/useCalcPageHeight";


### PR DESCRIPTION
## Checklist
- Contains unit tests ❌
- Contains breaking changes ❌
- Contains Atlas changes ✅
- Compatible with: MX 9️⃣

#### Web specific
- Contains e2e tests ❌
- Is accessible ✅
- Compatible with Studio ✅
- Cross-browser compatible ✅

## This PR contains
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?
- Fix bug with grid/gallery container height

## Relevant changes
We change how we calculate height of container. New approach use not just container height itself, but tries to count height of items that "fit" into one page.

## What should be covered while testing?
- DG2 and Gallery with infinite scroll stetting. Now widget should always have same height despite of number of re-renders.