### PR TITLE
DB-1953 remove null check, because null values are a feature in plotly

### DIFF
--- a/packages/shared/charts/src/hooks/usePlotChartDataSeries.ts
+++ b/packages/shared/charts/src/hooks/usePlotChartDataSeries.ts
@@ -206,10 +206,6 @@ function extractDataPoints(
         const x = xValue.get(item);
         const y = yValue.get(item);
 
-        if (!x.value || !y.value) {
-            return null;
-        }
-
         xData.push(x.value instanceof Big ? Number(x.value.toString()) : x.value);
         yData.push(y.value instanceof Big ? Number(y.value.toString()) : y.value);
 


### PR DESCRIPTION
## This PR contains

-   [x] Bug fix
-   [x] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?
Plotly allows for `null` in your data and will by default fill up gaps. It also has the option to set `connectgaps` to false so you can have a line with gaps in between.  https://plotly.com/javascript/line-charts/#connect-gaps-between-data

The code that this pull request removes prevents `null` ending up in your data set, even though plotly can handle this. Right now if you would have an empty value in your dataset the chart would not render. 

By removing this code, the chart will still render when you have an empty value in your data, by default it will connect the gaps and you will have to option to turn this off.

