### PR TITLE
[PAG-1466]: add DatasourceProps to StructurePreviewProps

### DIFF
--- a/packages/tools/piw-utils-internal/src/typings/PageEditor.ts
+++ b/packages/tools/piw-utils-internal/src/typings/PageEditor.ts
@@ -13,7 +13,8 @@ export type StructurePreviewProps =
     | RowLayoutProps
     | TextProps
     | DropZoneProps
-    | SelectableProps;
+    | SelectableProps
+    | DatasourceProps;
 
 export type ImageProps = BaseProps & {
     type: "Image";
@@ -62,4 +63,10 @@ export type DropZoneProps = BaseProps & {
 export type SelectableProps = BaseProps & {
     object: object;
     child: StructurePreviewProps;
+};
+
+export declare type DatasourceProps = BaseProps & {
+    type: "Datasource";
+    property: object;
+    child?: StructurePreviewProps;
 };


### PR DESCRIPTION
## Checklist

-   Contains unit tests ❌
-   Contains breaking changes ❌
-   Contains Atlas changes ❌
-   Compatible with: MX 9️⃣
-   Did you update version and changelog? ❌
-   PR title properly formatted (`[XX-000]: description`)? ✅

## This PR contains

-   [ ] Bug fix
-   [x] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

We are adding a `Datasource` option for structure mode previews. This allows the preview to have a header similar to the built-in ones (e.g. list view.) This PR adds the necessary type definitions for that change.

## Relevant changes

Update the type definitions for the `StructurePreviewProps`.

## What should be covered while testing?

This only affects the TypeScript definitions and should not need extra testing.
