### PR TITLE
[WC-1094]: fix styling of react-popper arrow

### DIFF
--- a/packages/pluggableWidgets/tooltip-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/tooltip-web/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
--   We fixed an issue with Tooltip widget having styling issues on a specific placement, caused due to react-popper usage.
+-   We fixed an issue with Tooltip widget having positioning issues on a specific placement.
 
 ## [1.2.0] - 2022-05-10
 

--- a/packages/pluggableWidgets/tooltip-web/CHANGELOG.md
+++ b/packages/pluggableWidgets/tooltip-web/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue with Tooltip widget having styling issues on a specific placement, caused due to react-popper usage.
+
 ## [1.2.0] - 2022-05-10
 
 ### Fixed

--- a/packages/pluggableWidgets/tooltip-web/package.json
+++ b/packages/pluggableWidgets/tooltip-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tooltip-web",
   "widgetName": "Tooltip",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Shows a value inside a colored tooltip or label",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "license": "Apache-2.0",

--- a/packages/pluggableWidgets/tooltip-web/src/components/Tooltip.tsx
+++ b/packages/pluggableWidgets/tooltip-web/src/components/Tooltip.tsx
@@ -39,7 +39,7 @@ export const Tooltip = (props: TooltipProps): ReactElement => {
             {
                 name: "flip",
                 options: {
-                    fallbackPlacements: ["top", "bottom"]
+                    fallbackPlacements: ["top", "right", "bottom", "left"]
                 }
             },
             { name: "offset", options: { offset: [0, 8] } }

--- a/packages/pluggableWidgets/tooltip-web/src/components/Tooltip.tsx
+++ b/packages/pluggableWidgets/tooltip-web/src/components/Tooltip.tsx
@@ -39,7 +39,7 @@ export const Tooltip = (props: TooltipProps): ReactElement => {
             {
                 name: "flip",
                 options: {
-                    fallbackPlacements: ["top", "right"]
+                    fallbackPlacements: ["top", "bottom"]
                 }
             },
             { name: "offset", options: { offset: [0, 8] } }

--- a/packages/pluggableWidgets/tooltip-web/src/package.xml
+++ b/packages/pluggableWidgets/tooltip-web/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="Tooltip" version="1.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="Tooltip" version="1.2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="Tooltip.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/tooltip-web/src/ui/Tooltip.scss
+++ b/packages/pluggableWidgets/tooltip-web/src/ui/Tooltip.scss
@@ -1,55 +1,28 @@
 .widget-tooltip {
-    &.widget-tooltip-top {
-        &,
-        &-end,
-        &-start {
-            .widget-tooltip-arrow {
-                bottom: -4px;
-
-                &:before {
-                    box-shadow: 1px 1px 1px rgb(0 0 0 / 10%);
-                    left: 0;
-                }
-            }
+    .widget-tooltip-content[data-popper-placement^="top"] > .widget-tooltip-arrow {
+        bottom: -4px;
+        &:before {
+            box-shadow: 1px 1px 1px rgb(0 0 0 / 10%);
+            left: 0;
         }
     }
 
-    &.widget-tooltip-bottom {
-        &,
-        &-end,
-        &-start {
-            .widget-tooltip-arrow {
-                top: -4px;
-
-                &:before {
-                    box-shadow: -1px -1px 1px rgb(0 0 0 / 10%);
-                }
-            }
+    .widget-tooltip-content[data-popper-placement^="bottom"] > .widget-tooltip-arrow {
+        top: -4px;
+        &:before {
+            box-shadow: -1px -1px 1px rgb(0 0 0 / 10%);
         }
     }
 
-    &.widget-tooltip-right {
-        &,
-        &-end,
-        &-start {
-            .widget-tooltip-arrow {
-                left: -8px;
-            }
+    .widget-tooltip-content[data-popper-placement^="left"] > .widget-tooltip-arrow {
+        right: 0;
+        &:before {
+            box-shadow: 1px -1px 1px rgb(0 0 0 / 10%);
         }
     }
 
-    &.widget-tooltip-left {
-        &,
-        &-end,
-        &-start {
-            .widget-tooltip-arrow {
-                right: 0;
-
-                &:before {
-                    box-shadow: 1px -1px 1px rgb(0 0 0 / 10%);
-                }
-            }
-        }
+    .widget-tooltip-content[data-popper-placement^="right"] > .widget-tooltip-arrow {
+        left: -8px;
     }
 
     .widget-tooltip-content {


### PR DESCRIPTION
## Checklist

-   Contains unit tests ❌ 
-   Contains breaking changes ❌
-   Contains Atlas changes ❌
-   Compatible with: MX 7️⃣, 8️⃣, 9️⃣
-   Did you update version and changelog? ✅ 
-   PR title properly formatted (`[XX-000]: description`)? ✅ 

#### Web specific

-   Contains e2e tests ✅❌
-   Is accessible ✅ ❌
-   Compatible with Studio ✅ ❌
-   Cross-browser compatible ✅ ❌

## This PR contains

-   [x] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?
Fix a UI issue reproducable on a specific fallback position configuration (right) of Tooltip widget, ('top' in Studio, 'right' in fallback properties)