### PR TITLE
chore: fix typescript and PWT issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -267,7 +267,7 @@
                 "tsconfig-paths": "^3.9.0",
                 "tslint": "^6.1.3",
                 "tslint-eslint-rules": "^5.4.0",
-                "typescript": "^4.5.4",
+                "typescript": "4.5.4",
                 "url-parse": "^1.4.7",
                 "victory-native": "^35.5.5",
                 "wdio-image-comparison-service": "^2.3.0",

--- a/packages/jsActions/nanoflow-actions-hybrid/package.json
+++ b/packages/jsActions/nanoflow-actions-hybrid/package.json
@@ -54,7 +54,7 @@
     "concurrently": "^6.0.0",
     "eslint": "^7.20.0",
     "npm-watch": "^0.6.0",
-    "typescript": "^4.5.4",
+    "typescript": "4.5.4",
     "rimraf": "^2.7.1"
   }
 }

--- a/packages/modules/atlas-core/package.json
+++ b/packages/modules/atlas-core/package.json
@@ -27,6 +27,6 @@
     "copy-and-watch": "^0.1.5",
     "concurrently": "^6.0.0",
     "ts-node": "^9.0.0",
-    "typescript": "^4.5.4"
+    "typescript": "4.5.4"
   }
 }

--- a/packages/modules/chart-widgets/package.json
+++ b/packages/modules/chart-widgets/package.json
@@ -25,7 +25,7 @@
     "@mendix/release-utils-internal": ">=1.0.0",
     "@mendix/pluggable-widgets-tools": ">=9.13.1",
     "ts-node": "^9.0.0",
-    "typescript": "^4.5.4",
+    "typescript": "4.5.4",
     "shelljs": "^0.8.4"
   }
 }

--- a/packages/shared/charts/package.json
+++ b/packages/shared/charts/package.json
@@ -22,7 +22,7 @@
     "@types/react-plotly.js": "^2.5.0",
     "copy-and-watch": "^0.1.5",
     "eslint": "^7.20.0",
-    "typescript": "^4.5.4",
+    "typescript": "4.5.4",
     "rimraf": "^2.7.1"
   },
   "dependencies": {

--- a/packages/theming/atlas/package.json
+++ b/packages/theming/atlas/package.json
@@ -36,7 +36,7 @@
     "concurrently": "^6.0.0",
     "fast-xml-parser": "^4.0.1",
     "sass": "^1.43.4",
-    "typescript": "^4.5.4"
+    "typescript": "4.5.4"
   },
   "dependencies": {}
 }

--- a/packages/tools/custom-widgets-utils-internal/package.json
+++ b/packages/tools/custom-widgets-utils-internal/package.json
@@ -50,7 +50,7 @@
     "tsconfig-paths": "^3.9.0",
     "tslint": "^6.1.3",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "^4.5.4",
+    "typescript": "4.5.4",
     "webpack": "^5.3.2",
     "webpack-cli": "^4.1.0",
     "webpack-dev-server": "^3.11.0",

--- a/packages/tools/piw-native-utils-internal/package.json
+++ b/packages/tools/piw-native-utils-internal/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "eslint": "^7.20.0",
-    "typescript": "^4.5.4",
+    "typescript": "4.5.4",
     "rimraf": "^2.7.1"
   }
 }

--- a/packages/tools/piw-utils-internal/package.json
+++ b/packages/tools/piw-utils-internal/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@mendix/pluggable-widgets-tools": ">=8.9.2",
     "eslint": "^7.20.0",
-    "typescript": "^4.5.4",
+    "typescript": "4.5.4",
     "rimraf": "^2.7.1"
   },
   "files": [

--- a/packages/tools/pluggable-widgets-tools/package.json
+++ b/packages/tools/pluggable-widgets-tools/package.json
@@ -118,7 +118,7 @@
     "shelljs": "^0.8.4",
     "ts-jest": "^26.4.3",
     "ts-node": "^9.0.0",
-    "typescript": "^4.5.4",
+    "typescript": "4.5.4",
     "webdriverio": "^7.5.3",
     "wdio-image-comparison-service": "^2.3.0",
     "xml2js": "^0.4.23",

--- a/packages/tools/release-utils-internal/package.json
+++ b/packages/tools/release-utils-internal/package.json
@@ -20,7 +20,7 @@
     "eslint": "^7.20.0",
     "peggy": "^1.2.0",
     "rimraf": "^2.7.1",
-    "typescript": "^4.5.4",
+    "typescript": "4.5.4",
     "fast-xml-parser": "^4.0.1",
     "zod": "^3.11.6",
     "shelljs": "^0.8.4"

--- a/packages/tools/release-utils-internal/src/github.ts
+++ b/packages/tools/release-utils-internal/src/github.ts
@@ -49,15 +49,21 @@ export class GitHub {
     }: GitHubReleaseInfo): Promise<void> {
         await this.ensureAuth();
 
-        const draftArgument = isDraft ? "--draft" : "";
-        const repoArgument = repo ? `-R "${repo}"` : "";
-        const filesArgument = filesToRelease ? `"${filesToRelease}"` : "";
-
         const targetHash = (await execShellCommand(`git rev-parse --verify ${target}`)).trim();
+        const command = [
+            `gh release create`,
+            `--title '${title}'`,
+            `--notes '${notes}'`,
+            isDraft ? `--draft` : "",
+            repo ? `-R '${repo}'` : "",
+            `'${tag}'`,
+            `--target '${targetHash}'`,
+            filesToRelease ? `'${filesToRelease}'` : ""
+        ]
+            .filter(str => str !== "")
+            .join(" ");
 
-        await execShellCommand(
-            `gh release create --title "${title}" --notes "${notes}" ${draftArgument} ${repoArgument} "${tag}" --target ${targetHash}  ${filesArgument}`
-        );
+        await execShellCommand(command);
     }
 
     async getReleaseIdByReleaseTag(releaseTag: string): Promise<string | undefined> {

--- a/scripts/data/package.json
+++ b/scripts/data/package.json
@@ -31,6 +31,6 @@
     "eslint-config-next": "12.0.8",
     "sass": "^1.43.4",
     "ts-node": "^9.0.0",
-    "typescript": "^4.5.4"
+    "typescript": "4.5.4"
   }
 }


### PR DESCRIPTION
## This PR contains

-   [ ] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [x] Other (describe)

## What is the purpose of this PR?

- Pin typescript version
- Fix bug with release notes in PWT release script

## Extra comment

We had to pin typescript because of "Scripts test" workflow, which was failing and blocking our pull requests. The problem comes from step from "Script test" where we, for some unknown reason delete `package-lock.json`. Because of that npm installs latest version of TS (4.8 on day of writing) and this version has some changes that cause errors in our existing code.
So, to stop "Script test" failing we decided to pin TS to version 4.5.4

