### PR TITLE
[PAG-1317]: replace className with class in Pluggable Widget tools

### DIFF
--- a/packages/tools/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/tools/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Deprecated
+
+-   We've deprecated the `className` preview property. From now on, you have to use `class` property instead.
+
+## [9.17.0] - 2022-09-02
+
 ### Added
 
 -   We added support for association properties linked to a data source, introduced in Mendix 9.17.

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.17.0",
+  "version": "9.18.0",
   "description": "Mendix Pluggable Widgets Tools",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
@@ -19,7 +19,11 @@ export interface MyWidgetContainerProps {
 }
 
 export interface MyWidgetPreviewProps {
+    /**
+     * @deprecated Deprecated since version 9.18.0. Please use class property instead.
+     */
     className: string;
+    class: string;
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
@@ -17,7 +17,11 @@ export interface MyWidgetContainerProps {
 }
 
 export interface MyWidgetPreviewProps {
+    /**
+     * @deprecated Deprecated since version 9.18.0. Please use class property instead.
+     */
     className: string;
+    class: string;
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
@@ -44,7 +44,11 @@ export interface MyWidgetProps<Style> {
 }
 
 export interface MyWidgetPreviewProps {
+    /**
+     * @deprecated Deprecated since version 9.18.0. Please use class property instead.
+     */
     className: string;
+    class: string;
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
@@ -112,7 +116,11 @@ export interface MyWidgetContainerProps {
 }
 
 export interface MyWidgetPreviewProps {
+    /**
+     * @deprecated Deprecated since version 9.18.0. Please use class property instead.
+     */
     className: string;
+    class: string;
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-association.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-association.ts
@@ -20,7 +20,11 @@ export interface MyWidgetContainerProps {
 }
 
 export interface MyWidgetPreviewProps {
+    /**
+     * @deprecated Deprecated since version 9.18.0. Please use class property instead.
+     */
     className: string;
+    class: string;
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;

--- a/packages/tools/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
+++ b/packages/tools/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
@@ -12,7 +12,11 @@ export function generatePreviewTypes(
     results.push(`export interface ${widgetName}PreviewProps {${
         !isLabeled
             ? `
+    /**
+     * @deprecated Deprecated since version 9.18.0. Please use class property instead.
+     */
     className: string;
+    class: string;
     style: string;
     styleObject?: CSSProperties;`
             : ""


### PR DESCRIPTION
## Checklist

-   Contains unit tests ✅
-   Contains breaking changes ✅
-   Contains Atlas changes ❌
-   Compatible with: MX 9️⃣
-   Did you update version and changelog? ✅
-   PR title properly formatted (`[XX-000]: description`)? ✅ ❌

## This PR contains

-   [ ] Bug fix
-   [ ] Feature
-   [x] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

_For the sake of consistency between the Pluggable Widget API and the client, we have replaced the className preview property with class._

## Relevant changes

- Preview types generator

## What should be covered while testing?

- Verify whether the preview type generator uses the right property name.

## Extra comments (optional)

By merging this PR, we have to update all the existing pluggable widgets to use `class` preview property instead of `className`. Before this fix, developers couldn't run `npm run build` command at the root level.
