### PR TITLE
[WC-1256]: data-widgets version bump to 2.5.5

### DIFF
--- a/packages/modules/data-widgets/package.json
+++ b/packages/modules/data-widgets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "data-widgets",
   "moduleName": "Data Widgets",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "repository": {


### PR DESCRIPTION
## Checklist

-   Contains unit tests ❌
-   Contains breaking changes ❌
-   Contains Atlas changes ❌
-   Compatible with: MX 7️⃣, 8️⃣, 9️⃣
-   Did you update version and changelog? ✅ 
-   PR title properly formatted (`[XX-000]: description`)? ✅ ❌

#### Web specific

-   Contains e2e tests ❌
-   Is accessible ❌
-   Compatible with Studio ✅ 
-   Cross-browser compatible ✅ 

## This PR contains

-   [ ] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [x] Other (version bump)

## What is the purpose of this PR?

Changing version of data-widgets module from 2.5.4 to 2.5.5
