### PR TITLE
fix: wrap gh cli params with single quotes

### DIFF
--- a/scripts/release/module-automation/commons.js
+++ b/scripts/release/module-automation/commons.js
@@ -241,10 +241,18 @@ async function createGithubRelease(moduleInfo, moduleChangelogs, mpkOutput) {
 }
 
 async function createGithubReleaseFrom({ title, body, tag, mpkOutput, isDraft = false }) {
-    const draftArgument = isDraft ? "--draft " : "";
-    await execShellCommand(
-        `gh release create --title "${title}" --notes "${body}" ${draftArgument}"${tag}" "${mpkOutput}"`
-    );
+    const command = [
+        `gh release create`,
+        `--title '${title}'`,
+        `--notes '${body}'`,
+        isDraft ? "--draft" : "",
+        `'${tag}'`,
+        `'${mpkOutput}'`
+    ]
+        .filter(str => str !== "")
+        .join(" ");
+
+    await execShellCommand(command);
 }
 
 function zip(src, fileName) {


### PR DESCRIPTION
## This PR contains

-   [x] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

Fix issue on pipeline.

## Relevant changes

Now all params passed to `gh release` will be single quoted, what will prevent issues with markdown.