### PR TITLE
[WC-1277] cssUrlTransform in PW tools inserts backslashes on Windows

### DIFF
--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   We updated `cypress` to version 10
 
+### Fixed
+
+-   We fixed an issue which caused CSS URL transforms to include paths with backslashes when running on Windows.
+
 ## [9.13.3] - 2022-08-15
 
 ### Added

--- a/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/tools/pluggable-widgets-tools/configs/rollup.config.js
@@ -50,7 +50,7 @@ const outAssetsDir = join(outWidgetDir, assetsDirName);
  * Its main purpose to "adjust" asset path so that
  * after bundling css by studio assets paths stay correct.
  * Adjustment is required because of assets copying -- postcss-url can copy
- * files, but final url will be relative to *destenation* file and though
+ * files, but final url will be relative to *destination* file and though
  * will be broken after bundling by studio (pro).
  *
  * Example
@@ -58,7 +58,7 @@ const outAssetsDir = join(outWidgetDir, assetsDirName);
  * after: com/mendix/widget/web/accordion/assets/icon.png
  */
 const cssUrlTransform = asset =>
-    asset.url.startsWith(`${assetsDirName}/`) ? `${outWidgetDir}/${asset.url}` : asset.url;
+    asset.url.startsWith(`${assetsDirName}/`) ? `${outWidgetDir.replace(/\\/g, "/")}/${asset.url}` : asset.url;
 
 export default async args => {
     const production = Boolean(args.configProduction);


### PR DESCRIPTION
## Checklist

-   Contains unit tests ❌
-   Contains breaking changes ❌
-   Contains Atlas changes ❌
-   Compatible with: MX 9️⃣
-   Did you update version and changelog? ✅ (changelog only)
-   PR title properly formatted (`[XX-000]: description`)? ✅

## This PR contains

-   [x] Bug fix

## What is the purpose of this PR?

The `cssUrlTransform` in the rollup config of the PW tools inserts the `outWidgetDir` into asset URLs if necessary. However, this wonderfully cross-platform piece of logic fails to take into account that Windows file system paths contain backslashes and URLs should not :wink:.

## Relevant changes

Replace backslash with forward slash when inserting the `outWidgetDir` into an asset URL.

## What should be covered while testing?

CSS URL transformation works correctly on Windows without inserting backslashes into the transformed URL, meaning that these assets of the bundled widget will work properly in the browser.