### PR TITLE
[NC-800]: The PopupMenu items are not translatable

### DIFF
--- a/packages/pluggableWidgets/popup-menu-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/popup-menu-native/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We added a translation feature for the menu items.
+
 ## [2.2.0] - 2022-04-07
 
 ### Added

--- a/packages/pluggableWidgets/popup-menu-native/CHANGELOG.md
+++ b/packages/pluggableWidgets/popup-menu-native/CHANGELOG.md
@@ -6,9 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-### Fixed
+### Breaking
 
--   We added a translation feature for the menu items.
+-   We added a translation feature for the menu items. This update will erase old captions on all existing widgets.
 
 ## [2.2.0] - 2022-04-07
 

--- a/packages/pluggableWidgets/popup-menu-native/package.json
+++ b/packages/pluggableWidgets/popup-menu-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "popup-menu-native",
   "widgetName": "PopupMenu",
-  "version": "2.2.1",
+  "version": "3.0.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/pluggableWidgets/popup-menu-native/package.json
+++ b/packages/pluggableWidgets/popup-menu-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "popup-menu-native",
   "widgetName": "PopupMenu",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/pluggableWidgets/popup-menu-native/src/PopupMenu.tsx
+++ b/packages/pluggableWidgets/popup-menu-native/src/PopupMenu.tsx
@@ -55,7 +55,7 @@ export function PopupMenu(props: PopupMenuProps<PopupMenuStyle>): ReactElement {
                     {...getRippleColor(styles.basic?.itemStyle?.rippleColor)}
                     testID={`${props.name}_basic-item`}
                 >
-                    {item.caption}
+                    {item.caption?.value}
                 </MenuItem>
             );
         });

--- a/packages/pluggableWidgets/popup-menu-native/src/PopupMenu.xml
+++ b/packages/pluggableWidgets/popup-menu-native/src/PopupMenu.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<widget id="com.mendix.widget.native.popupmenu.PopupMenu" pluginWidget="true" offlineCapable="true"
-        supportedPlatform="Native"
-        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd">
+<widget id="com.mendix.widget.native.popupmenu.PopupMenu" pluginWidget="true" offlineCapable="true" supportedPlatform="Native" xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../../../node_modules/mendix/custom_widget.xsd">
     <name>Pop-up menu</name>
     <description>Displays a set of pre-defined items within pop up menu</description>
     <studioProCategory>Menus &amp; navigation</studioProCategory>
@@ -22,7 +19,7 @@
                 </enumerationValues>
             </property>
             <property key="basicItems" type="object" isList="true" required="false">
-                <caption>Items </caption>
+                <caption>Items</caption>
                 <description />
                 <properties>
                     <property key="itemType" type="enumeration" defaultValue="item">
@@ -34,7 +31,7 @@
                             <enumerationValue key="divider">Divider</enumerationValue>
                         </enumerationValues>
                     </property>
-                    <property key="caption" type="string" required="false">
+                    <property key="caption" type="textTemplate" required="false">
                         <caption>Caption</caption>
                         <category>General</category>
                         <description />
@@ -74,6 +71,5 @@
                 </properties>
             </property>
         </propertyGroup>
-
     </properties>
 </widget>

--- a/packages/pluggableWidgets/popup-menu-native/src/__tests__/PopupMenu.spec.tsx
+++ b/packages/pluggableWidgets/popup-menu-native/src/__tests__/PopupMenu.spec.tsx
@@ -2,7 +2,7 @@ import { PopupMenuProps } from "../../typings/PopupMenuProps";
 import { PopupMenuStyle } from "../ui/Styles";
 import { Modal, Text, View } from "react-native";
 import { createElement } from "react";
-import { actionValue } from "@mendix/piw-utils-internal";
+import { actionValue, dynamicValue } from "@mendix/piw-utils-internal";
 import { fireEvent, render, within } from "@testing-library/react-native";
 import { PopupMenu } from "../PopupMenu";
 import { MenuDivider } from "react-native-material-menu";
@@ -24,8 +24,13 @@ describe("Popup menu", () => {
             style: [],
             menuTriggerer: <Text>Menu Triggerer</Text>,
             basicItems: [
-                { itemType: "item", action: dummyActionValue, caption: "yolo", styleClass: "defaultStyle" },
-                { itemType: "divider", styleClass: "defaultStyle", caption: "" }
+                {
+                    itemType: "item",
+                    action: dummyActionValue,
+                    caption: dynamicValue<string>("yolo"),
+                    styleClass: "defaultStyle"
+                },
+                { itemType: "divider", styleClass: "defaultStyle", caption: dynamicValue<string>("") }
             ],
             customItems: [{ content: <Text>Yolo</Text>, action: dummyActionValue }]
         };

--- a/packages/pluggableWidgets/popup-menu-native/src/package.xml
+++ b/packages/pluggableWidgets/popup-menu-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="PopupMenu" version="2.2.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="PopupMenu" version="2.2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="PopupMenu.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/popup-menu-native/src/package.xml
+++ b/packages/pluggableWidgets/popup-menu-native/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="PopupMenu" version="2.2.1" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="PopupMenu" version="3.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="PopupMenu.xml" />
         </widgetFiles>

--- a/packages/pluggableWidgets/popup-menu-native/typings/PopupMenuProps.d.ts
+++ b/packages/pluggableWidgets/popup-menu-native/typings/PopupMenuProps.d.ts
@@ -4,7 +4,7 @@
  * @author Mendix UI Content Team
  */
 import { ComponentType, CSSProperties, ReactNode } from "react";
-import { ActionValue } from "mendix";
+import { ActionValue, DynamicValue } from "mendix";
 
 export type RenderModeEnum = "basic" | "custom";
 
@@ -14,7 +14,7 @@ export type StyleClassEnum = "defaultStyle" | "primaryStyle" | "dangerStyle" | "
 
 export interface BasicItemsType {
     itemType: ItemTypeEnum;
-    caption: string;
+    caption?: DynamicValue<string>;
     action?: ActionValue;
     styleClass: StyleClassEnum;
 }


### PR DESCRIPTION
## Checklist

-   Contains unit tests ✅
-   Contains breaking changes ✅
-   Contains Atlas changes ❌
-   Compatible with: MX 9️⃣
-   Did you update version and changelog? ✅ 
-   PR title properly formatted (`[XX-000]: description`)? ✅ 

#### Native specific

-   Works in Android ✅
-   Works in iOS ✅ 
-   Works in Tablet ✅ 

## This PR contains

-   [x] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

Added translation support to menu items