### PR TITLE
Add retries to color picker web e2e test

### DIFF
--- a/configs/e2e/cypress/cypress.config.js
+++ b/configs/e2e/cypress/cypress.config.js
@@ -11,6 +11,7 @@ module.exports = defineConfig({
             });
         },
         baseUrl: "http://localhost:8080",
+        retries: 2,
         video: false,
         videoUploadOnPasses: false,
         viewportHeight: 1080,

--- a/packages/pluggableWidgets/color-picker-web/cypress/integration/ColorPicker.spec.js
+++ b/packages/pluggableWidgets/color-picker-web/cypress/integration/ColorPicker.spec.js
@@ -1,16 +1,40 @@
 describe("color-picker-web", () => {
-    describe("render a picker of mode", () => {
-        it("button", { browser: "!firefox" }, () => {
-            cy.visit("/p/modePage");
-            cy.wait(4000);
-            cy.get(".mx-name-colorPicker3").should("be.visible", true);
-            cy.get(".mx-name-colorPicker3 .widget-color-picker-inner").should(
-                "have.css",
-                "background",
-                "rgb(76, 175, 80) none repeat scroll 0% 0% / auto padding-box border-box"
-            );
+    const cleanMendixSession = () => {
+        cy.window().then(window => {
+            // Cypress opens a new session for every test, so it exceeds mendix license limit of 5 sessions, we need to logout after each test.
+            window.mx.session.logout();
         });
-        it("button", { browser: "firefox" }, () => {
+    };
+
+    afterEach(() => cleanMendixSession());
+
+    describe("render a picker of mode", () => {
+        it(
+            "button",
+            {
+                retries: {
+                    runMode: 10,
+                    openMode: 10
+                },
+                browser: "!firefox"
+            },
+            () => {
+                cy.visit("/p/modePage");
+                cy.wait(5000);
+                cy.get(".mx-name-colorPicker3 .widget-color-picker-inner", { timeout: 10000 }).should(
+                    "be.visible",
+                    true
+                );
+                cy.get(".mx-name-navigationTree3-2").click({ force: true });
+                cy.wait(5000);
+                cy.get(".mx-name-colorPicker3 .widget-color-picker-inner", { timeout: 10000 }).should(
+                    "have.css",
+                    "background",
+                    "rgba(0, 0, 0, 0) none repeat scroll 0% 0% / auto padding-box border-box"
+                );
+            }
+        );
+        it("button(Firefox)", { browser: "firefox" }, () => {
             cy.visit("/p/modePage");
             cy.wait(1000);
             cy.get(".mx-name-colorPicker3 .widget-color-picker-inner").should(


### PR DESCRIPTION
## Checklist

-   PR title properly formatted (`[XX-000]: description`)?  ❌

#### Web specific

-   Contains e2e tests ✅ 

#### Native specific

-   Works in Android ✅ ❌
-   Works in iOS ✅ ❌
-   Works in Tablet ✅ ❌


## This PR contains

-   [ ] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [x] Other (test fix)

## What is the purpose of this PR?

Since the update of Cypress 10, the color picker e2e test has been flakier. I have added retries to this test as there is one microflow running to get colors in the test project, and it seems that it is taking a long time to finish.

## Relevant changes

Added retries in the test spec and also in the general Cypress configuration.

## What should be covered while testing?

Automation should pass.
